### PR TITLE
Atualiza a biblioteca scielo_migration (scielo_classic_website) para 1.5.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -73,8 +73,8 @@ python-magic==0.4.27
 
 # DSM Migration
 # ------------------------------------------------------------------------------
-#-e git+https://github.com/scieloorg/scielo_migration.git@1.3.0#egg=scielo_classic_website
--e git+https://github.com/scieloorg/scielo_migration.git#egg=scielo_classic_website
+-e git+https://github.com/scieloorg/scielo_migration.git@1.5.1#egg=scielo_classic_website
+#-e git+https://github.com/scieloorg/scielo_migration.git#egg=scielo_classic_website
 python-dateutil==2.8.2
 tornado>=6.3.2 # not directly required, pinned by Snyk to avoid a vulnerability
 


### PR DESCRIPTION
#### O que esse PR faz?
Atualiza a biblioteca scielo_migration (scielo_classic_website) para 1.5.1 atualizar o dtd-version (1.3) e specific-user (sps-1.10) do XML gerado.
Além disso, esta alteração adiciona a data de processamento como a data de publicação no site (`<pub-date date-type="pub"/>`)

#### Onde a revisão poderia começar?
n/a

#### Como este poderia ser testado manualmente?
Executando a tarefa get_xml, que realiza a conversão de html para xml.
Os xml gerados ficam em `core/media/classic_website/.../*.xml`

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a

