### PR TITLE
Contorna problema de ausência de definição de `timezone_field.TimeZoneField.default_choices`

### DIFF
--- a/django_celery_beat/models.py
+++ b/django_celery_beat/models.py
@@ -74,12 +74,14 @@ def crontab_schedule_celery_timezone():
         CELERY_TIMEZONE = getattr(settings, "%s_TIMEZONE" % current_app.namespace)
     except AttributeError:
         return "UTC"
-    return (
-        CELERY_TIMEZONE
-        if CELERY_TIMEZONE
-        in [choice[0].zone for choice in timezone_field.TimeZoneField.default_choices]
-        else "UTC"
-    )
+    return "UTC"
+    # workaround para não obter o erro de default_choices não definido
+    # return (
+    #     CELERY_TIMEZONE
+    #     if CELERY_TIMEZONE
+    #     in [choice[0].zone for choice in timezone_field.TimeZoneField.default_choices]
+    #     else "UTC"
+    # )
 
 
 class SolarSchedule(models.Model):


### PR DESCRIPTION
#### O que esse PR faz?
Contorna problema de ausência de definição de `timezone_field.TimeZoneField.default_choices`

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Defeito ocorria ao agendar tasks

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a

