### PR TITLE
Corrige acesso ao issnl inexistente

### DIFF
--- a/proc/source_core_api.py
+++ b/proc/source_core_api.py
@@ -212,11 +212,11 @@ def process_journal_result(user, result, block_unregistered_collection, force_up
     # Processa dados oficiais do journal
     official = result["official"]
     official_journal = OfficialJournal.create_or_update(
-        title=official["title"],
-        title_iso=official["iso_short_title"],
-        issn_print=official["issn_print"],
-        issn_electronic=official["issn_electronic"],
-        issnl=official["issnl"],
+        title=official.get("title"),
+        title_iso=official.get("iso_short_title"),
+        issn_print=official.get("issn_print"),
+        issn_electronic=official.get("issn_electronic"),
+        issnl=official.get("issnl"),
         foundation_year=official.get("foundation_year"),
         user=user,
     )


### PR DESCRIPTION
#### O que esse PR faz?
Erro ao executar o  migrate_and_publish_journal de todos os periódicos de SPA

```
Exception Type
    <class 'KeyError'>
Exception Msg
    'issnl'
traceback
    [' File "/app/proc/source_core_api.py", line 141, in fetch_and_create_journal\n process_journal_result(\n', ' File "/app/proc/source_core_api.py", line 219, in process_journal_result\n issnl=official["issnl"],\n ~~~~~~~~^^^^^^^^^\n']
```

#### Onde a revisão poderia começar?
por commit

#### Como este poderia ser testado manualmente?
executar o  migrate_and_publish_journal de todos os periódicos

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a

