### PR TITLE
Corrige pid v2 no core caso esteja divergente com o pid v2 esperado por defeito na migração

### DIFF
--- a/pid_provider/client.py
+++ b/pid_provider/client.py
@@ -166,7 +166,11 @@ class PidProviderAPIClient:
         except Exception as e:
             previous_data = (self.pid_provider_api_get_token, username, password)
             self.reset()
-            current_data = (self.pid_provider_api_get_token, self.api_username, self.api_password)
+            current_data = (
+                self.pid_provider_api_get_token,
+                self.api_username,
+                self.api_password,
+            )
             if current_data != previous_data:
                 return self._get_token(
                     username=self.api_username,
@@ -274,9 +278,7 @@ class PidProviderAPIClient:
             try:
                 self._process_item_response(item, xml_with_pre, created)
             except AttributeError:
-                raise ValueError(
-                    f"Unexpected pid provider response: {response}"
-                )
+                raise ValueError(f"Unexpected pid provider response: {response}")
 
     def _process_item_response(self, item, xml_with_pre, created=None):
         logging.info(f"Pid Provider Response: {item}")


### PR DESCRIPTION
#### O que esse PR faz?
Corrige pid v2 no core caso esteja divergente com o pid v2 esperado por defeito na migração

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Executando a migração de artigos

Antes
No core
```
1518-8787-rsp-38-02-323
S0034-89102004000200024
vd6B3csGMk7G6WJWH66MJ9h
...
1518-8787-rsp-38-02-323
S1518-87872004112041636
NMqKncbNfJGK3pphdggRnds
...
1518-8787-rsp-38-02-326
S0034-89102004000200025
k86R3yCRLGxYjWpgFRQX5sK
...
1518-8787-rsp-38-02-326
S1518-87872004112041635
b4yFzYDZHVGyfmgSHxG4NSD
```

Depois no core
```
1518-8787-rsp-38-02-323
S0034-89102004000200024
vd6B3csGMk7G6WJWH66MJ9h
...
1518-8787-rsp-38-02-323
S0034-89102004000200024
NMqKncbNfJGK3pphdggRnds
...
1518-8787-rsp-38-02-326
S0034-89102004000200025
k86R3yCRLGxYjWpgFRQX5sK
...
1518-8787-rsp-38-02-326
S0034-89102004000200025
b4yFzYDZHVGyfmgSHxG4NSD
```

Antes no local

```
1518-8787-rsp-38-02-323
pid S1518-87872004112041636, v3: NMqKncbNfJGK3pphdggRnds
(1, <ArticleProc: 1518-8787-rsp-38-02-323>, 'S0034-89102004000200024', 'NMqKncbNfJGK3pphdggRnds', 'NMqKncbNfJGK3pphdggRnds', 'S1518-87872004112041636')
...
1518-8787-rsp-38-02-326
pid S1518-87872004112041635, v3: b4yFzYDZHVGyfmgSHxG4NSD
(2, <ArticleProc: 1518-8787-rsp-38-02-326>, 'S0034-89102004000200025', 'b4yFzYDZHVGyfmgSHxG4NSD', 'b4yFzYDZHVGyfmgSHxG4NSD', 'S1518-87872004112041635')
...
1518-8787-rsp-38-02-329
pid S0034-89102004000200026, v3: xGmyBc6t4Yy8qn5j7twCtns
(3, <ArticleProc: 1518-8787-rsp-38-02-329>, 'S0034-89102004000200026', 'xGmyBc6t4Yy8qn5j7twCtns', 'xGmyBc6t4Yy8qn5j7twCtns', 'S0034-89102004000200026')
```

Depois no local
```
1518-8787-rsp-38-02-323
pid S0034-89102004000200024, v3: NMqKncbNfJGK3pphdggRnds
(1, <ArticleProc: 1518-8787-rsp-38-02-323>, 'S0034-89102004000200024', 'NMqKncbNfJGK3pphdggRnds', 'NMqKncbNfJGK3pphdggRnds', 'S0034-89102004000200024')
...
1518-8787-rsp-38-02-326
pid S0034-89102004000200025, v3: b4yFzYDZHVGyfmgSHxG4NSD
(2, <ArticleProc: 1518-8787-rsp-38-02-326>, 'S0034-89102004000200025', 'b4yFzYDZHVGyfmgSHxG4NSD', 'b4yFzYDZHVGyfmgSHxG4NSD', 'S0034-89102004000200025')
...
1518-8787-rsp-38-02-329
pid S0034-89102004000200026, v3: xGmyBc6t4Yy8qn5j7twCtns
(3, <ArticleProc: 1518-8787-rsp-38-02-329>, 'S0034-89102004000200026', 'xGmyBc6t4Yy8qn5j7twCtns', 'xGmyBc6t4Yy8qn5j7twCtns', 'S0034-89102004000200026')
```
#### Algum cenário de contexto que queira dar?
Bug foi causado pela geração aleatória do pid_v2 sendo que o ideal era ter obtido pelo article_proc.pid em versões anteriores do upload

### Screenshots
n/a

#### Quais são tickets relevantes?
Foi identificado o problema no core.
https://github.com/scieloorg/core/issues/986

### Referências
n/a
