### PR TITLE
Melhorias e correções em procedimentos relacionados com a migração e publicação do conteúdo migrado

### DIFF
--- a/article/models.py
+++ b/article/models.py
@@ -281,8 +281,6 @@ class Article(ClusterableModel, CommonControlField):
         items = xml_sections.article_section
         items.extend(xml_sections.sub_article_section)
 
-        logging.info(list(items))
-
         try:
             toc = TOC.objects.get(issue=self.issue)
         except TOC.DoesNotExist:
@@ -290,7 +288,6 @@ class Article(ClusterableModel, CommonControlField):
 
         group = None
         for item in items:
-            logging.info(f"section: {item}")
             if not item.get("text"):
                 continue
             try:
@@ -301,7 +298,6 @@ class Article(ClusterableModel, CommonControlField):
                     text=item.get("text"),
                 )
             except JournalSection.MultipleObjectsReturned as e:
-                logging.info(f"duplicated {item}")
                 section = JournalSection.objects.filter(
                     parent=self.journal,
                     language=language,

--- a/collection/models.py
+++ b/collection/models.py
@@ -115,7 +115,6 @@ class WebSiteConfiguration(CommonControlField, ClusterableModel):
     @classmethod
     def get(cls, url=None, collection=None, purpose=None):
         params = dict(url=url, collection=collection, purpose=purpose)
-        logging.info(f"Collection.get({params})")
         if url:
             return cls.objects.get(url=url)
         if collection and purpose:

--- a/local.yml
+++ b/local.yml
@@ -11,9 +11,9 @@ services:
       - redis
       - postgres
       - mailhog
-      - pgbouncer
-    links:
-      - pgbouncer
+      # - pgbouncer
+    # links:
+    #   # - pgbouncer
     volumes:
       - .:/app:z
     env_file:
@@ -23,19 +23,19 @@ services:
       - "8007:8000"
     command: /start
 
-  pgbouncer:
-    image: edoburu/pgbouncer:1.14.0
-    restart: always
-    container_name: upload_local_pgbouncer
-    environment:
-      - DATABASE_URL=postgres://GVRFlLmcCNfGLhsFvSnCioYOPJPYpyfj:BQ4hSUL4rdj5WZLdR8ilDLRQMvCtzo0caMaXDO0olGsmycQjlcZlTVK9DepZR8kk@postgres/uploaddb
-      - MAX_CLIENT_CONN=100
-    ports:
-      - 6437:5432
-    depends_on:
-      - postgres
-    links:
-      - postgres
+  # pgbouncer:
+  #   image: edoburu/pgbouncer:1.14.0
+  #   restart: always
+  #   container_name: upload_local_pgbouncer
+  #   environment:
+  #     - DATABASE_URL=postgres://GVRFlLmcCNfGLhsFvSnCioYOPJPYpyfj:BQ4hSUL4rdj5WZLdR8ilDLRQMvCtzo0caMaXDO0olGsmycQjlcZlTVK9DepZR8kk@postgres/uploaddb
+  #     - MAX_CLIENT_CONN=100
+  #   ports:
+  #     - 6437:5432
+  #   depends_on:
+  #     - postgres
+  #   links:
+  #     - postgres
 
   postgres:
     build:

--- a/migration/controller.py
+++ b/migration/controller.py
@@ -236,7 +236,6 @@ def create_or_update_article(
     Create/update Issue
     """
     if not tracker_choices.allowed_to_run(article_proc.migration_status, force_update):
-        logging.info(f"article_proc.migration_status={article_proc.migration_status}")
         return article_proc.article
 
     article = Article.create_or_update(

--- a/migration/models.py
+++ b/migration/models.py
@@ -459,16 +459,19 @@ class MigratedFile(CommonControlField):
 
     @property
     def text(self):
-        if self.component_type == "html":
-            try:
-                with open(self.file.path, mode="r", encoding="iso-8859-1") as fp:
-                    return fp.read()
-            except:
+        try:
+            if self.component_type == "html":
+                try:
+                    with open(self.file.path, mode="r", encoding="iso-8859-1") as fp:
+                        return fp.read()
+                except:
+                    with open(self.file.path, mode="r", encoding="utf-8") as fp:
+                        return fp.read()
+            if self.component_type == "xml":
                 with open(self.file.path, mode="r", encoding="utf-8") as fp:
                     return fp.read()
-        if self.component_type == "xml":
-            with open(self.file.path, mode="r", encoding="utf-8") as fp:
-                return fp.read()
+        except Exception as e:
+            return None
 
 
 class MigratedJournal(MigratedData):
@@ -680,8 +683,11 @@ class JournalAcronIdFile(CommonControlField, ClusterableModel):
         return os.stat(source_path).st_size
 
     def is_up_to_date(self, file_size):
-        logging.info(f"{self.file.path} {file_size} {self.file_size}")
-        return bool(self.file_size and self.file_size == file_size)
+        try:
+            logging.info(f"{self.file.path} {file_size} {self.file_size}")
+            return bool(self.file_size and self.file_size == file_size)
+        except Exception as e:
+            return False
 
     @classmethod
     def modified_articles(cls, collection=None, journal_acron=None, issue_folder=None):

--- a/proc/tasks.py
+++ b/proc/tasks.py
@@ -621,7 +621,7 @@ def task_migrate_and_publish_articles(
         if collection_acron:
             params["collection__acron"] = collection_acron
         if journal_acron:
-            params["journal__acron"] = journal_acron
+            params["acron"] = journal_acron
 
         logging.info(params)
         article_api_data = None

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -72,7 +72,7 @@ mongoengine==0.28.2
 aiohttp==3.9.1
 # DSM Migration
 # ------------------------------------------------------------------------------
--e git+https://github.com/scieloorg/scielo_migration.git@1.6.12#egg=scielo_classic_website
+-e git+https://github.com/scieloorg/scielo_migration.git@1.7.4#egg=scielo_classic_website
 python-dateutil==2.8.2
 tornado>=6.3.2 # not directly required, pinned by Snyk to avoid a vulnerability
 


### PR DESCRIPTION
#### O que esse PR faz?
As modificações estão relacionadas com:
- Conversão HTML a XML
- Padronização do pacote SPS
- Geração da página do artigo em HTML
- Tarefa de publicação
- Obtenção de conteúdo do site clássico

-------------------------------
Melhorias
- (package.models) atualiza o conteúdo do XML no zip, sem duplicação
- (package.models) registra em relatório eventuais defeitos ao gerar as páginas HTML
- (package.models) pára de gerar as páginas HTML em PreviewArticlePage
- (proc.models) deixa o valor de public_ws_status consistente com o de public_ws_status

Correções de bug
- (package.models) corrige a validação de 'texts' considerando que pdfs nem sempre estão pareados com html / xml
- (proc.models) altera BaseProc.update_publication_stage() para atualizar public_ws_status e public_ws_status em caso de resultado negativo
- (html2xml) Atualiza a biblioteca scielo_migration (classic_website) de 1.6.12 para 1.7.4 (conversão de html para xml) - tratamento de tags de estilos (bold, italic, sup, ...)
- (publicação) Corrige o nome do filtro de journal_acron da tarefa task_migrate_and_publish_articles
- (dados do site clássico) Trata exceção de não estarem instanciados JournalAcronIdFile.file e MigratedFile.file

Outras mudanças
- Remove de local.yml pgbouncer, desncessário para versão mais recente de postgres
- Remove algumas logging.info de migration, article, collection

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Executar as tarefas de migração, especialmente de artigos (task_migrate_and_publish_articles)

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a
