### PR TITLE
Corrige consultas para identificar pid provider xml registrados

### DIFF
--- a/core/utils/similarity.py
+++ b/core/utils/similarity.py
@@ -3,3 +3,7 @@ from difflib import SequenceMatcher
 
 def is_similar(str1, str2, min_ratio=0.7):
     return SequenceMatcher(None, str1, str2).ratio() > min_ratio
+
+
+def how_similar(str1, str2):
+    return SequenceMatcher(None, str1, str2).ratio()

--- a/pid_provider/requester.py
+++ b/pid_provider/requester.py
@@ -292,7 +292,7 @@ class PidRequester(BasePidProvider):
 
         if not item_to_fix.fixed_in_upload:
             # atualiza v2 em pid_provider_xml
-            response = pid_provider_xml.fix_pid_v2(user, correct_pid_v2)
+            response = PidProviderXML.fix_pid_v2(user, pid_v3, correct_pid_v2)
             fixed["fixed_in_upload"] = response.get("v2") == correct_pid_v2
 
         if not item_to_fix.fixed_in_core:

--- a/pid_provider/wagtail_hooks.py
+++ b/pid_provider/wagtail_hooks.py
@@ -5,8 +5,8 @@ from wagtail.snippets.models import register_snippet
 from wagtail.snippets.views.snippets import SnippetViewSetGroup
 
 from config.menu import get_menu_order
-from core.views import CommonControlFieldViewSet
-from pid_provider.models import FixPidV2, OtherPid, PidProviderConfig, PidProviderXML
+from core.viewsets import CommonControlFieldViewSet
+from pid_provider.models import XMLVersion, FixPidV2, OtherPid, PidProviderConfig, PidProviderXML
 
 
 class PidProviderXMLViewSet(CommonControlFieldViewSet):
@@ -15,7 +15,7 @@ class PidProviderXMLViewSet(CommonControlFieldViewSet):
     menu_icon = "folder"
     menu_order = 300
     add_to_settings_menu = False
-    list_per_page = 10
+    list_per_page = 20
 
     # Configuração de listagem
     list_display = [
@@ -24,8 +24,7 @@ class PidProviderXMLViewSet(CommonControlFieldViewSet):
         "v3",
         "v2",
         "aop_pid",
-        "main_doi",
-        "available_since",
+        "proc_status",
         "other_pid_count",
         "updated",
     ]
@@ -154,16 +153,43 @@ class FixPidV2ViewSet(CommonControlFieldViewSet):
     export_filename = "fix_pid_v2"
 
 
+class XMLVersionViewSet(CommonControlFieldViewSet):
+    model = XMLVersion
+    menu_label = _("XML Versions")
+    menu_icon = "folder"
+    menu_order = 300
+    add_to_settings_menu = False
+    list_per_page = 10
+
+    # Configuração de listagem
+    list_display = [
+        "pid_provider_xml",
+        "file",
+        "finger_print",
+        "updated",
+    ]
+    search_fields = (
+        "file__path",
+        "pid_provider_xml__v3",
+        "pid_provider_xml__v2",
+        "pid_provider_xml__aop_pid",
+        "pid_provider_xml__pkg_name",
+        "pub_year",
+        "available_since",
+    )
+
+
 # Grupo de ViewSets
 class PidProviderViewSetGroup(SnippetViewSetGroup):
     menu_label = _("Pid Provider")
     menu_icon = "folder-open-inverse"
     menu_order = get_menu_order("pid_provider")
     items = (
-        PidProviderConfigViewSet,
         PidProviderXMLViewSet,
         OtherPidViewSet,
         FixPidV2ViewSet,
+        PidProviderConfigViewSet,
+        XMLVersionViewSet,
     )
 
 


### PR DESCRIPTION
## Pull Request: Otimização do sistema de matching e busca de documentos XML

#### O que esse PR faz?
Este PR refatora e otimiza o sistema de identificação e matching de documentos XML no PidProvider, por documentos com dados "insuficientes" para realizar a consulta como títulos de artigos e outros metadados.

Adicionalmente resolvendo problemas de performance e precisão na busca de registros duplicados. As principais melhorias incluem:

- **Sistema de scoring ponderado**: Substitui a comparação booleana simples por um sistema de pontuação que considera diferentes pesos para cada campo (título, autores, colaboradores, links, corpo parcial)
- **Otimização de queries**: Simplifica e melhora as queries de busca, removendo queries redundantes e adicionando cached_properties para evitar acessos repetidos ao xml_adapter
- **Melhor tratamento de conflitos**: Implementa método `best_matches()` que avalia múltiplos candidatos e registra detalhes em UnexpectedEvent quando há ambiguidade
- **Correções de bugs**: Corrige atribuição incorreta de pid_v2 e chamada de método como instância ao invés de classe
- **Melhorias no admin**: Adiciona novo painel para visualizar campos z_* (dados textuais usados no matching)

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Executando a migração de artigos

Verificar:
   - Lista de UnexpectedEvents
   - Lista de Article
   - Lista de PidProviderXML

#### Algum cenário de contexto que queira dar?

Exemplo de scoring:
- Título similar: +50 a +100 pontos (baseado em ratio de similaridade)
- Mesmo z_surnames: +100 pontos
- Mesmo pid_v2: +100 pontos
- Mesmo DOI: +100 pontos
- Score > 50 = match válido

### Screenshots
N/A - Mudanças são principalmente no backend e lógica de processamento

#### Quais são tickets relevantes?
- Issue #[número]: Erro MultipleObjectsReturned ao importar XMLs com títulos similares
- Issue #[número]: Performance degradada em busca de documentos duplicados
- Issue #[número]: Melhorar precisão na identificação de versões de artigos

### Referências
n/a