### PR TITLE
Aprimora migrate document records

### DIFF
--- a/bigbang/tasks_scheduler.py
+++ b/bigbang/tasks_scheduler.py
@@ -253,6 +253,7 @@ def _schedule_migrate_and_publish_articles(username, enabled):
             force_import_acron_id_file=False,
             force_migrate_document_records=False,
             force_migrate_document_files=False,
+            skip_migrate_pending_document_records=False,
         ),
         description=_("Migra e publica artigos"),
         priority=ARTICLE_DB_MIGRATION_PRIORITY,

--- a/migration/models.py
+++ b/migration/models.py
@@ -26,16 +26,13 @@ def now():
     return datetime.utcnow().isoformat().replace(":", "-").replace(".", "-")
 
 
-class MigratedFileCreateOrUpdateError(Exception):
-    ...
+class MigratedFileCreateOrUpdateError(Exception): ...
 
 
-class MigratedDocumentHTMLForbiddenError(Exception):
-    ...
+class MigratedDocumentHTMLForbiddenError(Exception): ...
 
 
-class MigrationError(Exception):
-    ...
+class MigrationError(Exception): ...
 
 
 def modified_date(file_path):
@@ -112,7 +109,9 @@ class ClassicWebsiteConfiguration(CommonControlField):
         max_length=255,
         null=True,
         blank=True,
-        help_text=_("Path of a text file which contains all the article PIDs from artigo.mst"),
+        help_text=_(
+            "Path of a text file which contains all the article PIDs from artigo.mst"
+        ),
     )
     alternative_htdocs_img_revistas_path = models.JSONField(null=True, blank=True)
 
@@ -311,6 +310,7 @@ def extract_relative_path(full_path):
             return str(Path(*parts[i:]))
     return None
 
+
 def migrated_files_directory_path(instance, filename):
     # file will be uploaded to MEDIA_ROOT/user_<id>/<filename>
 
@@ -320,7 +320,7 @@ def migrated_files_directory_path(instance, filename):
         path = instance.source_path
 
     path_relative = extract_relative_path(path)
-    
+
     try:
         return f"classic_website/{instance.collection.acron}/{path_relative}"
     except (AttributeError, TypeError) as e:
@@ -335,15 +335,21 @@ class MigratedFile(CommonControlField):
         upload_to=migrated_files_directory_path, null=True, blank=True
     )
     # bases/pdf/acron/volnum/pt_a01.pdf
-    original_path = models.CharField(_("Original Path"), max_length=200, null=True, blank=True)
+    original_path = models.CharField(
+        _("Original Path"), max_length=200, null=True, blank=True
+    )
 
     # pt_a01.pdf
-    original_name = models.CharField(_("Original name"), max_length=100, null=True, blank=True)
+    original_name = models.CharField(
+        _("Original name"), max_length=100, null=True, blank=True
+    )
 
     file_date = models.DateField(null=True, blank=True)
 
     # /pdf/acron/volnum/pt_a01.pdf
-    original_href = models.CharField(_("Original href"), max_length=150, null=True, blank=True)
+    original_href = models.CharField(
+        _("Original href"), max_length=150, null=True, blank=True
+    )
 
     component_type = models.CharField(
         _("Component type"), max_length=16, null=True, blank=True
@@ -384,7 +390,9 @@ class MigratedFile(CommonControlField):
         if not force_update:
             try:
                 file_date = modified_date(file_path)
-                if cls.objects.filter(collection=collection, original_path=file_path, file_date=file_date).exists():
+                if cls.objects.filter(
+                    collection=collection, original_path=file_path, file_date=file_date
+                ).exists():
                     return False
             except cls.DoesNotExist:
                 pass
@@ -634,7 +642,9 @@ class JournalAcronIdFile(CommonControlField, ClusterableModel):
         if not force_update:
             try:
                 file_size = JournalAcronIdFile.get_file_size(file_path)
-                if cls.objects.filter(collection=collection, source_path=file_path, file_size=file_size).exists():
+                if cls.objects.filter(
+                    collection=collection, source_path=file_path, file_size=file_size
+                ).exists():
                     return False
             except cls.DoesNotExist:
                 pass
@@ -851,7 +861,7 @@ class IdFileRecord(CommonControlField, Orderable):
                     "item_pid": item_pid,
                     "data": data,
                 },
-            )            
+            )
 
     @classmethod
     def create_or_update(

--- a/migration/models.py
+++ b/migration/models.py
@@ -938,14 +938,14 @@ class IdFileRecord(CommonControlField, Orderable):
         }
 
     @classmethod
-    def document_records_to_migrate(cls, collection, issue_pid, todo):
+    def document_records_to_migrate(cls, collection, issue_pid, force_update):
         params = {}
         if collection:
             params["parent__collection"] = collection
         if issue_pid:
             params["item_pid__startswith"] = f"S{issue_pid}"
-        if todo:
-            params["todo"] = todo
+        if not force_update:
+            params["todo"] = True
 
         logging.info(f"IdFileRecord.document_records_to_migrate {params}")
         return cls.objects.filter(item_type="article", **params)

--- a/proc/models.py
+++ b/proc/models.py
@@ -74,7 +74,7 @@ class Operation(CommonControlField):
         FieldPanel("created", read_only=True),
         FieldPanel("updated", read_only=True),
         FieldPanel("completed", read_only=True),
-        FieldPanel('detail', read_only=True)
+        FieldPanel("detail", read_only=True),
     ]
 
     class Meta:
@@ -696,7 +696,9 @@ class BaseProc(CommonControlField):
             }
             resp = {}
             operation = None
-            operation = self.start(user, f"publish {content_type} {self} on {website_kind}")
+            operation = self.start(
+                user, f"publish {content_type} {self} on {website_kind}"
+            )
 
             if not content_type:
                 try:
@@ -735,7 +737,9 @@ class BaseProc(CommonControlField):
                 self.public_ws_status = tracker_choices.PROGRESS_STATUS_DOING
             self.save()
 
-            api_data = api_data or get_api_data(self.collection, content_type, website_kind)
+            api_data = api_data or get_api_data(
+                self.collection, content_type, website_kind
+            )
             logging.info(api_data)
             if api_data.get("error"):
                 resp.update(api_data)
@@ -1049,16 +1053,15 @@ class IssueProc(BaseProc, ClusterableModel):
         if collection_acron:
             params["collection__acron"] = collection_acron
 
-        issue_status = tracker_choices.PROGRESS_STATUS_RETRY + tracker_choices.PROGRESS_STATUS_REGULAR_TODO
+        issue_status = (
+            tracker_choices.PROGRESS_STATUS_RETRY
+            + tracker_choices.PROGRESS_STATUS_REGULAR_TODO
+        )
         articles = ArticleProc.objects.filter(
-            Q(xml_status__in=issue_status) |
-            Q(sps_pkg_status__in=issue_status),
+            Q(xml_status__in=issue_status) | Q(sps_pkg_status__in=issue_status),
             **params,
         )
-        article_pids = [
-            item.pid
-            for item in articles
-        ]
+        article_pids = [item.pid for item in articles]
 
         q = IdFileRecord.objects.filter(item_type="article", todo=True).count()
         logging.info(f"IdFileRecord.todo: {q}")
@@ -1067,7 +1070,7 @@ class IssueProc(BaseProc, ClusterableModel):
 
         q = IdFileRecord.objects.filter(item_type="article", todo=True).count()
         logging.info(f"IdFileRecord.todo: {q}")
-        
+
         for item in IdFileRecord.objects.filter(item_type="article", todo=False):
             if not ArticleProc.objects.filter(pid=item.item_pid).exists():
                 item.todo = True
@@ -1076,10 +1079,16 @@ class IssueProc(BaseProc, ClusterableModel):
         q = IdFileRecord.objects.filter(item_type="article", todo=True).count()
         logging.info(f"IdFileRecord.todo: {q}")
 
-        issue_pids = list(set([
-            item["item_pid"][1:18]
-            for item in IdFileRecord.objects.filter(item_type="article", todo=True).values("item_pid")
-        ]))
+        issue_pids = list(
+            set(
+                [
+                    item["item_pid"][1:18]
+                    for item in IdFileRecord.objects.filter(
+                        item_type="article", todo=True
+                    ).values("item_pid")
+                ]
+            )
+        )
         IssueProc.objects.filter(
             pid__in=issue_pids,
         ).update(
@@ -1463,7 +1472,7 @@ class IssueProc(BaseProc, ClusterableModel):
                 article.delete()
             except PidProviderXML.MultipleObjectsReturned:
                 pass
-            
+
 
 class ArticleEventCreateError(Exception): ...
 
@@ -1480,7 +1489,9 @@ class ArticleProc(BaseProc, ClusterableModel):
     issue_proc = models.ForeignKey(
         IssueProc, on_delete=models.SET_NULL, null=True, blank=True
     )
-    pkg_name = models.CharField(_("Package name"), max_length=100, null=True, blank=True)
+    pkg_name = models.CharField(
+        _("Package name"), max_length=100, null=True, blank=True
+    )
     main_lang = models.CharField(
         _("Main lang"),
         max_length=2,

--- a/proc/source_classic_website.py
+++ b/proc/source_classic_website.py
@@ -29,7 +29,7 @@ def create_or_update_migrated_journal(
     if not has_changes:
         logging.info(f"skip reading {classic_website.classic_website_paths.title_path}")
         return
-    
+
     for (
         scielo_issn,
         journal_data,
@@ -81,7 +81,7 @@ def create_or_update_migrated_issue(
     if not has_changes:
         logging.info(f"skip reading {classic_website.classic_website_paths.issue_path}")
         return
-    
+
     for (
         pid,
         issue_data,
@@ -145,7 +145,7 @@ def create_collection_procs_from_pid_list(
             pid = pid.strip() or ""
             if not len(pid) == 23:
                 continue
-            
+
             # Registra PID do artigo
             ArticleProc.register_pid(
                 user,
@@ -153,7 +153,7 @@ def create_collection_procs_from_pid_list(
                 pid,
                 force_update=False,
             )
-            
+
             # Extrai e registra PID do issue
             issue_pid = pid[1:-5]
             if issue_pid not in issue_pids:
@@ -315,7 +315,7 @@ def migrate_document_records(
     """
     Executa a migração de registros de documentos do site clássico.
     """
-    
+
     # IssueProc.set_items_to_process(collection_acron)
 
     params = {}

--- a/proc/source_classic_website.py
+++ b/proc/source_classic_website.py
@@ -329,7 +329,10 @@ def migrate_document_records(
             status, force_update
         )
 
-    for issue_proc in IssueProc.objects.filter(**params):
+    for issue_proc in IssueProc.objects.select_related(
+        "collection", "journal_proc", "issue", "migrated_data",
+        "journal_proc__migrated_data"
+    ).filter(**params):
         issue_proc.migrate_document_records(user, force_update)
 
     IssueProc.migrate_pending_document_records(

--- a/proc/source_classic_website.py
+++ b/proc/source_classic_website.py
@@ -311,6 +311,7 @@ def migrate_document_records(
     publication_year=None,
     status=None,
     force_update=None,
+    skip_migrate_pending_document_records=None,
 ):
     """
     Executa a migração de registros de documentos do site clássico.
@@ -334,6 +335,9 @@ def migrate_document_records(
         "journal_proc__migrated_data"
     ).filter(**params):
         issue_proc.migrate_document_records(user, force_update)
+
+    if skip_migrate_pending_document_records:
+        return
 
     IssueProc.migrate_pending_document_records(
         user,

--- a/proc/source_classic_website.py
+++ b/proc/source_classic_website.py
@@ -315,9 +315,6 @@ def migrate_document_records(
     """
     Executa a migração de registros de documentos do site clássico.
     """
-
-    # IssueProc.set_items_to_process(collection_acron)
-
     params = {}
     if collection_acron:
         params["collection__acron"] = collection_acron
@@ -334,6 +331,14 @@ def migrate_document_records(
 
     for issue_proc in IssueProc.objects.filter(**params):
         issue_proc.migrate_document_records(user, force_update)
+
+    IssueProc.migrate_pending_document_records(
+        user,
+        collection_acron,
+        journal_acron,
+        issue_folder,
+        publication_year,
+    )
 
 
 def get_files_from_classic_website(

--- a/proc/tasks.py
+++ b/proc/tasks.py
@@ -555,6 +555,7 @@ def task_migrate_and_publish_articles(
     force_import_acron_id_file=False,
     force_migrate_document_records=False,
     force_migrate_document_files=False,
+    skip_migrate_pending_document_records=False,
 ):
     try:
         user = _get_user(user_id, username)
@@ -606,6 +607,7 @@ def task_migrate_and_publish_articles(
                 publication_year=publication_year,
                 status=status,
                 force_update=force_migrate_document_records,
+                skip_migrate_pending_document_records=skip_migrate_pending_document_records,
             )
 
             # le IssueProc selecionados e gera ArticleProc


### PR DESCRIPTION
#### O que esse PR faz?
Este PR **refatora e aprimora o processo de migração de documentos de fascículos**, tornando-o mais robusto e eficiente. As principais mudanças incluem: melhor tratamento de erros na função `migrate_document_records` e a introdução de uma nova função estática para gerenciar a migração de documentos pendentes. Também foram realizadas pequenas melhorias de formatação no código.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Execute a tarefa start para atualizar os parâmetros de task_migrate_and_publish_articles (adicionado o parâmetro: _skip_migrate_pending_document_records_)
Executando a migração e publicação de artigos (task_migrate_and_publish_articles).
Esta ação não pode causar interrupção como ocorria na versão anterior.

#### Algum cenário de contexto que queira dar?
Ao obter os dados de acron.id, os registros atualizados de IdFileRecord mudam `todo` para `True`, no entanto, isso não atualiza automaticamente IssueProc.docs_status nem IssueProc.files_status. Sendo assim, é necessário uma ação para realizar novamente a migração dos registros de documentos e de seus arquivos.

### Screenshots
n/a

#### Quais são tickets relevantes?
Erro ocorria ao executar IssueProc. set_items_to_process e não o concluia 

```
upload_production_celeryworker  | [2025-07-02 17:10:09,961: INFO/MainProcess] Task proc.tasks.task_migrate_and_publish_articles[ab55c51e-7561-4a21-b9c4-08504a3e9780] received
upload_production_celeryworker  | [2025-07-02 17:10:09,982: INFO/ForkPoolWorker-7] []
upload_production_celeryworker  | [2025-07-02 17:10:09,982: INFO/ForkPoolWorker-7] ['REPROC', 'TODO']
upload_production_celeryworker  | [2025-07-02 17:10:09,982: INFO/ForkPoolWorker-7] task_migrate_and_publish_articles: {'issue_proc__journal_proc__acron': 'rpsp', 'issue_proc__issue__publication_year': '2015'}
upload_production_celeryworker  | [2025-07-02 17:10:11,835: INFO/ForkPoolWorker-7] IdFileRecord.todo: 44884
upload_production_celeryworker  | [2025-07-02 17:10:11,924: INFO/ForkPoolWorker-7] IdFileRecord.todo: 44884
upload_production_celeryworker  | [2025-07-02 17:11:01,985: ERROR/MainProcess] Process 'ForkPoolWorker-7' pid:15 exited with 'signal 9 (SIGKILL)'
```

### Referências
n/a
