### PR TITLE
Altera comportamento de pid provider

### DIFF
--- a/package/models.py
+++ b/package/models.py
@@ -601,14 +601,24 @@ class SPSPkg(CommonControlField, ClusterableModel):
                     package = SPPackage.from_file(zip_file_path, workdir)
                     package.optimise(new_package_file_path=target, preserve_files=False)
 
+                # saved optimised
                 with open(target, "rb") as fp:
-                    # saved optimised
-                    self.file.save(filename, ContentFile(fp.read()))
+                    self.save_file(filename, fp.read())
         except Exception as e:
+            # saved original
             with open(zip_file_path, "rb") as fp:
-                # saved original
-                self.file.save(filename, ContentFile(fp.read()))
+                self.save_file(filename, fp.read())
         self.save()
+
+    def save_file(self, name, content):
+        try:
+            self.file.delete(save=True)
+        except Exception as e:
+            pass
+        try:
+            self.file.save(name, ContentFile(content))
+        except Exception as e:
+            raise Exception(f"Unable to save {name}. Exception: {e}")
 
     def generate_article_html_page(self, user):
         try:

--- a/pid_provider/base_pid_provider.py
+++ b/pid_provider/base_pid_provider.py
@@ -22,10 +22,14 @@ class BasePidProvider:
         is_published=None,
         origin=None,
         registered_in_core=None,
+        caller=None,
     ):
         """
         Fornece / Valida PID para o XML no formato de objeto de XMLWithPre
         """
+        # Completa os valores ausentes de pid com recuperados ou com inéditos
+        xml_changed = PidProviderXML.complete_pids(xml_with_pre)
+
         registered = PidProviderXML.register(
             xml_with_pre,
             name,
@@ -36,6 +40,11 @@ class BasePidProvider:
             origin=origin,
             registered_in_core=registered_in_core,
         )
+        if xml_changed:
+            registered["xml_changed"] = xml_changed
+            # indica que Upload precisa aplicar as mudanças no xml_with_pre
+            registered["apply_xml_changes"] = caller == "core"
+
         return registered
 
     def provide_pid_for_xml_zip(
@@ -47,6 +56,7 @@ class BasePidProvider:
         force_update=None,
         is_published=None,
         registered_in_core=None,
+        caller=None,
     ):
         """
         Fornece / Valida PID para o XML em um arquivo compactado
@@ -66,6 +76,7 @@ class BasePidProvider:
                     is_published=is_published,
                     origin=zip_xml_file_path,
                     registered_in_core=registered_in_core,
+                    caller=caller,
                 )
         except Exception as e:
             exc_type, exc_value, exc_traceback = sys.exc_info()

--- a/pid_provider/client.py
+++ b/pid_provider/client.py
@@ -238,20 +238,25 @@ class PidProviderAPIClient:
     def _process_post_xml_response(self, response, xml_with_pre, created=None):
         if not response:
             return
-        logging.info(f"_process_post_xml_response: {response}")
         for item in response:
+            logging.info(f"_process_post_xml_response ({xml_with_pre.data}): {item}")
 
             if not item.get("xml_changed"):
-                # dados em Upload é o mais atualizado
+                # pids do xml_with_pre não mudaram
+                logging.info("No xml changes")
                 return
 
             try:
                 # atualiza xml_with_pre com valor do XML registrado no Core
-                if not item.get("force_xml_changed"):
-                    # exceto 'force_xml_changed=True' ou
+                if not item.get("apply_xml_changes"):
+                    # exceto 'apply_xml_changes=True' ou
                     # exceto se o registro do Core foi criado posteriormente
                     if created and created < item["created"]:
                         # não atualizar com os dados do Core
+                        logging.info({
+                            "created_at_upload": created,
+                            "created_at_core": item['created'],
+                        })
                         return
 
                 for pid_type, pid_value in item["xml_changed"].items():
@@ -262,7 +267,7 @@ class PidProviderAPIClient:
                             xml_with_pre.v2 = pid_value
                         elif pid_type == "aop_pid":
                             xml_with_pre.aop_pid = pid_value
-                        item["do_upload_registration"] = True
+                        logging.info("XML changed")
                     except Exception as e:
                         pass
                 return

--- a/pid_provider/models.py
+++ b/pid_provider/models.py
@@ -1171,7 +1171,7 @@ class PidProviderXML(CommonControlField, ClusterableModel):
         Parameters
         ----------
         xml_adapter: PidProviderXMLAdapter
-        registered: XMLArticle
+        registered: PidProviderXML
 
         Returns
         -------
@@ -1233,7 +1233,7 @@ class PidProviderXML(CommonControlField, ClusterableModel):
         Arguments
         ---------
         xml_adapter: PidProviderXMLAdapter
-        registered: XMLArticle
+        registered: PidProviderXML
         """
         if registered:
             # recupera do registrado
@@ -1254,7 +1254,7 @@ class PidProviderXML(CommonControlField, ClusterableModel):
         Arguments
         ---------
         xml_adapter: PidProviderXMLAdapter
-        registered: XMLArticle
+        registered: PidProviderXML
         """
         if registered and registered.aop_pid:
             xml_adapter.aop_pid = registered.aop_pid
@@ -1267,7 +1267,7 @@ class PidProviderXML(CommonControlField, ClusterableModel):
         Arguments
         ---------
         xml_adapter: PidProviderXMLAdapter
-        registered: XMLArticle
+        registered: PidProviderXML
 
         """
         if registered and registered.v2 and xml_adapter.v2 != registered.v2:

--- a/pid_provider/models.py
+++ b/pid_provider/models.py
@@ -1032,10 +1032,7 @@ class PidProviderXML(CommonControlField, ClusterableModel):
         while True:
             generated = v3_gen.generates()
             if not cls._is_registered_pid(v3=generated):
-                try:
-                    OtherPid.objects.get(pid_type="pid_v3", pid_in_xml=generated)
-                except OtherPid.DoesNotExist:
-                    return generated
+                return generated
 
     @classmethod
     def _is_registered_pid(cls, v2=None, v3=None, aop_pid=None):
@@ -1050,7 +1047,13 @@ class PidProviderXML(CommonControlField, ClusterableModel):
             try:
                 found = cls.objects.filter(**kwargs)[0]
             except IndexError:
-                return False
+                try:
+                    OtherPid.objects.get(pid_in_xml=v3 or v2 or aop_pid)
+                    return True
+                except OtherPid.DoesNotExist:
+                    return False
+                except OtherPid.MultipleObjectsReturned:
+                    return True
             else:
                 return True
 

--- a/pid_provider/models.py
+++ b/pid_provider/models.py
@@ -1215,6 +1215,15 @@ class PidProviderXML(CommonControlField, ClusterableModel):
     def _is_valid_pid(cls, value):
         return bool(value and len(value) == 23)
 
+    def get_pids(self):
+        d = {}
+        d["pid_v3"] = [self.v3]
+        d["pid_v2"] = [self.v2]
+        d["aop_pid"] = [self.aop_pid]
+
+        for item in OtherPid.objects.filter(pid_provider_xml=self).iterator():
+            d[item.pid_type].append(item.pid_in_xml)
+
     @classmethod
     def _add_pid_v3(cls, xml_adapter, registered):
         """


### PR DESCRIPTION
#### O que esse PR faz?
Altera comportamento de pid provider. 
O XML pode ou não conter pids ao ser feita a requisição para o PidProvider.
Na versão atual, o XML que contém pids e já foi registrado, tem os pids substituídos pelos registrados, e os pids do XML são guardados em OtherPid. No entanto, é desejável que o pid que está no XML de um XML anteriormente registrado possa ser atualizado. Sendo assim, o pid do XML passa a ser o vigente e o registrado é movido para OtherPid. Para isso, foram feitas as seguintes mudanças:
- `PidProvider.provide_pid_for_xml_with_pre` **completa** os pids do `xml_with_pre` somente em caso de ausência com pids recuperados dos registrados ou gerados dos inéditos. Anteriormente os pids eram substituídos pelos registrados.
- `PidProviderXML.register` rejeita XML sem pid v3. Anteriormente ele gerava o pid v3 para os XML que não tinha pid v3 e não estavam registrados. Esta função passa a ser de `PidProvider.provide_pid_for_xml_with_pre`

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Executando as tarefas de migração generate_sps_package

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a
