### PR TITLE
Corrige caminho do xml migrado e corrige valor xml changed

### DIFF
--- a/htmlxml/models.py
+++ b/htmlxml/models.py
@@ -632,7 +632,7 @@ class HTMLXML(CommonControlField, ClusterableModel, Html2xmlAnalysis, BasicXMLFi
         except GenerateBodyAndBackFromHTMLError as e:
             # cria xml_body_and_back padrão
             document.xml_body_and_back = ["<article/>"]
-            detail = {"error": str(e)}
+            detail = {"warning": str(e)}
             done = False
 
         # guarda cada versão de body/back

--- a/htmlxml/models.py
+++ b/htmlxml/models.py
@@ -55,7 +55,6 @@ def format_code(cols):
 
 
 def _fromstring(xml_content):
-    logging.info(f"_fromstring {type(xml_content)}")
     pref, xml = split_processing_instruction_doctype_declaration_and_xml(xml_content)
     return etree.fromstring(xml)
 
@@ -281,7 +280,7 @@ class Html2xmlAnalysis(models.Model):
         yield "</div>"
 
     def tostring(self, node):
-        return etree.tostring(node, encoding="utf-8").decode("utf-8")
+        return etree.tostring(node, encoding="utf-8", pretty_print=True).decode("utf-8")
 
     def get_a_href_stats(self, html, xml):
         nodes = html.xpath(".//a[@href]")

--- a/migration/controller.py
+++ b/migration/controller.py
@@ -468,7 +468,7 @@ class PkgZipBuilder:
     def _build_sps_package_add_xml(self, zf):
         try:
             sps_xml_name = self.sps_pkg_name + ".xml"
-            zf.writestr(sps_xml_name, self.xml_with_pre.tostring())
+            zf.writestr(sps_xml_name, self.xml_with_pre.tostring(pretty_print=True))
             self.components[sps_xml_name] = {"component_type": "xml"}
         except Exception as e:
             exc_type, exc_value, exc_traceback = sys.exc_info()
@@ -478,19 +478,11 @@ class PkgZipBuilder:
             }
 
 
-def get_migrated_xml_with_pre(migrated_article):
+def get_migrated_xml_with_pre(article_proc):
     try:
-        xml_file_path = HTMLXML.get(migrated_article=migrated_article).file.path
-        origin = "HTML"
+        xml_file_path = HTMLXML.get(migrated_article=article_proc.migrated_data).file.path
     except HTMLXML.DoesNotExist:
-        xml_file_path = self.migrated_xml.file.path
-        origin = "XML"
-    try:
-        for item in XMLWithPre.create(path=xml_file_path):
-            return item
-    except Exception as e:
-        raise XMLVersionXmlWithPreError(
-            _("Unable to get xml with pre from migrated article ({}) {}: {} {}").format(
-                origin, xml_file_path, type(e), e
-            )
-        )
+        xml_file_path = article_proc.migrated_xml.file.path
+
+    for item in XMLWithPre.create(path=xml_file_path):
+        return item

--- a/migration/controller.py
+++ b/migration/controller.py
@@ -479,10 +479,22 @@ class PkgZipBuilder:
 
 
 def get_migrated_xml_with_pre(article_proc):
+    origin = None
     try:
-        xml_file_path = HTMLXML.get(migrated_article=article_proc.migrated_data).file.path
+        obj = HTMLXML.get(migrated_article=article_proc.migrated_data)
+        origin = "html"
     except HTMLXML.DoesNotExist:
-        xml_file_path = article_proc.migrated_xml.file.path
+        obj = article_proc.migrated_xml
+        origin = "xml"
 
-    for item in XMLWithPre.create(path=xml_file_path):
-        return item
+    try:
+        xml_file_path = None
+        xml_file_path = obj.file.path
+        for item in XMLWithPre.create(path=xml_file_path):
+            return item
+    except Exception as e:
+        raise XMLVersionXmlWithPreError(
+            _("Unable to get xml with pre from migrated article ({}) {}: {} {}").format(
+                origin, xml_file_path, type(e), e
+            )
+        )

--- a/package/models.py
+++ b/package/models.py
@@ -549,7 +549,7 @@ class SPSPkg(CommonControlField, ClusterableModel):
             operation = None
 
             for response in pid_provider_app.request_pid_for_xml_zip(
-                zip_xml_file_path, user, is_published=is_public
+                zip_xml_file_path, user, is_published=is_public, article_proc=article_proc,
             ):
                 logging.info(f"package response: {response}")
                 operation = article_proc.start(user, "request_pid_for_xml_zip")

--- a/package/models.py
+++ b/package/models.py
@@ -44,6 +44,10 @@ class SPSPkgAddPidV3ToZipFileError(Exception):
     ...
 
 
+class AddPidV3ToXMLFileError(Exception):
+    ...
+
+
 def now():
     return datetime.utcnow().isoformat().replace(":", "-").replace(".", "-")
 

--- a/pid_provider/client.py
+++ b/pid_provider/client.py
@@ -164,7 +164,9 @@ class PidProviderAPIClient:
             name, ext = os.path.splitext(name)
             zip_xml_file_path = os.path.join(tmpdirname, name + ".zip")
 
-            create_xml_zip_file(zip_xml_file_path, xml_with_pre.tostring())
+            create_xml_zip_file(
+                zip_xml_file_path, xml_with_pre.tostring(pretty_print=True)
+            )
 
             try:
                 return self._post_xml(zip_xml_file_path, self.token, self.timeout)

--- a/pid_provider/models.py
+++ b/pid_provider/models.py
@@ -79,7 +79,6 @@ class XMLVersion(CommonControlField):
         xml_with_pre,
     ):
         try:
-            logging.info(f"XMLVersion.create {xml_with_pre.finger_print}")
             obj = cls()
             obj.pid_provider_xml = pid_provider_xml
             obj.finger_print = xml_with_pre.finger_print
@@ -89,13 +88,11 @@ class XMLVersion(CommonControlField):
                 f"{pid_provider_xml.v3}.xml", xml_with_pre.tostring(pretty_print=True)
             )
             obj.save()
-            logging.info(f"XMLVersion saved {xml_with_pre.finger_print}")
             return obj
         except IntegrityError:
             return cls.get(pid_provider_xml, xml_with_pre.finger_print)
 
     def save_file(self, filename, content):
-        logging.info(filename)
         self.file.save(filename, ContentFile(content))
 
     @property
@@ -138,11 +135,7 @@ class XMLVersion(CommonControlField):
             )
 
         latest = cls.latest(pid_provider_xml)
-        logging.info(f"latest: {latest}")
-        logging.info(f"latest.finger_print: {latest.finger_print}")
-        logging.info(f"finger_print: {finger_print}")
         if latest.finger_print == finger_print:
-            logging.info("got")
             return latest
         raise cls.DoesNotExist(f"{pid_provider_xml} {finger_print}")
 
@@ -1237,7 +1230,6 @@ class PidProviderXML(CommonControlField, ClusterableModel):
         xml_with_pre : XMLWithPre
 
         """
-        logging.info("PidProviderXML.check_registration_demand")
         xml_adapter = xml_sps_adapter.PidProviderXMLAdapter(xml_with_pre)
 
         try:

--- a/pid_provider/requester.py
+++ b/pid_provider/requester.py
@@ -25,6 +25,7 @@ class PidRequester(BasePidProvider):
         origin_date=None,
         force_update=None,
         is_published=None,
+        article_proc=None,
     ):
         try:
             for xml_with_pre in XMLWithPre.create(path=zip_xml_file_path):
@@ -36,6 +37,7 @@ class PidRequester(BasePidProvider):
                     force_update=force_update,
                     is_published=is_published,
                     origin=zip_xml_file_path,
+                    article_proc=article_proc,
                 )
         except Exception as e:
             exc_type, exc_value, exc_traceback = sys.exc_info()
@@ -68,26 +70,26 @@ class PidRequester(BasePidProvider):
         force_update=None,
         is_published=None,
         origin=None,
+        article_proc=None,
     ):
         """
         Recebe um xml_with_pre para solicitar o PID v3
         """
-        v3 = xml_with_pre.v3
-        logging.info(".................................")
-        logging.info(
-            f"PidRequester.request_pid_for_xml_with_pre ({name}): {(xml_with_pre.sps_pkg_name, xml_with_pre.v3, xml_with_pre.v2, xml_with_pre.aop_pid)}"
+        main_op = article_proc.start(user, "request_pid_for_xml_with_pre")
+        registered = PidRequester.get_registration_demand(
+            xml_with_pre, article_proc, user
         )
 
-        registered = PidRequester.get_registration_demand(xml_with_pre)
-        logging.info(f"PidRequester.get_registration_demand: {name} {registered}")
         if registered.get("error_type"):
             return registered
 
-        self.core_registration(xml_with_pre, registered)
+        self.core_registration(xml_with_pre, registered, article_proc, user)
         xml_changed = registered.get("xml_changed")
 
         if not registered["registered_in_upload"]:
             # não está registrado em Upload, realizar registro
+
+            op = article_proc.start(user, ">>> upload registration")
             resp = self.provide_pid_for_xml_with_pre(
                 xml_with_pre,
                 xml_with_pre.filename,
@@ -98,23 +100,14 @@ class PidRequester(BasePidProvider):
                 origin=origin,
                 registered_in_core=registered.get("registered_in_core"),
             )
-            logging.info(f"core xml_changes: {registered.get('xml_changed')}")
-            logging.info(f"upload xml_changes: {resp.get('xml_changed')}")
-            logging.info(
-                (
-                    xml_with_pre.sps_pkg_name,
-                    xml_with_pre.v3,
-                    xml_with_pre.v2,
-                    xml_with_pre.aop_pid,
-                )
-            )
-
             xml_changed = xml_changed or resp.get("xml_changed")
-            logging.info(f"upload registration: {resp}")
             registered.update(resp)
-            logging.info(f"registered: {registered}")
             registered["registered_in_upload"] = bool(resp.get("v3"))
-            logging.info(f"registered: {registered}")
+            op.finish(
+                user,
+                completed=True,
+                detail={"registered": registered, "response": resp},
+            )
 
         registered["synchronized"] = (
             registered["registered_in_core"] and registered["registered_in_upload"]
@@ -122,13 +115,12 @@ class PidRequester(BasePidProvider):
         registered["xml_changed"] = xml_changed
         registered["xml_with_pre"] = xml_with_pre
         registered["filename"] = name
-        logging.info(f"registered={registered}")
-        logging.info(f"v3={xml_with_pre.v3}")
-        logging.info("__." * 10)
+
+        main_op.finish(user, completed=True, detail={"registered": registered})
         return registered
 
     @staticmethod
-    def get_registration_demand(xml_with_pre):
+    def get_registration_demand(xml_with_pre, article_proc, user):
         """
         Obtém a indicação de demanda de registro no Upload e/ou Core
 
@@ -137,34 +129,37 @@ class PidRequester(BasePidProvider):
         {"registered_in_upload": boolean, "registered_in_core": boolean}
 
         """
+        op = article_proc.start(user, ">>> get registration demand")
+
         registered = PidProviderXML.is_registered(xml_with_pre) or {}
         registered["registered_in_upload"] = bool(registered.get("v3"))
         registered["registered_in_core"] = registered.get("registered_in_core")
 
+        op.finish(user, completed=True, detail={"registered": registered})
+
         return registered
 
-    def core_registration(self, xml_with_pre, registered):
+    def core_registration(self, xml_with_pre, registered, article_proc, user):
         """
         Solicita PID v3 para o Core, se necessário
         """
-        if not self.pid_provider_api.enabled:
-            return registered
-
         if not registered["registered_in_core"]:
+            op = article_proc.start(user, ">>> core registration")
+
+            if not self.pid_provider_api.enabled:
+                op.finish(user, completed=False, detail={"core_pid_provider": "off"})
+                return registered
+
             response = self.pid_provider_api.provide_pid(
                 xml_with_pre, xml_with_pre.filename
-            )
-            logging.info(f"core xml_changes: {response.get('xml_changed')}")
-            logging.info(
-                (
-                    xml_with_pre.sps_pkg_name,
-                    xml_with_pre.v3,
-                    xml_with_pre.v2,
-                    xml_with_pre.aop_pid,
-                )
             )
             response = response or {}
             registered.update(response)
             registered["registered_in_core"] = bool(response.get("v3"))
-            logging.info(f"PidRequester.core_registration: {registered}")
+            op.finish(
+                user,
+                completed=True,
+                detail={"registered": registered, "response": response},
+            )
+
         return registered

--- a/proc/models.py
+++ b/proc/models.py
@@ -37,7 +37,7 @@ from migration.models import (
     MigratedIssue,
     MigratedJournal,
 )
-from migration.controller import PkgZipBuilder, get_migrated_xml_with_pre
+from migration.controller import PkgZipBuilder, get_migrated_xml_with_pre, XMLVersionXmlWithPreError
 from package import choices as package_choices
 from package.models import SPSPkg
 from proc import exceptions
@@ -1151,7 +1151,6 @@ class ArticleProc(BaseProc, ClusterableModel):
     ):
         try:
             operation = self.start(user, "generate_sps_package")
-
             self.sps_pkg_status = tracker_choices.PROGRESS_STATUS_DOING
             self.save()
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -60,7 +60,7 @@ minio==7.2
 # Upload
 # ------------------------------------------------------------------------------
 lxml==4.9.3 # https://github.com/lxml/lxml
--e git+https://github.com/scieloorg/packtools#egg=packtools
+-e git+https://github.com/scieloorg/packtools.git@3.3.0#egg=packtools
 -e git+https://github.com/scieloorg/scielo_scholarly_data#egg=scielo_scholarly_data
 
 # DSM Publication

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -60,7 +60,7 @@ minio==7.2
 # Upload
 # ------------------------------------------------------------------------------
 lxml==4.9.3 # https://github.com/lxml/lxml
--e git+https://github.com/scieloorg/packtools.git@3.3.0#egg=packtools
+-e git+https://github.com/scieloorg/packtools.git@3.3.1#egg=packtools
 -e git+https://github.com/scieloorg/scielo_scholarly_data#egg=scielo_scholarly_data
 
 # DSM Publication


### PR DESCRIPTION
#### O que esse PR faz?
- corrige caminho do xml migrado ao obter o XML para compor o zip
- corrige valor xml changed
- padroniza o XML (pretty_print) para facilitar a comparação / verificar a diferença
- registra em "Operation" os passos do pid provider no lugar de deixar como mensagem de log

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
executando o fluxo de migração

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a

