### PR TITLE
Corrige defeito de geração de SPSPkg

### DIFF
--- a/package/models.py
+++ b/package/models.py
@@ -768,7 +768,7 @@ class SPSPkg(CommonControlField, ClusterableModel):
                 with TemporaryDirectory() as workdir:
                     zip_file_path = os.path.join(targetdir, filename)
                     package = SPPackage.from_file(zip_file_path, workdir)
-                    package.optimise(new_package_file_path=target, preserve_files=False)
+                    package.optimise(new_package_file_path=zip_file_path, preserve_files=False)
                     result = self.upload_components_to_the_cloud(user, original_pkg_components, zip_file_path)
             return result
         except Exception as e:

--- a/package/models.py
+++ b/package/models.py
@@ -513,7 +513,6 @@ class SPSPkg(CommonControlField, ClusterableModel):
             obj.upload_package_to_the_cloud(user, original_pkg_components, article_proc)
             obj.validate(True)
 
-            article_proc.update_sps_pkg_status()
             operation.finish(user, completed=obj.is_complete, detail=obj.data)
 
             return obj
@@ -635,7 +634,7 @@ class SPSPkg(CommonControlField, ClusterableModel):
             operation.finish(
                 user,
                 completed=True,
-                detail={"source": zip_file_path, "optimized": False},
+                detail={"source": zip_file_path, "saved": self.file.path},
             )
         except Exception as e:
             exc_type, exc_value, exc_traceback = sys.exc_info()
@@ -643,7 +642,7 @@ class SPSPkg(CommonControlField, ClusterableModel):
                 user,
                 exc_traceback=exc_traceback,
                 exception=e,
-                detail={"source": zip_file_path, "optimized": False},
+                detail={"source": zip_file_path, "saved": False},
             )
 
     def save_file(self, name, content):
@@ -761,20 +760,28 @@ class SPSPkg(CommonControlField, ClusterableModel):
         return response
 
     def upload_zip_content_to_the_cloud(self, user, original_pkg_components):
-        filename = self.sps_pkg_name + ".zip"
+        result = {}
         try:
-            result = {}
             with TemporaryDirectory() as targetdir:
                 with TemporaryDirectory() as workdir:
+                    filename = self.sps_pkg_name + ".zip"
                     zip_file_path = os.path.join(targetdir, filename)
-                    package = SPPackage.from_file(zip_file_path, workdir)
+                    package = SPPackage.from_file(self.file.path, workdir)
                     package.optimise(new_package_file_path=zip_file_path, preserve_files=False)
                     result = self.upload_components_to_the_cloud(user, original_pkg_components, zip_file_path)
-            return result
+                    detail = {"source": self.file.path, "zip_file_path": zip_file_path, "optimized": True}
         except Exception as e:
             zip_file_path = self.file.path
-            return self.upload_components_to_the_cloud(user, original_pkg_components, zip_file_path)
-
+            detail = {
+                "source": zip_file_path,
+                "zip_file_path": zip_file_path,
+                "optimized": False,
+                "message": str(e),
+                "error": str(type(e)),
+            }
+            result = self.upload_components_to_the_cloud(user, original_pkg_components, zip_file_path)
+        result.update(detail)
+        return result
 
     def upload_components_to_the_cloud(self, user, original_pkg_components, zip_file_path):
         xml_with_pre = None


### PR DESCRIPTION
#### O que esse PR faz?
Corrige defeito de geração de SPSPkg.
Havia duas causas diferentes
- variável target não declarada
- instrução `article_proc.update_sps_pkg_status()` aplicada em uma instância de SPSPkg não atualizada

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Ao tentar migrar um item novo ou mesmo reprocessamento, o procedimento não finalizava, e não havia registro explícito do problema

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a

