### PR TITLE
Melhorias nas configurações dos conteineres

### DIFF
--- a/compose/production/django/celery/worker/start
+++ b/compose/production/django/celery/worker/start
@@ -5,4 +5,4 @@ set -o pipefail
 set -o nounset
 
 
-exec celery -A config.celery_app worker -l INFO
+exec celery -A config.celery_app worker -l INFO --concurrency=1 --max-tasks-per-child=1 --max-memory-per-child=200000

--- a/production.yml
+++ b/production.yml
@@ -1,17 +1,21 @@
+x-django-function: &django-function
+  image: infrascielo/upload:${SCMS_WEBAPP_VERSION:-v2.10.4}
+  restart: unless-stopped
+  platform: linux/x86_64
+  depends_on:
+    - postgres
+    - redis
+  env_file:
+    - ./.envs/.production/.django
+    - ./.envs/.production/.postgres
+  volumes:
+    - ../scielo/www:/scielo_www
+    - upload_media:/app/core/media
+
 services:
-  django: &django
-    image: infrascielo/upload:${SCMS_WEBAPP_VERSION}
+  django:
+    <<: *django-function
     container_name: upload_production_django
-    platform: linux/x86_64
-    depends_on:
-      - postgres
-      - redis
-    env_file:
-      - ./.envs/.production/.django
-      - ./.envs/.production/.postgres
-    volumes:
-      - ../scielo/www:/scielo_www
-      - upload_media:/app/core/media
     ports:
       - "8000:8000"
     command: /start
@@ -43,22 +47,23 @@ services:
     container_name: upload_production_redis
 
   celeryworker:
-    <<: *django
+    <<: *django-function
     container_name: upload_production_celeryworker
     command: /start-celeryworker
     ports: []
 
   celerybeat:
-    <<: *django
+    <<: *django-function
     container_name: upload_production_celerybeat
     command: /start-celerybeat
     ports: []
 
   flower:
-    <<: *django
+    <<: *django-function
     container_name: upload_production_flower
     command: /start-flower
-    ports: []
+    ports:
+      - "5555:5555"
 
 
 volumes:


### PR DESCRIPTION
#### O que esse PR faz?

Melhoria na configuração do compose de produção:
- Criação de extension para configuração de conteineres para imagem `infrascielo/upload`, o que nos possibilita escalar os conteineres, se necessário
- Adiciona reinicialização automática dos conteineres
- Adiciona portas externas para o Flower

Adiciona configuração do Celery Worker de parâmetros na inicialização do worker:
- concurrency=1
- max-tasks-per-child=1
- max-memory-per-child=200000

#### Onde a revisão poderia começar?
Pelo production.yml, o extension criado.

#### Como este poderia ser testado manualmente?
Para testar a reinicialização dos conteineres e o funcionamento do extension:
- Recrie os conteineres que usam a imagem `infrascielo/upload`
- Reinicie a máquina onde os conteineres estão rodando
- Os conteineres devem estar iniciados, sem necessidade de fazê-lo manualmente

Para testar o Flower:
- Acesse o endereço do conteiner na porta 5555. A interface do Flower deve ser exibida

Para testar o Worker:
- Execute o comando `docker stats` e verifique o consumo de memória do worker
- Realizar processamentos de artigos. Ao terminar, o worker deve estar com a memória inicial

#### Algum cenário de contexto que queira dar?
Foram realizados testes no ambiente de homologação onde o worker estava consumindo muitos recursos de máquina. Com as novas configurações, o consumo está bem abaixo. As demais melhorias nos possibilita otimizar o uso da aplicação.

### Screenshots
n/a

#### Quais são tickets relevantes?
#715 

### Referências
.