### PR TITLE
Fecha as conexões de banco de dados antes e depois de finalizar as tarefas

### DIFF
--- a/config/celery_app.py
+++ b/config/celery_app.py
@@ -15,3 +15,5 @@ app.config_from_object("django.conf:settings", namespace="CELERY")
 
 # Load task modules from all registered Django app configs.
 app.autodiscover_tasks()
+
+import config.celery_signals

--- a/config/celery_signals.py
+++ b/config/celery_signals.py
@@ -1,0 +1,30 @@
+# myproject/celery_signals.py (ou myproject/utils/celery_signals.py)
+
+from celery.signals import worker_process_init, task_prerun, task_postrun
+from django.db import close_old_connections
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _close_old_connections():
+    try:
+        close_old_connections()
+        logger.info("Conexões de banco de dados antigas fechadas após a tarefa Celery.")
+    except Exception as e:
+        logger.error(f"Erro ao fechar conexões de banco de dados após a tarefa Celery: {e}")
+
+
+@worker_process_init.connect
+def close_connections(**kwargs):
+    """Fecha conexões quando o worker é iniciado"""
+    _close_old_connections()
+
+@task_prerun.connect
+def close_connections_task_prerun(**kwargs):
+    """Fecha conexões antes de cada task"""
+    _close_old_connections()
+
+@task_postrun.connect
+def close_connections_task_postrun(**kwargs):
+    _close_old_connections()


### PR DESCRIPTION
## Descrição
Este PR adiciona sinais do Celery para gerenciar conexões do banco de dados, prevenindo problemas com conexões obsoletas em workers de longa duração.

## Mudanças
- ✨ Adiciona novo módulo `config/celery_signals.py` com handlers de sinais
- 🔧 Importa o módulo de sinais em `config/celery_app.py`
- 🗄️ Implementa fechamento automático de conexões antigas do banco de dados em três momentos:
  - Na inicialização do worker
  - Antes de cada tarefa
  - Após cada tarefa

## Motivação
Workers do Celery de longa duração podem manter conexões obsoletas com o banco de dados, causando erros como "connection already closed" ou timeouts. Esta implementação garante que as conexões sejam renovadas apropriadamente.

## Como testar
1. Inicie o worker do Celery
2. Execute tarefas que acessam o banco de dados
3. Verifique os logs para confirmar que as conexões estão sendo gerenciadas corretamente
4. Monitore por erros de conexão durante execução prolongada
