### PR TITLE
Remove espaços (quebra de linha) no início e fim do arquivo XML antes de registrar no minio

### DIFF
--- a/package/models.py
+++ b/package/models.py
@@ -740,7 +740,7 @@ class SPSPkg(CommonControlField, ClusterableModel):
         filename = self.sps_pkg_name + ".xml"
         try:
             response = minio_push_file_content(
-                content=xml_with_pre.tostring(pretty_print=True).encode("utf-8"),
+                content=xml_with_pre.tostring(pretty_print=True).encode("utf-8").strip(),
                 mimetype=mimetypes.types_map[".xml"],
                 object_name=f"{self.subdir}/{filename}",
             )


### PR DESCRIPTION
#### O que esse PR faz?
Remove espaços (quebra de linha) no início e fim do arquivo XML antes de registrar no minio
Tenta resolver o problema ao executar a migração de artigos que ocorriam em:

```python
def generate_article_html_page(self, user):
        try:
            generator = HTMLGenerator.parse(
                file=self.xml_uri,
                valid_only=False,
                xslt="3.0",
            )
```

```
[2024-07-02 14:54:14,547: ERROR/ForkPoolWorker-4] PreviewArticlePage 2215-5287-mlcr-21-02-101 cannot parse from 'NoneType'
Traceback (most recent call last):
  File "/app/package/models.py", line 629, in generate_article_html_page
    generator = HTMLGenerator.parse(
                ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/packtools/domain.py", line 514, in parse
    et = utils.XML(file)
         ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/packtools/utils.py", line 100, in XML
    xml = etree.parse(file, parser)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "src/lxml/etree.pyx", line 3548, in lxml.etree.parse
  File "src/lxml/parser.pxi", line 1902, in lxml.etree._parseDocument
TypeError: cannot parse from 'NoneType'
[2024-07-02 14:54:14,585: INFO/ForkPoolWorker-4] Task proc.tasks.task_generate_sps_package[d499c002-8a54-4ff8-98eb-5c5ef7e4b832] succeeded in 4.1396419908851385s: None
[2024-07-02 14:54:14,587: INFO/MainProcess] Task proc.tasks.task_generate_sps_package[46089ceb-61f7-4671-948b-26cd419d2039] received
[2024-07-02 14:54:14,667: INFO/ForkPoolWorker-4] []
[2024-07-02 14:54:14,713: INFO/ForkPoolWorker-4] Posting xml with {'sps_pkg_name': '2215-5287-mlcr-21-02-71', 'pid_v3': '8wJ7b8hjwt64rcfGgpf34Wc', 'pid_v2': 'S1409-00152004000200009', 'aop_pid': None, 'filename': '2215-5287-mlcr-21-02-71.xml', 'files': ['2215-5287-mlcr-21-02-71.xml']}
```

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Ocorria ao executar migração para alguns artigos XML gerados pelo 

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
Remove espaços (quebra de linha) no início e fim do arquivo XML antes de registrar no minio

#### Quais são tickets relevantes?
(ocorreu ao implantar na coleção CRI)

### Referências
n/a
