### PR TITLE
Cria property para retornar texto puro de mission do periódico.

### DIFF
--- a/journal/models.py
+++ b/journal/models.py
@@ -1,20 +1,15 @@
 import logging
 from datetime import datetime
 
-from django.db import IntegrityError, models
-from django.db.models import Q
-from django.utils.translation import gettext_lazy as _
-from modelcluster.fields import ParentalKey
-from modelcluster.models import ClusterableModel
-from wagtail.admin.panels import FieldPanel, InlinePanel, ObjectList, TabbedInterface
-from wagtail.models import Orderable
-from wagtailautocomplete.edit_handlers import AutocompletePanel
-
 from collection.models import Collection, Language
 from core.choices import MONTHS
 from core.forms import CoreAdminModelForm
 from core.models import CommonControlField, HTMLTextModel, TextModel
-from institution.models import Institution, InstitutionHistory
+from django.db import IntegrityError, models
+from django.db.models import Q
+from django.utils.html import strip_tags
+from django.utils.translation import gettext_lazy as _
+from institution.models import InstitutionHistory
 from journal import choices
 from journal.exceptions import (
     MissionCreateOrUpdateError,
@@ -23,6 +18,11 @@ from journal.exceptions import (
 )
 from journal.forms import OfficialJournalForm
 from location.models import Location
+from modelcluster.fields import ParentalKey
+from modelcluster.models import ClusterableModel
+from wagtail.admin.panels import FieldPanel, InlinePanel, ObjectList, TabbedInterface
+from wagtail.models import Orderable
+from wagtailautocomplete.edit_handlers import AutocompletePanel
 
 
 class JournalSection(TextModel, CommonControlField):
@@ -843,6 +843,12 @@ class Mission(CommonControlField, HTMLTextModel):
             return cls.create(user, journal, language, mission_text)
         except cls.DoesNotExist:
             return cls.create(user, journal, language, mission_text)
+
+    @property
+    def content_plain_text(self):
+        if self.text:
+            return strip_tags(self.text)
+        return None
 
 
 class JournalCollection(CommonControlField, ClusterableModel):

--- a/proc/source_core_api.py
+++ b/proc/source_core_api.py
@@ -5,14 +5,13 @@ Módulo responsável pela busca e processamento de dados da API Core externa.
 import logging
 import sys
 
-from django.conf import settings
-from django.db.models import Q
-
 from collection.models import Collection
 from core.utils.requester import fetch_data
+from django.conf import settings
+from django.db.models import Q
+from institution.models import Institution
 from issue.models import Issue
 from journal.models import (
-    Institution,
     Journal,
     JournalCollection,
     JournalHistory,

--- a/publication/utils/journal.py
+++ b/publication/utils/journal.py
@@ -13,7 +13,7 @@ def build_journal(
     builder.add_contact(**journal.contact)
 
     for mission in journal.mission.all():
-        builder.add_mission(mission.language.code2, mission.text)
+        builder.add_mission(mission.language.code2, mission.content_plain_text)
 
     for journal_history in journal_history.all():
         logging.info(f"journal_history.event_type: {journal_history.event_type}")


### PR DESCRIPTION
#### O que esse PR faz?
Cria property para retornar texto puro de mission e adiciona ao payload de Journal

#### Onde a revisão poderia começar?
pelos commits

#### Como este poderia ser testado manualmente?
Executar task proc.tasks.task_publish_journals

#### Algum cenário de contexto que queira dar?
Após reavaliação, decidi não prosseguir com esta PR. A solução foi implementada 
na camada de template meta.html do opac_5 usando o filtro |striptags do Jinja2, que é mais apropriado 
para este caso de uso.

Razões:
- O RichTextField deve manter seu propósito de retornar conteúdo formatado
- Diferentes contextos (meta tags vs. conteúdo da página) requerem diferentes 
  tratamentos do mesmo dado
- O filtro |striptags oferece a flexibilidade necessária sem modificar o model

### Screenshots
N/A

#### Quais são tickets relevantes?
https://github.com/scieloorg/opac_5/pull/362

### Referências
N/A

