### PR TITLE
Adiciona comando update ao Makefile para remoção e atualização de containers de produção

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,3 +127,9 @@ volume_down:  ## Remove all volume
 
 clean_celery_logs:
 	@sudo truncate -s 0 $$(docker inspect --format='{{.LogPath}}' scielo_core_local_celeryworker)
+
+exclude_upload_production_django:  ## Exclude all productions containers
+	@docker rmi -f $(shell docker images --filter=reference='upload_production*' -q)
+	@echo "Exclude all upload production containers"
+
+update: stop rm exclude_upload_production_django up


### PR DESCRIPTION
#### O que esse PR faz?
Este PR adiciona um novo comando update ao Makefile, que facilita a remoção de todos os containers de produção relacionados a upload_production. 

#### Onde a revisão poderia começar?
Pelos commits

#### Como este poderia ser testado manualmente?

1. make update

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A

