### PR TITLE
Aprimora a criação de Issue.pid e aprimora a criação de IssueProc

### DIFF
--- a/issue/models.py
+++ b/issue/models.py
@@ -26,8 +26,7 @@ def _get_digits(value):
         return 0
 
 
-class IssueGetOrCreateError(Exception):
-    ...
+class IssueGetOrCreateError(Exception): ...
 
 
 class Issue(CommonControlField, IssuePublicationDate):

--- a/issue/models.py
+++ b/issue/models.py
@@ -162,9 +162,7 @@ class Issue(CommonControlField, IssuePublicationDate):
             obj.number = number
             obj.publication_year = publication_year
             obj.order = order or obj.generate_order()
-            obj.issue_pid_suffix = issue_pid_suffix or str(obj.generate_order()).zfill(
-                4
-            )
+            obj.issue_pid_suffix = issue_pid_suffix or obj.generate_issue_pid_suffix()
             obj.is_continuous_publishing_model = is_continuous_publishing_model
             obj.total_documents = total_documents
             obj.creator = user
@@ -210,9 +208,11 @@ class Issue(CommonControlField, IssuePublicationDate):
             obj.total_documents = total_documents or obj.total_documents
             obj.publication_year = publication_year or obj.publication_year
             obj.order = order or obj.order or obj.generate_order()
-            obj.issue_pid_suffix = issue_pid_suffix or obj.issue_pid_suffix
-            if not obj.issue_pid_suffix and obj.order:
-                obj.issue_pid_suffix = str(obj.order).zfill(4)
+            obj.issue_pid_suffix = (
+                issue_pid_suffix
+                or obj.issue_pid_suffix
+                or obj.generate_issue_pid_suffix()
+            )
             obj.updated_by = user
             obj.save()
             return obj
@@ -229,6 +229,9 @@ class Issue(CommonControlField, IssuePublicationDate):
                 order,
                 issue_pid_suffix,
             )
+
+    def generate_issue_pid_suffix(self):
+        return str(self.generate_order()).zfill(4)
 
     def generate_order(self, suppl_start=1000, spe_start=2000):
         x = 0

--- a/proc/controller.py
+++ b/proc/controller.py
@@ -539,9 +539,7 @@ def create_or_update_journal_acron_id_file(
         )
 
 
-def migrate_issue(
-    user, issue_proc, force_update
-):
+def migrate_issue(user, issue_proc, force_update):
     try:
         event = None
         detail = None
@@ -603,7 +601,9 @@ def migrate_document_records(
     if publication_year:
         params["issue__publication_year"] = str(publication_year)
     if status:
-        params["docs_status__in"] = tracker_choices.get_valid_status(status, force_update)
+        params["docs_status__in"] = tracker_choices.get_valid_status(
+            status, force_update
+        )
 
     for issue_proc in IssueProc.objects.filter(**params):
         issue_proc.migrate_document_records(user, force_update)
@@ -628,7 +628,9 @@ def get_files_from_classic_website(
     if publication_year:
         params["issue__publication_year"] = str(publication_year)
     if status:
-        params["files_status__in"] = tracker_choices.get_valid_status(status, force_update)
+        params["files_status__in"] = tracker_choices.get_valid_status(
+            status, force_update
+        )
 
     for issue_proc in IssueProc.objects.filter(**params):
         issue_proc.get_files_from_classic_website(

--- a/proc/controller.py
+++ b/proc/controller.py
@@ -303,15 +303,11 @@ def fetch_and_create_issues(journal, pub_year, volume, suppl, number, user):
                         collection=journal_proc.collection, issue=issue
                     )
                 except IssueProc.DoesNotExist:
-                    issue_pid_suffix = str(issue.order).zfill(4)
-                    issue_proc = IssueProc.get_or_create(
+                    issue_proc = IssueProc.create_from_journal_proc_and_issue(
                         user,
-                        journal_proc.collection,
-                        pid=f"{journal_proc.pid}{issue.publication_year}{issue_pid_suffix}",
+                        journal_proc,
+                        issue,
                     )
-                    issue_proc.issue = issue
-                    issue_proc.journal_proc = journal_proc
-                    issue_proc.save()
 
 
 def create_or_update_migrated_journal(

--- a/proc/models.py
+++ b/proc/models.py
@@ -1244,14 +1244,14 @@ class IssueProc(BaseProc, ClusterableModel):
             errors = 0
             journal_data = self.journal_proc.migrated_data.data
             resumption = None if force_update else self.resumption_date
-            
+
             params = dict(
                 collection=self.journal_proc.collection,
                 issue_pid=self.pid,
-                resumption=resumption
+                resumption=resumption,
             )
             logging.info(f"Migrate documents {params}")
-            
+
             # registros novos ou atualizados
             id_file_records = IdFileRecord.document_records_to_migrate(**params)
             resumption_date = resumption
@@ -1275,8 +1275,12 @@ class IssueProc(BaseProc, ClusterableModel):
                     exc_type, exc_value, exc_traceback = sys.exc_info()
                     subevent = self.start(user, "migrate documet records / item")
                     subevent.finish(
-                        user, completed=False, detail=detail,
-                        exception=e, exc_traceback=exc_traceback)
+                        user,
+                        completed=False,
+                        detail=detail,
+                        exception=e,
+                        exc_traceback=exc_traceback,
+                    )
 
             self.resumption_date = resumption_date
             self.save()
@@ -1303,10 +1307,7 @@ class IssueProc(BaseProc, ClusterableModel):
             self.docs_status = tracker_choices.PROGRESS_STATUS_REPROC
             self.save()
             operation.finish(
-                user,
-                exc_traceback=exc_traceback,
-                exception=e,
-                detail=detail or params
+                user, exc_traceback=exc_traceback, exception=e, detail=detail or params
             )
 
     def create_or_update_article_proc(self, user, pid, data, force_update):
@@ -1340,20 +1341,13 @@ class IssueProc(BaseProc, ClusterableModel):
                 main_lang=document.original_language,
                 force_update=force_update,
             )
-            event.finish(
-                user,
-                completed=True,
-                detail=str(article_proc)
-            )
+            event.finish(user, completed=True, detail=str(article_proc))
         except Exception as e:
             exc_type, exc_value, exc_traceback = sys.exc_info()
             self.docs_status = tracker_choices.PROGRESS_STATUS_REPROC
             self.save()
             event.finish(
-                user,
-                exc_traceback=exc_traceback,
-                exception=e,
-                detail=detail or params
+                user, exc_traceback=exc_traceback, exception=e, detail=detail or params
             )
         return article_proc
 

--- a/proc/models.py
+++ b/proc/models.py
@@ -409,7 +409,7 @@ class BaseProc(CommonControlField):
         raise ValueError("BaseProc.get requires collection and pid")
 
     @classmethod
-    def get_or_create(cls, user, collection, pid):
+    def get_or_create(cls, user, collection, pid, **kwargs):
         if collection and pid:
             try:
                 return cls.get(collection, pid)
@@ -1003,6 +1003,19 @@ class IssueProc(BaseProc, ClusterableModel):
             ObjectList(panel_proc_result, heading=_("Events")),
         ]
     )
+
+    @staticmethod
+    def create_from_journal_proc_and_issue(user, journal_proc, issue):
+        issue_pid_suffix = issue.issue_pid_suffix
+        issue_proc = IssueProc.get_or_create(
+            user,
+            journal_proc.collection,
+            pid=f"{journal_proc.pid}{issue.publication_year}{issue_pid_suffix}",
+        )
+        issue_proc.issue = issue
+        issue_proc.journal_proc = journal_proc
+        issue_proc.save()
+        return issue_proc
 
     def set_status(self):
         if self.migration_status == tracker_choices.PROGRESS_STATUS_REPROC:


### PR DESCRIPTION
#### O que esse PR faz?
Aprimora a criação de Issue.pid e aprimora a criação de IssueProc.
Desvincula o Issue.pid de Issue.order. Issue.pid deve ser fixo e Issue.order pode ser editável. Inicialmente ambos podem ter o mesmo valor.
IssueProc pode ser criado com dados registrados em core.scielo.org/api/v1/issue.
São funcionalidade em uso na alimentação direta. Este PR é para manter a compatibilidade com o branch rc.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Executando o fluxo de alimentação direta

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a
