### PR TITLE
Adiciona capacidade de reatribuir pacote

### DIFF
--- a/upload/button_helper.py
+++ b/upload/button_helper.py
@@ -65,7 +65,10 @@ class UploadButtonHelper(ButtonHelper):
         if obj.status == choices.PS_PUBLISHED:
             btns.append(self.view_published_document(obj, classnames))
 
-        if obj.assignee is None and obj.status == choices.PS_QA and ph.user_can_assign_package(usr, obj):
-            btns.append(self.assign(obj, classnames))
+        if obj.assignee is None:
+            if obj.status == choices.PS_QA and ph.user_can_assign_package(usr, obj):
+                btns.append(self.assign(obj, classnames))
+        elif obj.assignee != usr:
+            btns.append(self.assign(obj, classnames, _('Reassign')))
             
         return btns

--- a/upload/button_helper.py
+++ b/upload/button_helper.py
@@ -10,8 +10,8 @@ class UploadButtonHelper(ButtonHelper):
     index_button_classnames = ["button", "button-small", "button-secondary"]
     btn_default_classnames = ["button-small", "icon",]
 
-    def assign(self, obj, classnames):
-        text = _("Assign")
+    def assign(self, obj, classnames, label=None):
+        text = label or _("Assign")
         return {
             "url": reverse("upload:assign") + "?package_id=%s" % str(obj.id),
             "label": text,

--- a/upload/models.py
+++ b/upload/models.py
@@ -25,7 +25,7 @@ class Package(CommonControlField):
     status = models.CharField(_('Status'), max_length=32, choices=choices.PACKAGE_STATUS, default=choices.PS_ENQUEUED_FOR_VALIDATION)
     article = models.ForeignKey(Article, blank=True, null=True, on_delete=models.SET_NULL)
     issue = models.ForeignKey(Issue, blank=True, null=True, on_delete=models.SET_NULL)
-    assignee = models.OneToOneField(User, blank=True, null=True, on_delete=models.SET_NULL)
+    assignee = models.ForeignKey(User, blank=True, null=True, on_delete=models.SET_NULL)
 
     stat_disagree_n = models.IntegerField(_('Disagree (n)'), null=True, blank=True)
     stat_disagree_p = models.FloatField(_('Disagree (%)'), null=True, blank=True)

--- a/upload/views.py
+++ b/upload/views.py
@@ -185,19 +185,20 @@ def assign(request):
         )
     elif package_id:
         package = get_object_or_404(Package, pk=package_id)
-
-        if package.assignee is None:
-            package.assignee = user
-            package.save()
-
+        is_reassign = package.assignee is None
+        
+        package.assignee = user
+        package.save()
+        
+        if is_reassign:
             messages.success(
                 request,
                 _('Package has been assigned with success.')
             )
         else:
-            messages.error(
+            messages.warning(
                 request,
-                _('It was not possible to assign the package because it already has an assinee.')
+                _('Package has been reassigned with success.')
             )
 
     return redirect(request.META.get('HTTP_REFERER'))

--- a/upload/views.py
+++ b/upload/views.py
@@ -185,12 +185,12 @@ def assign(request):
         )
     elif package_id:
         package = get_object_or_404(Package, pk=package_id)
-        is_reassign = package.assignee is None
+        is_reassign = package.assignee is not None
         
         package.assignee = user
         package.save()
         
-        if is_reassign:
+        if not is_reassign:
             messages.success(
                 request,
                 _('Package has been assigned with success.')

--- a/upload/wagtail_hooks.py
+++ b/upload/wagtail_hooks.py
@@ -285,12 +285,7 @@ class QualityAnalysisPackageAdmin(ModelAdmin):
         qs = super().get_queryset(request)
 
         if self.permission_helper.user_can_access_all_packages(request.user, None):
-            return qs.filter(
-                Q(status=choices.PS_QA) & (
-                    Q(assignee=request.user) | 
-                    Q(assignee=None)
-                )
-            )
+            return qs.filter(status=choices.PS_QA)
     
         return qs.none()
 

--- a/upload/wagtail_hooks.py
+++ b/upload/wagtail_hooks.py
@@ -261,9 +261,12 @@ class QualityAnalysisPackageAdmin(ModelAdmin):
         'stat_disagree',
         'stat_incapable_to_fix',
     )
-    list_filter = ()
+    list_filter = (
+        'assignee',
+    )
     search_fields = (
         'file',
+        'assignee__username',
         'creator__username',
         'updated_by__username',
     )


### PR DESCRIPTION
#### O que esse PR faz?
Cria capacidade de atribuir pacote já atruído a algum usuário.

#### Onde a revisão poderia começar?
Por commits.

#### Como este poderia ser testado manualmente?
1. Ter dois usuários distintos com permissões de view_qa_package e assign_qa_package (o que é fácil de fazer em settings/groups)
2. Criar um pacote e forçar seu estado para 'quality-analysis
3. Abrir tela de pacotes em qa com usuário 1
4. Atribuir pacote a si mesmo
5. Abrir tela de pacotes em qa com usuário 2
6. Acionar botão "Reatribuir"

#### Algum cenário de contexto que queira dar?
O efeito colateral que isso causa é que na tela que lista os pacotes em QA o usuário QA logado deverá enxergar todos os pacotes em QA (atribuídos a ele, sem usuário atribuído e **atribuídos a outros usuários QA**). Para facilitar a busca por pacotes atribuídos a um qa, foi ativado search por username de `assinee` assim como um filtro na lateral.
`
### Screenshots
Tela que ilustra usuário qa1 logado com opção de acessar botão "Reassign". Ao clicar neste botão, o pacote passa a ser de sua responsabilidade.
![image](https://user-images.githubusercontent.com/2096125/198384871-ef79baca-42ae-414b-87b8-589d8fb3b771.png)

#### Quais são tickets relevantes?
N/A

### Referências
N/A