### PR TITLE
Realiza a importação de registros de artigos sem a dependência de dados de issue

### DIFF
--- a/migration/models.py
+++ b/migration/models.py
@@ -878,3 +878,10 @@ class IdFileRecord(CommonControlField, Orderable):
 
         logging.info(f"IdFileRecord.document_records_to_migrate {params}")
         return cls.objects.filter(item_type="article", **params)
+
+    @classmethod
+    def add_issue_folder(cls, issue_pid, issue_folder):
+        return cls.objects.filter(
+            Q(item_pid__startswith=f"S{issue_pid}") | Q(item_pid=issue_pid),
+            issue_folder__in=["", None]
+        ).update(issue_folder=issue_folder)

--- a/proc/models.py
+++ b/proc/models.py
@@ -1205,6 +1205,8 @@ class IssueProc(BaseProc, ClusterableModel):
         logging.info(f"Migrate documents from {resumption}")
         # registros novos ou atualizados
 
+        IdFileRecord.add_issue_folder(self.pid, self.issue_folder)
+
         params = dict(
             collection=self.journal_proc.collection,
             journal_acron=self.journal_proc.acron,
@@ -1217,7 +1219,7 @@ class IssueProc(BaseProc, ClusterableModel):
         for record in id_file_records:
             try:
                 logging.info(f"migrate_document_records: {record.item_pid}")
-                data = record.get_record_data(journal_data)
+                data = record.get_record_data(journal_data, issue_data=self.migrated_data.data)
                 article_proc = self.create_or_update_article_proc(
                     user, record.item_pid, data["data"], force_update
                 )

--- a/proc/wagtail_hooks.py
+++ b/proc/wagtail_hooks.py
@@ -107,6 +107,7 @@ class IssueProcModelAdmin(ModelAdmin):
         "issue__volume",
         "issue__number",
         "issue__supplement",
+        "pid",
     )
 
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -72,7 +72,7 @@ mongoengine==0.28.2
 aiohttp==3.9.1
 # DSM Migration
 # ------------------------------------------------------------------------------
--e git+https://github.com/scieloorg/scielo_migration.git@1.7.5#egg=scielo_classic_website
+-e git+https://github.com/scieloorg/scielo_migration.git@1.7.7#egg=scielo_classic_website
 python-dateutil==2.8.2
 tornado>=6.3.2 # not directly required, pinned by Snyk to avoid a vulnerability
 


### PR DESCRIPTION
#### O que esse PR faz?
Melhora importação de registros de artigos

#### Onde a revisão poderia começar?
Por commits

#### Como este poderia ser testado manualmente?
Executando a migração de dados do periódico aps de Portugal.
No momento que executa a tarefa migrate_and_publish_journals é coletado o conteúdo de aps.id contendo os registros dos artigos de aps.

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
Fix #590

### Referências
n/a
