### PR TITLE
Adiciona filtros de journal_acron e publication_year para migrar dados de artigos

### DIFF
--- a/bigbang/tasks_scheduler.py
+++ b/bigbang/tasks_scheduler.py
@@ -251,6 +251,8 @@ def _schedule_migrate_document_files_and_records(username, enabled):
         name="task_migrate_document_files",
         kwargs=dict(
             username=username,
+            journal_acron=None,
+            publication_year=None,
             force_update=False,
         ),
         description=_("Migra arquivos dos documentos"),
@@ -266,6 +268,8 @@ def _schedule_migrate_document_files_and_records(username, enabled):
         name="task_migrate_document_records",
         kwargs=dict(
             username=username,
+            journal_acron=None,
+            publication_year=None,
             force_update=False,
         ),
         description=_("Migra registros dos documentos"),

--- a/migration/tasks.py
+++ b/migration/tasks.py
@@ -262,11 +262,15 @@ def task_migrate_document_files(
     user_id=None,
     username=None,
     collection_acron=None,
+    journal_acron=None,
+    publication_year=None,
     force_update=False,
 ):
     try:
+        publication_year = publication_year and str(publication_year)
         for collection in _get_collections(collection_acron):
-            items = IssueProc.files_to_migrate(collection, force_update)
+            items = IssueProc.files_to_migrate(
+                collection, journal_acron, publication_year, force_update)
             for item in items:
                 # Importa os arquivos das pastas */acron/volnum/*
                 task_import_one_issue_files.apply_async(
@@ -328,11 +332,16 @@ def task_migrate_document_records(
     user_id=None,
     username=None,
     collection_acron=None,
+    journal_acron=None,
+    publication_year=None,
     force_update=False,
 ):
     try:
+        publication_year = publication_year and str(publication_year)
+
         for collection in _get_collections(collection_acron):
-            items = IssueProc.docs_to_migrate(collection, force_update)
+            items = IssueProc.docs_to_migrate(
+                collection, journal_acron, publication_year, force_update)
             for item in items:
                 # Importa os registros de documentos
                 task_import_one_issue_document_records.apply_async(

--- a/proc/models.py
+++ b/proc/models.py
@@ -716,7 +716,7 @@ class IssueProc(BaseProc, ClusterableModel):
             )
 
     @classmethod
-    def files_to_migrate(cls, collection, force_update):
+    def files_to_migrate(cls, collection, journal_acron, publication_year, force_update):
         """
         Muda o status de PROGRESS_STATUS_REPROC para PROGRESS_STATUS_TODO
         E se force_update = True, muda o status de PROGRESS_STATUS_DONE para PROGRESS_STATUS_TODO
@@ -735,10 +735,17 @@ class IssueProc(BaseProc, ClusterableModel):
             migration_status=tracker_choices.PROGRESS_STATUS_DONE,
         ).update(files_status=tracker_choices.PROGRESS_STATUS_TODO)
 
+        params = {}
+        if publication_year:
+            params['issue__publication_year'] = publication_year
+        if journal_acron:
+            params['journal_proc__acron'] = journal_acron
+
         return cls.objects.filter(
             files_status=tracker_choices.PROGRESS_STATUS_TODO,
             collection=collection,
             migration_status=tracker_choices.PROGRESS_STATUS_DONE,
+            **params,
         ).iterator()
 
     def get_files_from_classic_website(
@@ -790,7 +797,7 @@ class IssueProc(BaseProc, ClusterableModel):
             )
 
     @classmethod
-    def docs_to_migrate(cls, collection, force_update):
+    def docs_to_migrate(cls, collection, journal_acron, publication_year, force_update):
         """
         Muda o status de PROGRESS_STATUS_REPROC para PROGRESS_STATUS_TODO
         E se force_update = True, muda o status de PROGRESS_STATUS_DONE para PROGRESS_STATUS_TODO
@@ -809,10 +816,17 @@ class IssueProc(BaseProc, ClusterableModel):
             migration_status=tracker_choices.PROGRESS_STATUS_DONE,
         ).update(docs_status=tracker_choices.PROGRESS_STATUS_TODO)
 
+        params = {}
+        if publication_year:
+            params['issue__publication_year'] = publication_year
+        if journal_acron:
+            params['journal_proc__acron'] = journal_acron
+
         return cls.objects.filter(
             docs_status=tracker_choices.PROGRESS_STATUS_TODO,
             collection=collection,
             migration_status=tracker_choices.PROGRESS_STATUS_DONE,
+            **params,
         ).iterator()
 
     def get_article_records_from_classic_website(


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona filtros de journal_acron e publication_year para migrar dados de artigos com o intuito de obter um subconjunto de artigos para migrar e testar o fluxo até a publicação.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Executando as tarefas **task_migrate_document_records** task e **task_migrate_document_files** com os filtros de `journal_acron` e  `publication_year`

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a
