### PR TITLE
Corrige publicação de dados de periódicos: subject_areas e status

### DIFF
--- a/publication/api/journal.py
+++ b/publication/api/journal.py
@@ -185,10 +185,10 @@ class JournalPayload:
 
     def add_thematic_scopes(self, subject_categories, subject_areas):
         # Subject Categories
-        self.data["subject_categories"] = subject_categories
+        self.data["subject_categories"] = [item for item in subject_categories if item]
 
         # Study Area
-        self.data["subject_areas"] = subject_areas
+        self.data["subject_areas"] = [item for item in subject_areas if item]
 
     def add_issue_count(self, issue_count):
         # Issue count

--- a/publication/utils/journal.py
+++ b/publication/utils/journal.py
@@ -17,6 +17,7 @@ def build_journal(
 
     for journal_history in journal_history.all():
         logging.info(f"journal_history.event_type: {journal_history.event_type}")
+
         if journal_history.event_type == "ADMITTED":
             event_type = "current"
         elif journal_history.interruption_reason == "ceased":
@@ -28,6 +29,9 @@ def build_journal(
             event_type = "suspended"
         elif journal_history.interruption_reason == "not-open-access":
             event_type = "suspended"
+        elif journal_history.event_type == "INTERRUPTED":
+            # deceased está incorreto no opac
+            event_type = "deceased"
         else:
             event_type = "inprogress"
 


### PR DESCRIPTION
#### O que esse PR faz?
Corrige dois problemas relacionados ao processamento de dados de periódicos:
1. Remove valores vazios (None) das listas de categorias e áreas temáticas no payload da API
2. Adiciona tratamento específico para journals com status INTERRUPTED, mapeando corretamente para 'deceased'

#### Onde a revisão poderia começar?
`publication/utils/journal.py` - linha 32, onde foi adicionado o novo mapeamento para event_type INTERRUPTED

#### Como este poderia ser testado manualmente?
1. Identificar um journal com status INTERRUPTED no banco de dados
2. Executar o build do journal via API ou comando de management
3. Verificar que o status é mapeado para 'deceased' ao invés de 'inprogress'
4. Para as áreas temáticas: criar/editar um journal com valores None em subject_categories ou subject_areas
5. Verificar que o payload final não contém elementos vazios nessas listas

#### Algum cenário de contexto que queira dar?
ocorreu em Costa Rica, Portugal, Argentina

### Screenshots
N/A - Alterações em lógica de backend

#### Quais são tickets relevantes?
ocorreu em Costa Rica, Portugal, Argentina

```
Entonces, por ejemplo para la revista “Temas medievales” con acrónimo tmedie, el error que se visualiza es:

Completed:
False

Detail:
{'doit': True, 'error': "ValidationError (Journal:0327-5094) (2.StringField only accepts string values: ['study_areas'])", 'failed': True, 'payload': '{"sponsors": [], "status_history": [{"status": "deceased", "date": "2017-07-21", "reason": "ceased"}, {"status": "current", "date": 
```


```
23-10-2025
V2.10.8

Las revistas descontinuadas no salen en sitio nuevo. Acá, la pantalla del status de una de las revistas:

```
### Referências
n/a