### PR TITLE
Garante que no XML migrado (seja nativo ou gerado a partir do HTML) tenha o PID v2 e o order (article-id other)

### DIFF
--- a/migration/controller.py
+++ b/migration/controller.py
@@ -502,9 +502,15 @@ def get_migrated_xml_with_pre(article_proc):
         xml_file_path = obj.file.path
         for item in XMLWithPre.create(path=xml_file_path):
             if article_proc.pid and item.v2 != article_proc.pid:
-                # corrige ou adiciona pid v2 no XML migrado nativo ou obtido do html
+                # corrige ou adiciona pid v2 no XML nativo ou obtido do html
                 # usando o valor do pid v2 do site clássico
                 item.v2 = article_proc.pid
+
+            order = str(int(article_proc.pid[-5:]))
+            if not item.order or str(int(item.order)) != order:
+                # corrige ou adiciona other pid no XML nativo ou obtido do html
+                # usando o valor do "order" do site clássico
+                item.order = article_proc.pid[-5:]
             return item
     except Exception as e:
         raise XMLVersionXmlWithPreError(

--- a/migration/controller.py
+++ b/migration/controller.py
@@ -501,6 +501,10 @@ def get_migrated_xml_with_pre(article_proc):
         xml_file_path = None
         xml_file_path = obj.file.path
         for item in XMLWithPre.create(path=xml_file_path):
+            if article_proc.pid and item.v2 != article_proc.pid:
+                # corrige ou adiciona pid v2 no XML migrado nativo ou obtido do html
+                # usando o valor do pid v2 do site clássico
+                item.v2 = article_proc.pid
             return item
     except Exception as e:
         raise XMLVersionXmlWithPreError(

--- a/migration/models.py
+++ b/migration/models.py
@@ -448,12 +448,10 @@ class MigratedFile(CommonControlField):
             pass
 
     def save_file(self, name, content, delete=False):
-        if self.file:
-            if delete:
-                try:
-                    self.file.delete(save=True)
-                except Exception as e:
-                    pass
+        try:
+            self.file.delete(save=True)
+        except Exception as e:
+            pass
         self.file.save(name, ContentFile(content))
 
     def is_up_to_date(self, file_date):

--- a/pid_provider/models.py
+++ b/pid_provider/models.py
@@ -93,6 +93,10 @@ class XMLVersion(CommonControlField):
             return cls.get(pid_provider_xml, xml_with_pre.finger_print)
 
     def save_file(self, filename, content):
+        try:
+            self.file.delete(save=True)
+        except Exception as e:
+            pass
         self.file.save(filename, ContentFile(content))
 
     @property

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -60,7 +60,7 @@ minio==7.2
 # Upload
 # ------------------------------------------------------------------------------
 lxml==4.9.3 # https://github.com/lxml/lxml
--e git+https://github.com/scieloorg/packtools.git@3.3.1#egg=packtools
+-e git+https://github.com/scieloorg/packtools.git@3.4.0#egg=packtools
 -e git+https://github.com/scieloorg/scielo_scholarly_data#egg=scielo_scholarly_data
 
 # DSM Publication

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -73,7 +73,7 @@ python-magic==0.4.27
 
 # DSM Migration
 # ------------------------------------------------------------------------------
--e git+https://github.com/scieloorg/scielo_migration.git@1.6.3#egg=scielo_classic_website
+-e git+https://github.com/scieloorg/scielo_migration.git@1.6.4#egg=scielo_classic_website
 #-e git+https://github.com/scieloorg/scielo_migration.git#egg=scielo_classic_website
 python-dateutil==2.8.2
 tornado>=6.3.2 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
#### O que esse PR faz?
Garante que no XML migrado (seja nativo ou gerado a partir do HTML) tenha o PID v2 e o order (article-id other).
Este dados são essenciais para manter o vínculo com o legado, que as URL antigas possam ser redirecionadas para as novas. Por algum motivo desconhecido o XML nativo nem sempre contém o PID v2 e o order devidamente identificados:

```xml
<article-id pub-id-type="other">00507</article-id>
<article-id pub-id-type="publisher-id" specific-use="scielo-v2">S0034-89102022000100507</article-id>
```
Além desta mudança:
- evita duplicar arquivos em core/media, deixa sempre a última versão
- corrige a obtenção de registros de artigos que estão presentes nas pastas base_xml em serial
- 

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
No upload, no processo de migração, executando a tarefa generate_sps_package, serão adicionados ou atualizados pid v2 e order no XML do pacote SPS, mantendo intactos os XML nativos migrados para preservar o conteúdo.

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a

