### PR TITLE
Indica o status de verificação da presença nos sites

### DIFF
--- a/publication/tasks.py
+++ b/publication/tasks.py
@@ -541,9 +541,16 @@ def fetch_data_and_register_result(self, pid_v3, url, username, user_id):
         else:
             try:
                 obj = ScieloURLStatus.get(article=article, url=url)
-                obj.delete()
+                obj.available = True
+                obj.save()
             except ScieloURLStatus.DoesNotExist:
-                pass
+                ScieloURLStatus.create_or_update(
+                    article=article,
+                    url=url,
+                    check_date=datetime.now(),
+                    available=True,
+                    user=user,
+                )
     except Exception as e:
         exc_type, exc_value, exc_traceback = sys.exc_info()
         UnexpectedEvent.create(

--- a/publication/tests.py
+++ b/publication/tests.py
@@ -203,6 +203,8 @@ class ArticleAvailabilityTest(TestCase):
         scielo_url_status_last = ScieloURLStatus.objects.filter(available=False).last()
 
         self.assertEqual(ScieloURLStatus.objects.filter(available=False).count(), 2)
+        self.assertEqual(ScieloURLStatus.objects.filter(available=True).count(), 2)
+                
         self.assertEqual(scielo_url_status_first.available, False)
         self.assertEqual(scielo_url_status_last.available, False)
         self.assertEqual(
@@ -238,14 +240,10 @@ class ArticleAvailabilityTest(TestCase):
             )
         self.assertEqual(mock_fetch_data.call_count, 4)
 
-        scielo_url_status_first = ScieloURLStatus.objects.filter(
-            available=False
-        ).first()
-
         self.assertEqual(ScieloURLStatus.objects.filter(available=False).count(), 1)
-        self.assertEqual(scielo_url_status_first.available, False)
+        self.assertEqual(ScieloURLStatus.objects.filter(available=True).count(), 3)
         self.assertEqual(
-            scielo_url_status_first.url,
+            ScieloURLStatus.objects.get(available=False).url,
             f"{self.web_site_configuration_scl.url}/scielo.php?script=sci_arttext&pid={self.article.pid_v2}&lang=en&nrm=iso",
         )
 


### PR DESCRIPTION
#### O que esse PR faz?
Registra o status de verificação da presença nos sites no modelo ScieloURLStatus.

#### Onde a revisão poderia começar?
pelos commits

#### Como este poderia ser testado manualmente?
Executar a task initiate_article_availability_check e verificar na area administrativa o status do artigo no site

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
![image](https://github.com/user-attachments/assets/95d85303-bb32-49e6-abbf-5fb106346451)


#### Quais são tickets relevantes?
#603 

### Referências
N/A

