### PR TITLE
Corrige a migração de XML nativos e corrige a obtenção de registros de parágrafos de bases-work/artigo/p

### DIFF
--- a/proc/models.py
+++ b/proc/models.py
@@ -1622,7 +1622,7 @@ class ArticleProc(BaseProc, ClusterableModel):
 
             detail = {}
             detail["file_type"] = self.migrated_data.file_type
-
+            result = {}
             if self.migrated_data.file_type == "html":
                 migrated_data = self.migrated_data
                 classic_ws_doc = migrated_data.document

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -93,7 +93,7 @@ iso639-lang==2.6.3  # Mantendo versão maior
 -e git+https://github.com/scieloorg/packtools.git@4.12.8#egg=packtools
 -e git+https://github.com/scieloorg/scielo_scholarly_data#egg=scielo_scholarly_data
 -e git+https://github.com/scieloorg/opac_schema.git@v2.66#egg=opac_schema
--e git+https://github.com/scieloorg/scielo_migration.git@1.9.5#egg=scielo_classic_website
+-e git+https://github.com/scieloorg/scielo_migration.git@1.9.6#egg=scielo_classic_website
 
 # ========================================
 # Development & Testing


### PR DESCRIPTION
#### O que esse PR faz?
Corrige ausência de definição da variável result que causava erro ao processar xml nativo em:

```python
if result.get("exceptions"):
```

Também corrigia a obtenção dos registros de parágrafos do caminho `bases-work/artigo/p/...`

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Executando a migração de artigos XML
Executando a migração de artigos HTML cujos parágrafos estão em `bases-work/artigo/p`

#### Algum cenário de contexto que queira dar?
defeitos identificados pela equipe Argentina

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a

