### PR TITLE
Refatora Todos Os Campo 'Language' para Relacionamento ForeignKey com modelo Language em core.models

### DIFF
--- a/collection/models.py
+++ b/collection/models.py
@@ -5,11 +5,12 @@ from django.utils.translation import gettext_lazy as _
 from wagtail.admin.panels import FieldPanel, InlinePanel
 from wagtailautocomplete.edit_handlers import AutocompletePanel
 
+from core.choices import LANGUAGE
 from core.forms import CoreAdminModelForm
 from core.models import CommonControlField
 
 from collection import choices
-
+from collection.utils import language_iso
 
 class LanguageGetOrCreateError(Exception):
     ...
@@ -180,9 +181,16 @@ class Language(CommonControlField):
 
     def autocomplete_label(self):
         return self.code2
+    
+    
+    @classmethod
+    def load(cls, user=None):
+        for k, v in LANGUAGE:
+            cls.get_or_create(name=v, code2=k, creator=user)
 
     @classmethod
     def get(cls, name=None, code2=None):
+        code2 = language_iso(code=code2)
         if code2:
             if not code2.isalpha() or len(code2) != 2:
                 raise ValueError(f"Language.get_or_create invalid code2 {code2}")

--- a/collection/utils.py
+++ b/collection/utils.py
@@ -1,0 +1,12 @@
+import re
+import logging
+from iso639 import Lang
+from iso639.exceptions import InvalidLanguageValue
+
+def language_iso(code):
+    code = re.split(r"-|_", code)[0] if code else ""
+    try:
+        return Lang(code).pt1
+    except InvalidLanguageValue as e:
+        logging.error(f"{e.msg} ({code})")
+        return ''

--- a/core/models.py
+++ b/core/models.py
@@ -9,6 +9,7 @@ from wagtail.fields import RichTextField
 from wagtail.snippets.models import register_snippet
 
 from . import choices
+from collection.models import Language
 
 User = get_user_model()
 
@@ -56,9 +57,7 @@ class CommonControlField(models.Model):
 
 class RichTextWithLang(models.Model):
     text = RichTextField(null=False, blank=False)
-    language = models.CharField(
-        _("Language"), max_length=2, choices=choices.LANGUAGE, null=False, blank=False
-    )
+    language = models.ForeignKey(Language, null=True, blank=True, on_delete=models.SET_NULL)
 
     panels = [FieldPanel("text"), FieldPanel("language")]
 
@@ -68,9 +67,7 @@ class RichTextWithLang(models.Model):
 
 class TextWithLangAndValidity(models.Model):
     text = models.TextField(_("Text"), null=False, blank=False)
-    language = models.CharField(
-        _("Language"), max_length=2, choices=choices.LANGUAGE, null=False, blank=False
-    )
+    language = models.ForeignKey(Language, null=True, blank=True, on_delete=models.SET_NULL)
     initial_date = models.DateField(null=True, blank=True)
     final_date = models.DateField(null=True, blank=True)
 
@@ -102,9 +99,7 @@ class RichTextWithLangAndValidity(RichTextWithLang):
 
 class TextWithLang(models.Model):
     text = models.TextField(_("Text"), null=False, blank=False)
-    language = models.CharField(
-        _("Language"), max_length=2, choices=choices.LANGUAGE, null=False, blank=False
-    )
+    language = models.ForeignKey(Language, null=True, blank=True, on_delete=models.SET_NULL)
 
     panels = [FieldPanel("text"), FieldPanel("language")]
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -78,3 +78,7 @@ tornado>=6.3.2 # not directly required, pinned by Snyk to avoid a vulnerability
 # ------------------------------------------------------------------------------
 tenacity==8.2.3  # https://pypi.org/project/tenacity/
 urllib3==2.2.1
+
+# iso639-langs
+# ------------------------------------------------------------------------------
+iso639-lang==2.2.3

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -3,7 +3,7 @@
 # Werkzeug[watchdog]==2.0.3 # https://github.com/pallets/werkzeug
 Werkzeug==3.0.1 # https://github.com/pallets/werkzeug
 ipdb==0.13.13  # https://github.com/gotcha/ipdb
-psycopg2==2.9.9  # https://github.com/psycopg/psycopg2
+psycopg2-binary==2.9.9  # https://github.com/psycopg/psycopg2
 watchgod==0.8.2  # https://github.com/samuelcolvin/watchgod
 
 # Testing


### PR DESCRIPTION
#### O que esse PR faz?
Refatora Todos Os Campo 'Language' para Relacionamento ForeignKey com modelo Language em core.models

#### Onde a revisão poderia começar?
pelos commits

#### Como este poderia ser testado manualmente?
make django_migrate

#### Algum cenário de contexto que queira dar?
Não é possível mudar o modelo Language para core.models por causa da herança de CommonControlField.
Ref: https://stackoverflow.com/questions/25648393/how-to-move-a-model-between-two-django-apps-django-1-7

### Screenshots
N/A

#### Quais são tickets relevantes?
#437 

### Referências
https://stackoverflow.com/questions/25648393/how-to-move-a-model-between-two-django-apps-django-1-7

