### PR TITLE
Correção de Comando de Exclusão e Atualização de Imagens Docker no Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,11 @@ clean_celery_logs:
 	@sudo truncate -s 0 $$(docker inspect --format='{{.LogPath}}' scielo_core_local_celeryworker)
 
 exclude_upload_production_django:  ## Exclude all productions containers
-	@docker rmi -f $(shell docker images --filter=reference='upload_production*' -q)
-	@echo "Exclude all upload production containers"
+	@if [ -n "$$(docker images --format '{{.Repository}}:{{.Tag}}' | grep 'upload_production' | grep -v 'upload_production_postgres')" ]; then \
+		docker rmi -f $$(docker images --format '{{.Repository}}:{{.Tag}}' | grep 'upload_production' | grep -v 'upload_production_postgres'); \
+		echo "Excluded all upload production containers"; \
+	else \
+		echo "No images found for 'upload_production*'"; \
+	fi
 
 update: stop rm exclude_upload_production_django up

--- a/Makefile
+++ b/Makefile
@@ -129,8 +129,8 @@ clean_celery_logs:
 	@sudo truncate -s 0 $$(docker inspect --format='{{.LogPath}}' scielo_core_local_celeryworker)
 
 exclude_upload_production_django:  ## Exclude all productions containers
-	@if [ -n "$$(docker images --format '{{.Repository}}:{{.Tag}}' | grep 'upload_production' | grep -v 'upload_production_postgres')" ]; then \
-		docker rmi -f $$(docker images --format '{{.Repository}}:{{.Tag}}' | grep 'upload_production' | grep -v 'upload_production_postgres'); \
+	@if [ -n "$$(docker images --format '{{.Repository}}:{{.Tag}}' | grep 'infrascielo/upload' | grep -v 'upload_production_postgres')" ]; then \
+		docker rmi -f $$(docker images --format '{{.Repository}}:{{.Tag}}' | grep 'infrascielo/upload' | grep -v 'upload_production_postgres'); \
 		echo "Excluded all upload production containers"; \
 	else \
 		echo "No images found for 'upload_production*'"; \


### PR DESCRIPTION
#### O que esse PR faz?
Este PR corrige o comando de exclusão de imagens Docker no Makefile para assegurar que apenas as imagens relevantes de produção sejam excluídas e atualizadas.

#### Onde a revisão poderia começar?
Pelo commit

#### Como este poderia ser testado manualmente?
1. make update compose=production.yml

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A

