### PR TITLE
Adiciona dropdown com opções para ver HTML, XML e PDF

### DIFF
--- a/upload/templates/modeladmin/upload/package/inspect.html
+++ b/upload/templates/modeladmin/upload/package/inspect.html
@@ -54,7 +54,7 @@
                         <td>
                             {% trans 'See the XML and/or DTD Formation Report: ' %}
                             {% for x in validation_results.xml_or_dtd.xmls %}
-                                <a href="{{ x.uri }}">XML {{ forloop.counter }}</a>
+                                <a href="{{ x.inspect_uri }}">XML {{ forloop.counter }}</a>
                                 {% if not forloop.last %} | {% endif %}
                             {% endfor %}
                         </td>

--- a/upload/templates/modeladmin/upload/package/inspect.html
+++ b/upload/templates/modeladmin/upload/package/inspect.html
@@ -149,16 +149,10 @@
         </table>
     </div>
     {% endif %}
-
-    <div class="nice-padding">
-        <h3>{% trans "Preview" %}</h3>
-        {% for x in validation_results.xml_or_dtd.xmls %}
-            {% for language in languages %}
-                <a class="button is-small" target="_blank" href="{% url 'upload:preview_document' %}?package_id={{ package_id }}&xml_path={{ x.xml_path }}&language={{ language }}">{% trans "Preview HTML " %} {{ forloop.parentloop.counter }} {{ language|title }}</a></p>
-            {% endfor %}
-        {% endfor %}
-        <a class="button" href="" disabled>{% trans "View XML" %}</a></p>
-    </div>
+    
+    {% if validation_results.xml_or_dtd.status == 'approved' %}
+        {% include 'modeladmin/upload/package/inspect_buttons.html' %}
+    {% endif %}
 
     {% if status == 'validated-with-errors' or status == 'quality-analysis' %}
         <div class="nice-padding">

--- a/upload/templates/modeladmin/upload/package/inspect.html
+++ b/upload/templates/modeladmin/upload/package/inspect.html
@@ -155,15 +155,17 @@
     {% endif %}
 
     {% if status == 'validated-with-errors' or status == 'quality-analysis' %}
-        <div class="nice-padding">
+        <div class="nice-padding row">
             <h3>{% trans "Actions" %}</h3>
-            {% if status == 'validated-with-errors' and perms.upload.send_validation_error_resolution %}
-                <a class="button is-small" href="{% url 'upload:error_resolution' %}?package_id={{ package_id }}">{% trans 'Start Error Resolution' %}</a>
-            {% else %}
-                {% if status == 'quality-analysis' and perms.upload.analyse_validation_error_resolution %}
-                    <a class="button is-small" href="{% url 'upload:error_resolution' %}?scope=analyse&package_id={{ package_id }}">{% trans 'Analyse Error Resolution' %}</a>
+            <div class="col2">
+                {% if status == 'validated-with-errors' and perms.upload.send_validation_error_resolution %}
+                    <a class="button is-small" href="{% url 'upload:error_resolution' %}?package_id={{ package_id }}">{% trans 'Start Error Resolution' %}</a>
+                {% else %}
+                    {% if status == 'quality-analysis' and perms.upload.analyse_validation_error_resolution %}
+                        <a class="button is-small" href="{% url 'upload:error_resolution' %}?scope=analyse&package_id={{ package_id }}">{% trans 'Analyse Error Resolution' %}</a>
+                    {% endif %}
                 {% endif %}
-            {% endif %}
+            </div>
         </div>
     {% endif %}
 

--- a/upload/templates/modeladmin/upload/package/inspect.html
+++ b/upload/templates/modeladmin/upload/package/inspect.html
@@ -154,6 +154,8 @@
         {% include 'modeladmin/upload/package/inspect_buttons.html' %}
     {% endif %}
 
+    {% include 'modeladmin/upload/package/inspect_buttons_download.html' %}
+
     {% if status == 'validated-with-errors' or status == 'quality-analysis' %}
         <div class="nice-padding row">
             <h3>{% trans "Actions" %}</h3>

--- a/upload/templates/modeladmin/upload/package/inspect_buttons.html
+++ b/upload/templates/modeladmin/upload/package/inspect_buttons.html
@@ -1,6 +1,6 @@
 {% load i18n modeladmin_tags wagtailadmin_tags wagtailcore_tags %}
 
-<div class="nice-padding">
+<div class="nice-padding row">
     <h3>{% trans "Preview" %}</h3>
     <div class="col2">
         <div class="dropdown dropup dropdown-button match-width">

--- a/upload/templates/modeladmin/upload/package/inspect_buttons.html
+++ b/upload/templates/modeladmin/upload/package/inspect_buttons.html
@@ -1,0 +1,56 @@
+{% load i18n modeladmin_tags wagtailadmin_tags wagtailcore_tags %}
+
+<div class="nice-padding">
+    <h3>{% trans "Preview" %}</h3>
+    <div class="col2">
+        <div class="dropdown dropup dropdown-button match-width">
+            <button value="drop up" class="button icon icon-doc-full">{% trans 'HTML' %}</button>
+            <div class="dropdown-toggle">
+                <svg class="icon icon-arrow-up icon" aria-hidden="true" focusable="false">
+                    <use href="#icon-arrow-up"></use>
+                </svg>
+            </div>
+            <ul>
+                {% for x in validation_results.xml_or_dtd.xmls %}
+                    {% for language in languages %}
+                        <li>
+                            <a class="button is-small" target="_blank" href="{% url 'upload:preview_document' %}?package_id={{ package_id }}&xml_path={{ x.xml_name }}&language={{ language }}">{% trans "Preview HTML " %} - {{ language|title }}</a>
+                        </li>
+                    {% endfor %}
+                {% endfor %}
+            </ul>
+        </div>
+    </div>
+    <div class="col2">
+        <div class="dropdown dropup dropdown-button match-width">
+            <button value="drop up" class="button icon icon-doc-full">{% trans 'XML' %}</button>
+            <div class="dropdown-toggle">
+                <svg class="icon icon-arrow-up icon" aria-hidden="true" focusable="false">
+                    <use href="#icon-arrow-up"></use>
+                </svg>
+            </div>
+            <ul>
+                {% for x in validation_results.xml_or_dtd.xmls %}
+                    <li><a class="button is-small" target="_blank" href="{{ x.base_uri }}">{% trans "View XML " %}{{ forloop.counter }}</a></li>
+                {% endfor %}
+            </ul>
+        </div>
+    </div>
+{% if pdfs %}
+    <div class="col2">
+        <div class="dropdown dropup dropdown-button match-width">
+            <button value="drop up" class="button icon icon-download">{% trans 'PDF' %}</button>
+            <div class="dropdown-toggle">
+                <svg class="icon icon-arrow-up icon" aria-hidden="true" focusable="false">
+                    <use href="#icon-arrow-up"></use>
+                </svg>
+            </div>
+            <ul>
+                {% for pdf in pdfs %}
+                    <li><a class="button is-small" target="_blank" href="{{ pdf.base_uri }}">{% trans 'Download PDF' %} - {{ pdf.language|title }}</a></li>
+                {% endfor %}
+            </ul>
+        </div>
+    </div>
+{% endif %}
+</div>

--- a/upload/templates/modeladmin/upload/package/inspect_buttons.html
+++ b/upload/templates/modeladmin/upload/package/inspect_buttons.html
@@ -1,7 +1,7 @@
 {% load i18n modeladmin_tags wagtailadmin_tags wagtailcore_tags %}
 
 <div class="nice-padding row">
-    <h3>{% trans "Preview" %}</h3>
+    <h3>{% trans "Preview (optimized package)" %}</h3>
     <div class="col2">
         <div class="dropdown dropup dropdown-button match-width">
             <button value="drop up" class="button icon icon-doc-full">{% trans 'HTML' %}</button>

--- a/upload/templates/modeladmin/upload/package/inspect_buttons_download.html
+++ b/upload/templates/modeladmin/upload/package/inspect_buttons_download.html
@@ -1,0 +1,25 @@
+{% load i18n modeladmin_tags wagtailadmin_tags wagtailcore_tags %}
+
+<div class="nice-padding row">
+    <h3>{% trans "Download" %}</h3>
+    <div class="col2">
+        <a href="/media/{{ original_pkg }}" class="button bicolor button--icon">
+            <span class="icon-wrapper">
+                <svg class="icon icon-download-alt icon" aria-hidden="true" focusable="false">
+                    <use href="#icon-download-alt"></use>
+                </svg>
+            </span>{% trans 'Original package' %}
+        </a>
+    </div>
+    {% if category != 'generated-by-the-system' and validation_results.xml_or_dtd.status == 'approved' %}
+        <div class="col2">
+            <a href="/media/{{ optimized_pkg }}" class="button bicolor button--icon">
+                <span class="icon-wrapper">
+                    <svg class="icon icon-download-alt icon" aria-hidden="true" focusable="false">
+                        <use href="#icon-download-alt"></use>
+                    </svg>
+                </span>{% trans 'Optimized package' %}
+            </a>
+        </div>
+    {% endif %}
+</div>

--- a/upload/wagtail_hooks.py
+++ b/upload/wagtail_hooks.py
@@ -159,8 +159,9 @@ class PackageAdminInspectView(InspectView):
 
                 if vr.data and isinstance(vr.data, dict):
                     data['validation_results'][vr_name]['xmls'].append({
-                        'xml_path': vr.data.get('xml_path'),
-                        'uri': ValidationResultAdmin().url_helper.get_action_url('inspect', vr.id)
+                        'xml_name': vr.data.get('xml_path'),
+                        'base_uri': file_utils.os.path.join(dir_optz, vr.data.get('xml_path')),
+                        'inspect_uri': ValidationResultAdmin().url_helper.get_action_url('inspect', vr.id)
                     })
 
         return super().get_context_data(**data)

--- a/upload/wagtail_hooks.py
+++ b/upload/wagtail_hooks.py
@@ -123,7 +123,7 @@ class PackageAdminInspectView(InspectView):
                 document_name = package_utils.get_xml_filename(package_files)
                 rendition_name = package_utils.get_rendition_expected_name(rendition, document_name)
                 data['pdfs'].append({
-                    'base_uri': file_utils.os.path.join(dir_optz, rendition_name),
+                    'base_uri': file_utils.os.path.join(optz_dir, rendition_name),
                     'language': rendition.language,
                 })
         except XMLFormatError:
@@ -133,15 +133,16 @@ class PackageAdminInspectView(InspectView):
         data = {
             'validation_results': {},
             'package_id': self.instance.id,
+            'original_pkg': self.instance.file.name,
             'status': self.instance.status,
             'category': self.instance.category,
             'languages': package_utils.get_languages(self.instance.file.name),
             'pdfs': []
         }
 
-        dir_optz = self.discover_dir_optz()
- 
-        self.set_pdf_paths(data, dir_optz)
+        optz_file_path, optz_dir = self.get_optimized_package_filepath_and_directory()
+        data['optimized_pkg'] = optz_file_path
+        self.set_pdf_paths(data, optz_dir)
 
         for vr in self.instance.validationresult_set.all():
             vr_name = vr.report_name()
@@ -162,7 +163,7 @@ class PackageAdminInspectView(InspectView):
                 if vr.data and isinstance(vr.data, dict):
                     data['validation_results'][vr_name]['xmls'].append({
                         'xml_name': vr.data.get('xml_path'),
-                        'base_uri': file_utils.os.path.join(dir_optz, vr.data.get('xml_path')),
+                        'base_uri': file_utils.os.path.join(optz_dir, vr.data.get('xml_path')),
                         'inspect_uri': ValidationResultAdmin().url_helper.get_action_url('inspect', vr.id)
                     })
 

--- a/upload/wagtail_hooks.py
+++ b/upload/wagtail_hooks.py
@@ -100,8 +100,8 @@ class PackageCreateView(CreateView):
 
 
 class PackageAdminInspectView(InspectView):
-    def discover_dir_optz(self):
-        # Obtém caminho do pacote otimzado
+    def get_optimized_package_filepath_and_directory(self):
+        # Obtém caminho do pacote otimizado
         _path = package_utils.generate_filepath_with_new_extension(
             self.instance.file.name, 
             '.optz',
@@ -109,12 +109,14 @@ class PackageAdminInspectView(InspectView):
         )
 
         # Obtém diretório em que o pacote otimizado foi extraído
-        return file_utils.get_file_url(
+        _directory = file_utils.get_file_url(
             dirname='',
             filename=file_utils.get_filename_from_filepath(_path)
         )
 
-    def set_pdf_paths(self, data, dir_optz):
+        return _path, _directory
+
+    def set_pdf_paths(self, data, optz_dir):
         try:
             for rendition in package_utils.get_article_renditions_from_zipped_xml(self.instance.file.name):
                 package_files = file_utils.get_file_list_from_zip(self.instance.file.name)

--- a/upload/wagtail_hooks.py
+++ b/upload/wagtail_hooks.py
@@ -134,7 +134,12 @@ class PackageAdminInspectView(InspectView):
             'status': self.instance.status,
             'category': self.instance.category,
             'languages': package_utils.get_languages(self.instance.file.name),
+            'pdfs': []
         }
+
+        dir_optz = self.discover_dir_optz()
+ 
+        self.set_pdf_paths(data, dir_optz)
 
         for vr in self.instance.validationresult_set.all():
             vr_name = vr.report_name()

--- a/upload/wagtail_hooks.py
+++ b/upload/wagtail_hooks.py
@@ -3,6 +3,8 @@ from django.db.models import Q
 from django.http import HttpResponseRedirect
 from django.urls import include, path
 from django.utils.translation import gettext as _
+from upload.utils import file_utils
+from upload.utils.xml_utils import XMLFormatError
 
 from wagtail.core import hooks
 from wagtail.contrib.modeladmin.options import ModelAdmin, ModelAdminGroup, modeladmin_register
@@ -98,6 +100,20 @@ class PackageCreateView(CreateView):
 
 
 class PackageAdminInspectView(InspectView):
+    def discover_dir_optz(self):
+        # Obtém caminho do pacote otimzado
+        _path = package_utils.generate_filepath_with_new_extension(
+            self.instance.file.name, 
+            '.optz',
+            True,
+        )
+
+        # Obtém diretório em que o pacote otimizado foi extraído
+        return file_utils.get_file_url(
+            dirname='',
+            filename=file_utils.get_filename_from_filepath(_path)
+        )
+
     def get_context_data(self):
         data = {
             'validation_results': {},

--- a/upload/wagtail_hooks.py
+++ b/upload/wagtail_hooks.py
@@ -114,6 +114,19 @@ class PackageAdminInspectView(InspectView):
             filename=file_utils.get_filename_from_filepath(_path)
         )
 
+    def set_pdf_paths(self, data, dir_optz):
+        try:
+            for rendition in package_utils.get_article_renditions_from_zipped_xml(self.instance.file.name):
+                package_files = file_utils.get_file_list_from_zip(self.instance.file.name)
+                document_name = package_utils.get_xml_filename(package_files)
+                rendition_name = package_utils.get_rendition_expected_name(rendition, document_name)
+                data['pdfs'].append({
+                    'base_uri': file_utils.os.path.join(dir_optz, rendition_name),
+                    'language': rendition.language,
+                })
+        except XMLFormatError:
+            data['pdfs'] = []
+
     def get_context_data(self):
         data = {
             'validation_results': {},


### PR DESCRIPTION
#### O que esse PR faz?
Agrega na tela de inspeção de pacotes botões para pré-visualizar HTML, XML e PDF disponíveis. Havendo mais de um idioma, todas as opções são mostradas - isso também vale para situações em que há mais de um XML (errata).

#### Onde a revisão poderia começar?
Por commits.

#### Como este poderia ser testado manualmente?
N/A

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
Botões
![image](https://user-images.githubusercontent.com/2096125/198697030-ddbe359e-f83a-4441-8696-8aa58c6f61dc.png)

Botões expandidos
![image](https://user-images.githubusercontent.com/2096125/198697118-82e9cd5d-6fa6-4ff8-93ea-6303bacaa4ad.png)

#### Quais são tickets relevantes?
N/A

### Referências
N/A