### PR TITLE
Verifica se xml registrado e xml recebido são iguais, somente após completar XML com os pids registrados

### DIFF
--- a/package/models.py
+++ b/package/models.py
@@ -428,6 +428,9 @@ class SPSPkg(CommonControlField, ClusterableModel):
     def get(cls, pid_v3):
         return cls.objects.get(pid_v3=pid_v3)
 
+    def set_registered_in_core(self, value):
+        PidRequester.set_registered_in_core(self.pid_v3, value)
+
     @staticmethod
     def is_registered_in_core(pid_v3):
         if not pid_v3:

--- a/pid_provider/requester.py
+++ b/pid_provider/requester.py
@@ -86,21 +86,6 @@ class PidRequester(BasePidProvider):
             return registered
 
         xml_changed = {}
-        # Completa os valores ausentes de pid com recuperados ou com inéditos
-        try:
-            before = (xml_with_pre.v3, xml_with_pre.v2, xml_with_pre.aop_pid)
-            xml_with_pre.v3 = xml_with_pre.v3 or registered["v3"]
-            xml_with_pre.v2 = xml_with_pre.v2 or registered["v2"]
-            if registered["aop_pid"]:
-                xml_with_pre.aop_pid = registered["aop_pid"]
-
-            # verifica se houve mudança nos PIDs do XML
-            after = (xml_with_pre.v3, xml_with_pre.v2, xml_with_pre.aop_pid)
-            for label, bef, aft in zip(("pid_v3", "pid_v2", "aop_pid"), before, after):
-                if bef != aft:
-                    xml_changed[label] = aft
-        except KeyError:
-            pass
 
         # Solicita pid para Core
         self.core_registration(xml_with_pre, registered, article_proc, user)
@@ -156,7 +141,9 @@ class PidRequester(BasePidProvider):
         """
         op = article_proc.start(user, ">>> get registration demand")
 
-        registered = PidProviderXML.is_registered(xml_with_pre) or {}
+        registered = PidProviderXML.is_registered(xml_with_pre)
+        if registered.get("error_type"):
+            return registered
 
         if registered.get("is_equal"):
             # xml recebido é igual ao registrado

--- a/pid_provider/requester.py
+++ b/pid_provider/requester.py
@@ -77,6 +77,9 @@ class PidRequester(BasePidProvider):
         """
         Recebe um xml_with_pre para solicitar o PID v3
         """
+        # identifica as mudanças no xml_with_pre
+        xml_changed = {}
+
         main_op = article_proc.start(user, "request_pid_for_xml_with_pre")
         registered = PidRequester.get_registration_demand(
             xml_with_pre, article_proc, user
@@ -84,8 +87,6 @@ class PidRequester(BasePidProvider):
 
         if registered.get("error_type"):
             return registered
-
-        xml_changed = {}
 
         # Solicita pid para Core
         self.core_registration(xml_with_pre, registered, article_proc, user)
@@ -250,3 +251,13 @@ class PidRequester(BasePidProvider):
             fixed["fixed_in_core"] = obj.fixed_in_core
         logging.info(fixed)
         return fixed
+
+    @staticmethod
+    def set_registered_in_core(pid_v3, value):
+        try:
+            PidProviderXML.objects.filter(
+                registered_in_core=bool(not value),
+                v3=pid_v3,
+            ).update(registered_in_core=value)
+        except Exception as e:
+            logging.exception(e)

--- a/proc/tasks.py
+++ b/proc/tasks.py
@@ -261,6 +261,7 @@ def task_generate_sps_packages(
     force_update=False,
     body_and_back_xml=False,
     html_to_xml=False,
+    force_core_update=True,
 ):
     try:
         for collection in _get_collections(collection_acron):
@@ -279,6 +280,7 @@ def task_generate_sps_packages(
                         "item_id": item.id,
                         "body_and_back_xml": body_and_back_xml,
                         "html_to_xml": html_to_xml,
+                        "force_core_update": force_core_update,
                     }
                 )
     except Exception as e:
@@ -297,6 +299,7 @@ def task_generate_sps_packages(
                 "force_update": force_update,
                 "body_and_back_xml": body_and_back_xml,
                 "html_to_xml": html_to_xml,
+                "force_core_update": force_core_update,
             },
         )
 
@@ -309,10 +312,13 @@ def task_generate_sps_package(
     html_to_xml=False,
     username=None,
     user_id=None,
+    force_core_update=None,
 ):
     try:
         user = _get_user(user_id, username)
         item = ArticleProc.objects.get(pk=item_id)
+        if force_core_update and item.sps_pkg:
+            item.sps_pkg.set_registered_in_core(False)
         item.generate_sps_package(
             user,
             body_and_back_xml,


### PR DESCRIPTION
#### O que esse PR faz?
Verifica se xml registrado e xml recebido são iguais, somente após completar XML com os pids registrados.
Também adiciona parâmetro para forçar a sincronização com o Core.

#### Onde a revisão poderia começar?
Por commits

#### Como este poderia ser testado manualmente?
Executando a tarefa generate_sps_package

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a

