### PR TITLE
Resolve problemas de html2xml body and back ausentes e caracteres especiais em referencias

### DIFF
--- a/article/wagtail_hooks.py
+++ b/article/wagtail_hooks.py
@@ -43,7 +43,6 @@ class ArticleModelAdmin(ModelAdmin):
         "pid_v3",
         "status",
         "display_sections",
-        "order",
         "fpage",
         "position",
         "first_publication_date",

--- a/proc/models.py
+++ b/proc/models.py
@@ -1423,6 +1423,9 @@ class ArticleProc(BaseProc, ClusterableModel):
                 self.migrated_data.file_type = self.migrated_data.document.file_type
                 self.migrated_data.save()
 
+            detail = {}
+            detail["file_type"] = self.migrated_data.file_type
+
             if self.migrated_data.file_type == "html":
                 migrated_data = self.migrated_data
                 classic_ws_doc = migrated_data.document
@@ -1433,17 +1436,19 @@ class ArticleProc(BaseProc, ClusterableModel):
                     record_types="|".join(classic_ws_doc.record_types or []),
                 )
                 htmlxml.html_to_xml(user, self, body_and_back_xml)
+                htmlxml.generate_report(user, self)
+                detail.update(htmlxml.data)
 
             xml = get_migrated_xml_with_pre(self)
-
             if xml:
                 self.xml_status = tracker_choices.PROGRESS_STATUS_DONE
+                detail.update(xml.data)
             else:
                 self.xml_status = tracker_choices.PROGRESS_STATUS_REPROC
             self.save()
 
             completed = self.xml_status == tracker_choices.PROGRESS_STATUS_DONE
-            operation.finish(user, completed=completed, detail=xml and xml.data)
+            operation.finish(user, completed=completed, detail=detail)
             return completed
         except Exception as e:
             exc_type, exc_value, exc_traceback = sys.exc_info()

--- a/proc/wagtail_hooks.py
+++ b/proc/wagtail_hooks.py
@@ -198,6 +198,7 @@ class ArticleProcModelAdmin(ModelAdmin):
     edit_view_class = ProcEditView
     list_per_page = 10
     list_display = (
+        "__str__",
         "pkg_name",
         "issue_proc",
         "xml_status",

--- a/publication/api/document.py
+++ b/publication/api/document.py
@@ -24,7 +24,7 @@ def publish_article(article_proc, api_data, journal_pid=None):
             raise ValueError(
                 "publication.api.document.publish_article requires journal_pid")
 
-    order = article_proc.article.order
+    order = article_proc.article.position
     pub_date = article_proc.article.first_publication_date or datetime.utcnow()
 
     build_article(builder, article_proc.article, journal_pid, order, pub_date)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -72,7 +72,7 @@ mongoengine==0.28.2
 aiohttp==3.9.1
 # DSM Migration
 # ------------------------------------------------------------------------------
--e git+https://github.com/scieloorg/scielo_migration.git@1.7.4#egg=scielo_classic_website
+-e git+https://github.com/scieloorg/scielo_migration.git@1.7.5#egg=scielo_classic_website
 python-dateutil==2.8.2
 tornado>=6.3.2 # not directly required, pinned by Snyk to avoid a vulnerability
 

--- a/tracker/choices.py
+++ b/tracker/choices.py
@@ -46,4 +46,4 @@ PROGRESS_STATUS_REGULAR_TODO = [
 
 
 def allowed_to_run(status, force_update):
-    return force_update and status in PROGRESS_STATUS_FORCE_UPDATE or status in PROGRESS_STATUS_TODO
+    return force_update and status in PROGRESS_STATUS_FORCE_UPDATE or status in PROGRESS_STATUS_REGULAR_TODO


### PR DESCRIPTION
#### O que esse PR faz?
Resolve defeito de o sistema não identificar registros com status de "reproc" ou "todo" para (re)processar.
Resolve problemas de html2xml body and back ausentes e caracteres especiais em referencias.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Selecionar um artigo que foi inserido no sistema como HTML, então precisa passar pela conversão de html para xml.
Alterando o status de algum ArticleProc para "to reprocess" e executar a tarefa de migração e publicação de artigos.
O  artigo selecionado como "to reprocess" deve ser reprocessado e observar que a lista de eventos foi incrementada com os eventos de html2xml.

#### Algum cenário de contexto que queira dar?
Para a identificação deste problema foi usado arquivos da coleção prt, acrônimo ri. 
https://github.com/scieloorg/scielo_migration/pull/69

### Screenshots
n/a

#### Quais são tickets relevantes?
Relacionado com https://github.com/scieloorg/scielo_migration/pull/69

### Referências
n/a
