### PR TITLE
Adiciona validação de xml:lang

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -55,7 +55,7 @@ minio==7.1.0
 # Upload
 # ------------------------------------------------------------------------------
 lxml==4.9.1 # https://github.com/lxml/lxml
--e git+https://github.com/scieloorg/packtools@2.15#egg=packtools
+-e git+https://github.com/scieloorg/packtools@2.16.1#egg=packtools
 -e git+https://github.com/scieloorg/scielo_scholarly_data#egg=scielo_scholarly_data
 
 # DSM Publication

--- a/upload/tasks.py
+++ b/upload/tasks.py
@@ -436,6 +436,8 @@ def task_validate_content(self, file_path, xml_path, package_id):
 
 @celery_app.task(bind=True, name='Validate XML Language')
 def task_validate_xml_lang(self, file_path, xml_path, package_id):
+    xml_str = file_utils.get_xml_content_from_zip(file_path, xml_path)
+    xml_tree = xml_utils.get_etree_from_xml_content(xml_str)
 @celery_app.task(bind=True, name='Check validation error resolutions')
 def task_check_resolutions(self, package_id):
     return controller.update_package_check_errors(package_id)

--- a/upload/tasks.py
+++ b/upload/tasks.py
@@ -455,6 +455,17 @@ def task_validate_xml_lang(self, file_path, xml_path, package_id):
             message=_('All languages have been successfully validated.')
         )
     else:
+        vr.data.update({'description': [{'error_message': e.message, 'error_line': e.line} for e in errors]}),
+        controller.update_validation_result(
+            vr.id,
+            status=choices.VS_DISAPPROVED,
+            message=_('One or more languages are invalid.'),
+            data=vr.data,
+        )
+    
+    return result
+        
+
 @celery_app.task(bind=True, name='Check validation error resolutions')
 def task_check_resolutions(self, package_id):
     return controller.update_package_check_errors(package_id)

--- a/upload/tasks.py
+++ b/upload/tasks.py
@@ -433,6 +433,9 @@ def task_validate_content(self, file_path, xml_path, package_id):
         }
     )
 
+
+@celery_app.task(bind=True, name='Validate XML Language')
+def task_validate_xml_lang(self, file_path, xml_path, package_id):
 @celery_app.task(bind=True, name='Check validation error resolutions')
 def task_check_resolutions(self, package_id):
     return controller.update_package_check_errors(package_id)

--- a/upload/tasks.py
+++ b/upload/tasks.py
@@ -438,6 +438,8 @@ def task_validate_content(self, file_path, xml_path, package_id):
 def task_validate_xml_lang(self, file_path, xml_path, package_id):
     xml_str = file_utils.get_xml_content_from_zip(file_path, xml_path)
     xml_tree = xml_utils.get_etree_from_xml_content(xml_str)
+
+    result, errors = sps_validation_article_and_subarticles.validate_language(xml_tree)
 @celery_app.task(bind=True, name='Check validation error resolutions')
 def task_check_resolutions(self, package_id):
     return controller.update_package_check_errors(package_id)

--- a/upload/tasks.py
+++ b/upload/tasks.py
@@ -447,6 +447,14 @@ def task_validate_xml_lang(self, file_path, xml_path, package_id):
         status=choices.VS_CREATED,
         data={'xml_path': xml_path},
     )
+
+    if result is True:
+        controller.update_validation_result(
+            vr.id, 
+            status=choices.VS_APPROVED, 
+            message=_('All languages have been successfully validated.')
+        )
+    else:
 @celery_app.task(bind=True, name='Check validation error resolutions')
 def task_check_resolutions(self, package_id):
     return controller.update_package_check_errors(package_id)

--- a/upload/tasks.py
+++ b/upload/tasks.py
@@ -5,6 +5,7 @@ from packtools.sps.utils import file_utils as sps_file_utils
 from packtools.sps.models import package as sps_package
 from packtools.sps import exceptions as sps_exceptions
 from packtools.sps.validation import (
+    article_and_subarticles as sps_validation_article_and_subarticles,
     article as sps_validation_article,
     journal as sps_validation_journal,
 )

--- a/upload/tasks.py
+++ b/upload/tasks.py
@@ -440,6 +440,13 @@ def task_validate_xml_lang(self, file_path, xml_path, package_id):
     xml_tree = xml_utils.get_etree_from_xml_content(xml_str)
 
     result, errors = sps_validation_article_and_subarticles.validate_language(xml_tree)
+
+    vr = controller.add_validation_result(
+        error_category=choices.VE_DATA_CONSISTENCY_ERROR,
+        package_id=package_id,
+        status=choices.VS_CREATED,
+        data={'xml_path': xml_path},
+    )
 @celery_app.task(bind=True, name='Check validation error resolutions')
 def task_check_resolutions(self, package_id):
     return controller.update_package_check_errors(package_id)

--- a/upload/tasks.py
+++ b/upload/tasks.py
@@ -63,6 +63,16 @@ def run_validations(filename, package_id, package_category, article_id=None, iss
                 countdown=10,
             )
 
+            # Aciona validação de conteúdo
+            task_validate_content.apply_async(
+                kwargs={
+                    'file_path': optimised_filepath,
+                    'xml_path': xml_path,
+                    'package_id': package_id,
+                },
+                countdown=10,
+            )
+
         # Aciona validação de compatibilidade entre dados do pacote e o Issue selecionado
         if issue_id is not None and package_category:
             task_validate_article_and_issue_data.apply_async(

--- a/upload/tasks.py
+++ b/upload/tasks.py
@@ -423,6 +423,16 @@ def task_validate_renditions(file_path, xml_path, package_id):
         return True
 
 
+@celery_app.task(bind=True, name='Validate XML content')
+def task_validate_content(self, file_path, xml_path, package_id):
+    task_validate_xml_lang.apply_async(
+        kwargs={
+            'file_path': file_path,
+            'xml_path': xml_path,
+            'package_id': package_id,
+        }
+    )
+
 @celery_app.task(bind=True, name='Check validation error resolutions')
 def task_check_resolutions(self, package_id):
     return controller.update_package_check_errors(package_id)


### PR DESCRIPTION
#### O que esse PR faz?
Cria uma validação genérica de conteúdo e inclui, nela, a validação de xml:lang de `<article>` e `<sub-article>`.

#### Onde a revisão poderia começar?
Por commits

#### Como este poderia ser testado manualmente?
1. Envie pacote cujo XML esteja sem o atributo xml:lang ou esteja com um valor inválido
2. Observe, na inspeção de validação de conteúdo, que caso o xml:lang não esteja definido na tag, o sistema anota o erro "... has no language".
3. Observe, na inspeção de validação de conteúdo, que caso o xml:lang seja um valor indevido, por exemplo, portugol, o sistema anota o erro "... has an invalid langauge: portugol".
4. Observe, na inspeção de validação de conteúdo, que a linha também é anotada.

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
**Exemplo de tela que consta idioma inválido**
![image](https://user-images.githubusercontent.com/2096125/200915377-2f957ef2-cde4-47d8-acd8-5544223ed04b.png)


#### Quais são tickets relevantes?
#120 

### Referências
N/A