### PR TITLE
Corrige a passagem de parâmetros de upload_to_the_cloud para as páginas html de artigo

### DIFF
--- a/package/models.py
+++ b/package/models.py
@@ -763,13 +763,13 @@ class SPSPkg(CommonControlField, ClusterableModel):
                 else:
                     component = original_pkg_components.get(item) or {}
                     result = self.upload_to_the_cloud(
-                        user,
-                        item,
-                        ext,
-                        content,
-                        component.get("component_type") or "asset",
-                        component.get("lang"),
-                        component.get("legacy_uri"),
+                        user=user,
+                        filename=item,
+                        ext=ext,
+                        content=content,
+                        component_type=component.get("component_type") or "asset",
+                        lang=component.get("lang"),
+                        legacy_uri=component.get("legacy_uri"),
                     )
                     items.append(result)
         return {"xml_with_pre": xml_with_pre, "items": items}
@@ -843,8 +843,9 @@ class SPSPkg(CommonControlField, ClusterableModel):
                 content,
                 item["component_type"],
                 lang,
-                item.get("error"),
-                item.get("error_type"),
+                legacy_uri=None,
+                error=item.get("error"),
+                error_type=item.get("error_type"),
             )
             items.append(response)
         return {"items": items}


### PR DESCRIPTION
#### O que esse PR faz?
Corrige a passagem de parâmetros de upload_to_the_cloud para as páginas html de artigo

```
The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/app/package/models.py", line 273, in create_or_update
    obj.save()
  File "/usr/local/lib/python3.11/site-packages/django/db/models/base.py", line 822, in save
    self.save_base(
  File "/usr/local/lib/python3.11/site-packages/django/db/models/base.py", line 909, in save_base
    updated = self._save_table(
              ^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/db/models/base.py", line 1067, in _save_table
    results = self._do_insert(
              ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/db/models/base.py", line 1108, in _do_insert
    return manager._insert(
           ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/db/models/manager.py", line 87, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/db/models/query.py", line 1847, in _insert
    return query.get_compiler(using=using).execute_sql(returning_fields)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 1823, in execute_sql
    cursor.execute(sql, params)
  File "/usr/local/lib/python3.11/site-packages/django/db/backends/utils.py", line 79, in execute
    return self._execute_with_wrappers(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/db/backends/utils.py", line 92, in _execute_with_wrappers
    return executor(sql, params, many, context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/db/backends/utils.py", line 100, in _execute
    with self.db.wrap_database_errors:
  File "/usr/local/lib/python3.11/site-packages/django/db/utils.py", line 91, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/usr/local/lib/python3.11/site-packages/django/db/backends/utils.py", line 105, in _execute
    return self.cursor.execute(sql, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
django.db.utils.DataError: value too long for type character varying(120)


During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/app/package/models.py", line 510, in create_or_update
    obj.upload_package_to_the_cloud(user, original_pkg_components, article_proc)
  File "/app/package/models.py", line 676, in upload_package_to_the_cloud
    self.upload_items_to_the_cloud(
  File "/app/package/models.py", line 689, in upload_items_to_the_cloud
    response = callable_get_items(user, **params)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/package/models.py", line 839, in upload_article_page_to_the_cloud
    response = self.upload_to_the_cloud(
               ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/package/models.py", line 741, in upload_to_the_cloud
    SPSPkgComponent.create_or_update(
  File "/app/package/models.py", line 276, in create_or_update
    raise SPSPkgComponentCreateOrUpdateError(
package.models.SPSPkgComponentCreateOrUpdateError: Unable to create or update componentfile: None 1518-8787-rsp-56-9-en.html value too long for type character varying(120)
 <class 'django.db.utils.DataError'>
[2024-09-24 19:05:48,943: INFO/ForkPoolWorker-1] Task proc.tasks.task_migrate_and_publish_article[4ffb04e8-0d33-4460-a824-602dc228c8d5] succeeded in 1.2660860298201442s: None
```

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Executando a migração de artigos. Ocorre erro no momento de registrar o html no MinIO, mas pode ser devido a algum erro na geração do HTML 

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a
