### PR TITLE
Muda bind_mount para volumes e mapea a pasta media

### DIFF
--- a/compose/production/django/Dockerfile
+++ b/compose/production/django/Dockerfile
@@ -87,12 +87,15 @@ COPY ./compose/production/django/celery/flower/start /start-flower
 RUN sed -i 's/\r$//g' /start-flower
 RUN chmod +x /start-flower
 
-
 # copy application code to WORKDIR
 COPY --chown=django:django . ${APP_HOME}
 
 # make django owner of the WORKDIR directory as well.
 RUN chown -R django:django ${APP_HOME}
+
+RUN mkdir -p ${APP_HOME}/core/media \
+    && chown -R django:django ${APP_HOME}/core/media \
+    && chmod -R 775 ${APP_HOME}/core/media
 
 USER django
 

--- a/production.yml
+++ b/production.yml
@@ -13,7 +13,7 @@ services:
       - ./.envs/.production/.postgres
     volumes:
       - ../scielo/www:/scielo_www
-      - ./core/media:/app/core/media
+      - upload_media:/app/core/media
     ports:
       - "8000:8000"
     command: /start
@@ -61,3 +61,8 @@ services:
     container_name: upload_production_flower
     command: /start-flower
     ports: []
+
+
+volumes:
+  upload_media:
+    name: upload_media


### PR DESCRIPTION
#### O que esse PR faz?
- No serviço do django, realiza a mudança de bind_mount para volume gerenciado pelo docker. Mapea a pasta /app/core/media para o volume.
- Atribui permissoes do grupo django a pasta media.

#### Onde a revisão poderia começar?
pelos commits

#### Como este poderia ser testado manualmente?
1. docker compose down
2. docker compose up

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A

