### PR TITLE
Corrige a ausência de parâmetro de JournalAcronIdFile.has_changes ao executar a migração de journal. Este erro impede a importação dos dados de bases-work/acron/acron.id

### DIFF
--- a/core/templates/wagtailadmin/base.html
+++ b/core/templates/wagtailadmin/base.html
@@ -12,5 +12,5 @@
     {% else %}
             <img src="{% static 'images/logos/logo_scielo_negative100x100.png' %}" alt="SciELO logo"/>
     {% endif %}
-    <br/>Upload v2.7.7
+    <br/>Upload v2.7.8
 {% endblock %}

--- a/migration/controller.py
+++ b/migration/controller.py
@@ -927,7 +927,7 @@ def register_acron_id_file_content(
                 user, completed=False, message=_(f"{source_path} does not exist")
             )
         elif JournalAcronIdFile.has_changes(
-            user, collection, source_path, force_update
+            user, collection, journal_acron, source_path, force_update
         ):
             start = datetime.utcnow().isoformat()
             journal_id_file = JournalAcronIdFile.create_or_update(


### PR DESCRIPTION
#### O que esse PR faz?
Corrige a ausência de parâmetro de JournalAcronIdFile.has_changes ao executar a migração de journal. Este erro impede a importação dos dados de bases-work/acron/acron.id e, por consequência, impediu a migração de artigos

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Executar a tarefa de migração de journal com `force_update: true, "force_import_acron_id_file": true`
Executar a tarefa de migração de issue com `force_update: true, "force_migrate_document_records": true`
Executar a tarefa de migração de article

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a

