### PR TITLE
Adiciona capacidade de filtrar por status os items a serem migrados (journal, issue, article)

### DIFF
--- a/bigbang/tasks_scheduler.py
+++ b/bigbang/tasks_scheduler.py
@@ -76,6 +76,8 @@ def delete_migration_tasks():
             "migrate_title_databases",
             "task_migrate_document_files",
             "task_migrate_document_records",
+            "migrate_and_publish",
+            "create_procs_from_pid_list"
         ]
     )
 
@@ -85,8 +87,8 @@ def schedule_migration_subtasks(username):
     _schedule_migrate_and_publish_articles(username, enabled)
     _schedule_migrate_and_publish_issues(username, enabled)
     _schedule_migrate_and_publish_journals(username, enabled)
-    _schedule_migration_and_publication(username, enabled)
-    _schedule_create_procs_from_pid_list(username, enabled)
+    # _schedule_migration_and_publication(username, enabled)
+    # _schedule_create_procs_from_pid_list(username, enabled)
 
 
 def schedule_publication_subtasks(username):
@@ -154,10 +156,11 @@ def _schedule_migrate_and_publish_journals(username, enabled):
         task="proc.tasks.task_migrate_and_publish_journals",
         name="migrate_and_publish_journals",
         kwargs=dict(
-            username=None,
+            username=username,
             collection_acron=None,
             journal_acron=None,
             force_update=False,
+            status=["REPROC", "TODO", "DOING", "DONE", "PENDING", "BLOCKED"],
             force_import_acron_id_file=False,
         ),
         description=_("Migra e publica os periódicos"),
@@ -184,6 +187,7 @@ def _schedule_migrate_and_publish_issues(username, enabled):
             journal_acron=None,
             publication_year=None,
             issue_folder=None,
+            status=["REPROC", "TODO", "DOING", "DONE", "PENDING", "BLOCKED"],
             force_update=False,
             force_migrate_document_records=False,
         ),
@@ -207,6 +211,7 @@ def _schedule_migrate_and_publish_articles(username, enabled):
             journal_acron=None,
             publication_year=None,
             issue_folder=None,
+            status=["REPROC", "TODO", "DOING", "DONE", "PENDING", "BLOCKED"],
             force_update=False,
         ),
         description=_("Migra e publica artigos"),

--- a/tracker/choices.py
+++ b/tracker/choices.py
@@ -44,6 +44,21 @@ PROGRESS_STATUS_REGULAR_TODO = [
     PROGRESS_STATUS_TODO,
 ]
 
+VALID_STATUS = PROGRESS_STATUS_FORCE_UPDATE + [PROGRESS_STATUS_DOING]
+
+
+def get_valid_status(status, force_update):
+    if status: 
+        if isinstance(status, str):
+            status = [status]
+        if isinstance(status, list):
+            return list(set(status) & set(VALID_STATUS)) or list(VALID_STATUS)
+    if force_update:
+        return PROGRESS_STATUS_FORCE_UPDATE
+    return PROGRESS_STATUS_REGULAR_TODO
+
 
 def allowed_to_run(status, force_update):
+    if force_update and status == PROGRESS_STATUS_DOING:
+        return True
     return force_update and status in PROGRESS_STATUS_FORCE_UPDATE or status in PROGRESS_STATUS_REGULAR_TODO


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona capacidade de filtrar por status os items a serem migrados (journal, issue, article)
Adiciona registro de evento (create_or_update_journal, create or update issue)
Evita publicar se o website em questão não está configurado

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?

**NOTA**: _Antes de tudo, execute a tarefa start que cria as tarefas. Com isso, será automaticamente adicionado o parâmetro status com os valores aceitáveis._

Edite as tarefas e verifique que o parâmetro status foi adicionado. 
O valor pode ser null, ou str. Caso não seja válido, o sistema deve usar os valores padrão.
Execute as tarefas de migração.

Em Journal processing e Issue processing verifique em Eventos que está registrado respectivamente create or update journal, create or update issue.

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a
