### PR TITLE
Corrige a url da api core adicionando uma barra no final

### DIFF
--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -11,7 +11,7 @@ SECRET_KEY = env(
     default="FMiraeekXCSl3zHfg7D4oHx7ufT46HRnwnsawKgTCC53BYajVkVzb8HhOvBOHakR",
 )
 # https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts
-ALLOWED_HOSTS = ["localhost", "0.0.0.0", "127.0.0.1", "192.168.1.98"]
+ALLOWED_HOSTS = ["localhost", "0.0.0.0", "127.0.0.1", "192.168.1.213"]
 
 # CACHES
 # ------------------------------------------------------------------------------
@@ -67,5 +67,5 @@ CELERY_TASK_EAGER_PROPAGATES = True
 # Your stuff...
 # ------------------------------------------------------------------------------
 
-JOURNAL_API_URL = f"http://{ALLOWED_HOSTS[-1]}:8009/api/v1/journal"
-ISSUE_API_URL = f"http://{ALLOWED_HOSTS[-1]}:8009/api/v1/issue"
+JOURNAL_API_URL = f"http://{ALLOWED_HOSTS[-1]}:8009/api/v1/journal/"
+ISSUE_API_URL = f"http://{ALLOWED_HOSTS[-1]}:8009/api/v1/issue/"

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -243,5 +243,5 @@ LOGGING = {
 # Your stuff...
 # ------------------------------------------------------------------------------
 
-JOURNAL_API_URL = "https://core.scielo.org/api/v1/journal"
-ISSUE_API_URL = "https://core.scielo.org/api/v1/issue"
+JOURNAL_API_URL = "https://core.scielo.org/api/v1/journal/"
+ISSUE_API_URL = "https://core.scielo.org/api/v1/issue/"


### PR DESCRIPTION
#### O que esse PR faz?
Corrige a url da api core adicionando uma barra no final para resolver:

```
[2025-10-08 19:43:40,734: ERROR/ForkPoolWorker-7] Erro not retryable: https://core.scielo.org/api/v1/issue, 404 Client Error: Not Found for url: https://core.scielo.org/pt-br/api/v1/issue/?issn_print=1814-4144&issn_electronic=1814-4152&volume=22
[2025-10-08 19:43:40,735: INFO/ForkPoolWorker-7] issue: None
```
Evitando o redirecionamento para **https://core.scielo.org/pt-br/api/v1/issue/**

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Pelo menu upload, subir um pacote cujo issue é novo, então o sistema consultará o core para obter os dados do issue

#### Algum cenário de contexto que queira dar?
Houve alguma mudança no core que ao receber uma requisição sem a barra no final, redireciona para uma rota com o idioma. 

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a
