### PR TITLE
Corrige momento de atribuição de Article.first_publication_date

### DIFF
--- a/article/models.py
+++ b/article/models.py
@@ -326,10 +326,9 @@ class Article(ClusterableModel, CommonControlField):
             TocSection.create_or_update(user, toc, group, section)
 
     def add_article_publication_date(self):
-        if self.sps_pkg.xml_with_pre.article_publication_date:
-            self.first_publication_date = datetime.strptime(
-                self.sps_pkg.xml_with_pre.article_publication_date, "%Y-%m-%d"
-            )
+        if self.sps_pkg.is_public:
+            self.first_publication_date = self.sps_pkg.pub_date
+            self.save()
 
     def add_position(self, position=None, fpage=None):
         try:

--- a/package/models.py
+++ b/package/models.py
@@ -916,3 +916,10 @@ class SPSPkg(CommonControlField, ClusterableModel):
             d["content"] = fp.read()
         d["filename"] = self.sps_pkg_name + ".zip"
         return d
+
+    @property
+    def pub_date(self):
+        try:
+            return datetime.fromisoformat(self.xml_with_pre.article_publication_date)
+        except Exception as e:
+            logging.exception(e)

--- a/publication/api/document.py
+++ b/publication/api/document.py
@@ -26,7 +26,7 @@ def publish_article(article_proc, api_data, journal_pid=None, is_public=True):
             )
 
     order = article_proc.article.position
-    pub_date = article_proc.article.first_publication_date or datetime.utcnow()
+    pub_date = article_proc.sps_pkg.pub_date
 
     build_article(builder, article_proc.article, journal_pid, order, pub_date, is_public)
 

--- a/upload/models.py
+++ b/upload/models.py
@@ -1165,6 +1165,8 @@ class Package(CommonControlField, ClusterableModel):
                 self.public_ws_pubdate = datetime.utcnow()
                 self.status = choices.PS_PUBLISHED
                 self.save()
+                self.article.sps_pkg.is_public = True
+                self.article.add_article_publication_date()
                 self.article.update_status(new_status=article_choices.AS_PUBLISHED)
 
     @property


### PR DESCRIPTION
#### O que esse PR faz?
Na migração, é possível a qualquer momento instanciar Article.first_publication_date, pois o artigo já está publicado.
No entanto, no caso da alimentação direta, considerar atualizar Article.first_publication_date somente se publicado no site público.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Subir um pacote válido.
Após ser publicado com sucesso o valor de `Article.first_publication_date` deve ser correspondente ao encontrado no XML.
Em caso de falha, o valor de `Article.first_publication_date` deve ser `None`

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a

