### PR TITLE
Refatoração do fluxo de migração e tratamento de duplicações

### DIFF
--- a/article/models.py
+++ b/article/models.py
@@ -2,6 +2,7 @@ import logging
 import traceback
 from datetime import datetime, timezone
 
+from django.db import transaction
 from django.contrib.auth import get_user_model
 from django.db import IntegrityError, models
 from django.db.models import Count, Q
@@ -516,44 +517,68 @@ class Article(ClusterableModel, CommonControlField):
 
     @classmethod
     def exclude_repetitions(cls, user, field_name, field_value, timeout=None):
-        events = []
+        """
+        Remove artigos duplicados baseado em um campo específico,
+        mantendo o artigo mais relevante (publicado e válido tem prioridade).
+        """
         repeated_items = cls.objects.filter(**{field_name: field_value})
-        events.append(f"{field_name}='{field_value}': {len(repeated_items)} articles")
-
+        total_initial = repeated_items.count()
+        
+        if total_initial <= 1:
+            return [f"{field_name}='{field_value}': {total_initial} artigo(s), nenhuma ação necessária"]
+        
+        events = [f"{field_name}='{field_value}': {total_initial} artigos encontrados"]
+        
+        # Atualiza status de disponibilidade antes de decidir qual manter
         cls.update_availability_status(user, timeout, repeated_items)
-        if not repeated_items.exists():
-            events.append(f"{field_name}='{field_value}': {len(repeated_items)} articles")
+        
+        # Recarrega queryset após atualização de status
+        repeated_items = cls.objects.filter(**{field_name: field_value})
+        
+        item_to_keep_id = cls.choose_item_to_keep(repeated_items)
+        if not item_to_keep_id:
+            # Fallback: mantém o mais recentemente atualizado
+            item_to_keep_id = repeated_items.order_by('-updated').values_list('id', flat=True).first()
+        
+        if not item_to_keep_id:
+            events.append("Erro: nenhum item encontrado para manter")
             return events
         
-        items_to_delete = repeated_items
-        item_to_keep_id = cls.choose_item_to_keep(repeated_items)
-        if item_to_keep_id:
-            events.append(f"Item to keep: Article ID {item_to_keep_id}")
-            items_to_delete = items_to_delete.exclude(id=item_to_keep_id)
+        events.append(f"Artigo mantido: ID {item_to_keep_id}")
         
-        total = len(items_to_delete)
-        events.append(f"{field_name}='{field_value}': {total} articles")
-        pp_xml_id_to_delete = []
-        sps_pkg_id_to_delete = []
-        for item_to_delete in items_to_delete:
-            if item_to_delete.sps_pkg:
-                sps_pkg_id_to_delete.append(item_to_delete.sps_pkg.id)
-            if item_to_delete.pp_xml:
-                pp_xml_id_to_delete.append(item_to_delete.pp_xml.id)
-
-        if total:
-            items_to_delete.delete()
-        events.append(f"Deleted Article: {total}")
-
-        total = len(sps_pkg_id_to_delete)
-        if total:
-            SPSPkg.objects.filter(id__in=sps_pkg_id_to_delete).delete()
-        events.append(f"Deleted SPSPkg: {total}")
+        # Coleta IDs relacionados em uma única passagem
+        items_to_delete = repeated_items.exclude(id=item_to_keep_id).select_related('sps_pkg', 'pp_xml')
         
-        total = len(pp_xml_id_to_delete)
-        if total:
-            PidProviderXML.objects.filter(id__in=pp_xml_id_to_delete).delete()
-        events.append(f"Deleted PidProviderXML: {total}")
+        sps_pkg_ids = set()
+        pp_xml_ids = set()
+        article_ids = []
+        
+        for item in items_to_delete:
+            article_ids.append(item.id)
+            if item.sps_pkg_id:
+                sps_pkg_ids.add(item.sps_pkg_id)
+            if item.pp_xml_id:
+                pp_xml_ids.add(item.pp_xml_id)
+        
+        total_to_delete = len(article_ids)
+        events.append(f"Artigos a deletar: {total_to_delete}")
+        
+        if not total_to_delete:
+            return events
+        
+        # Executa deleções em transação atômica
+        with transaction.atomic():
+            deleted_articles, _ = cls.objects.filter(id__in=article_ids).delete()
+            events.append(f"Articles deletados: {deleted_articles}")
+            
+            if sps_pkg_ids:
+                deleted_sps, _ = SPSPkg.objects.filter(id__in=sps_pkg_ids).delete()
+                events.append(f"SPSPkg deletados: {deleted_sps}")
+            
+            if pp_xml_ids:
+                deleted_pp, _ = PidProviderXML.objects.filter(id__in=pp_xml_ids).delete()
+                events.append(f"PidProviderXML deletados: {deleted_pp}")
+        
         return events
 
     @classmethod

--- a/article/wagtail_hooks.py
+++ b/article/wagtail_hooks.py
@@ -53,6 +53,7 @@ class ArticleSnippetViewSet(SnippetViewSet):
     list_filter = ("status", "journal")
     search_fields = (
         "sps_pkg__sps_pkg_name",
+        "pid_v2",
         "pid_v3",
         "issue__publication_year",
         "journal__official_journal__title",

--- a/package/models.py
+++ b/package/models.py
@@ -166,7 +166,7 @@ class BasicXMLFile(models.Model):
         try:
             delete_files(self.file.path)
         except Exception as e:
-            logging.exception(f"Error deleting file {self.file.path}: {e}")
+            pass
         super().delete(using=using, keep_parents=keep_parents)
 
     @property
@@ -606,7 +606,7 @@ class SPSPkg(CommonControlField, ClusterableModel):
             operation.finish(
                 user,
                 completed=True,
-                detail={"source": zip_file_path, "saved": self.file.path},
+                detail={"source": zip_file_path, "saved": filename},
             )
         except Exception as e:
             exc_type, exc_value, exc_traceback = sys.exc_info()
@@ -621,7 +621,7 @@ class SPSPkg(CommonControlField, ClusterableModel):
         try:
             delete_files(self.file.path)
         except Exception as e:
-            logging.exception(f"Unable to delete {self.file.path} {e} {type(e)}")
+            pass
         try:
             self.file.save(name, ContentFile(content))
         except Exception as e:

--- a/proc/tasks.py
+++ b/proc/tasks.py
@@ -1397,8 +1397,6 @@ def task_exclude_article_repetition(self, journal_proc_id, qa_api_data=None, pub
         for field_name in ("pid_v2", "sps_pkg__sps_pkg_name"):
             repeated_items = Article.get_repeated_items(field_name, journal)
             task_exec.add_number(f"repeated_by_{field_name}", repeated_items.count())
-            task_exec.add_number(f"repeated_by_{field_name}", len(repeated_items))
-            task_exec.add_number(f"repeated_by_{field_name}", repeated_items.count())
             for repeated_value in repeated_items:
                 try:
                     events = Article.exclude_repetitions(user, field_name, repeated_value, timeout=timeout)

--- a/proc/tasks.py
+++ b/proc/tasks.py
@@ -7,6 +7,8 @@ from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 
 from article.models import Article
+from journal.models import Journal
+from issue.models import Issue
 from collection.choices import PUBLIC, QA
 from collection.models import Collection, WebSiteConfiguration
 from config import celery_app
@@ -74,6 +76,7 @@ class TaskExecution:
             completed = False
         else:
             completed = True
+        self.params["item"] = self.item
         detail = {
             "params": self.params,
             "stats": self.stats,
@@ -882,19 +885,28 @@ def task_migrate_and_publish_articles_by_journal(
             collection__acron=collection_acron,
             acron=journal_acron,
         )
+
+        task_exclude_article_repetition(
+            journal_proc.id,
+            qa_api_data=None,
+            public_api_data=None,
+            username=user.username,
+            user_id=user.id,
+            timeout=None,
+        )
+
         task_exec.add_event("Read journal acron id file")
         response = controller.register_acron_id_file_content(
             user,
             journal_proc,
             force_update=force_import_acron_id_file,
         )
+
         try:
             article_pids = response.pop("article_pids")
         except KeyError:
             article_pids = []
-        task_exec.add_event(
-            {"read acron.id response": response}
-        )
+        task_exec.add_event(f"acron.id response: {response}")
         task_exec.add_number("total_articles_to_process", len(article_pids))
         
         # Agrupa os article_pids por issue_pid
@@ -911,6 +923,7 @@ def task_migrate_and_publish_articles_by_journal(
 
         status = tracker_choices.get_valid_status(status, force_update)
         task_exec.add_event(f"Select journal issues which docs_status or files_status in {status} and/or has articles to process")
+
         events = []
         issue_proc_list = IssueProc.get_id_and_pid_list_to_process(
             journal_proc,
@@ -994,31 +1007,23 @@ def task_migrate_and_publish_articles_by_issue(
             "collection", "journal_proc",
         ).get(id=issue_proc_id)
         task_exec.item = str(issue_proc)
-        task_exec.add_event("Exclude article repetition from issue")
-        task_exclude_article_repetition_from_issue(
-            issue_proc_id=issue_proc_id,
-            qa_api_data=qa_api_data,
-            public_api_data=public_api_data,
-            username=username,
-            user_id=user_id,
+
+        task_exec.add_event(f"STATUS={status}")
+        task_exec.add_event(f"total article_pids: {len(article_pids)}")
+        task_exec.add_event(f"docs_status: {issue_proc.docs_status}")
+
+        task_exec.add_event("Migrate document records")
+        total_migrated_records = issue_proc.migrate_document_records(user, force_migrate_document_records)
+        task_exec.add_number("total_migrated_records", total_migrated_records)
+
+        task_exec.add_event("Migrate issue files")
+        total_migrated_files = issue_proc.get_files_from_classic_website(
+            user, force_migrate_document_files, controller.migrate_issue_files
         )
+        task_exec.add_number("total_migrated_files", total_migrated_files)
 
         task_exec.add_event("Mark articles for reprocessing")
         ArticleProc.mark_for_reprocessing(issue_proc, article_pids)
-
-        task_exec.add_event(f"docs_status in {status} or article_pids={bool(article_pids)}")
-        if issue_proc.docs_status in status or article_pids:
-            task_exec.add_event("Migrate document records")
-            total_docs_to_migrate = issue_proc.migrate_document_records(user, force_update)
-            task_exec.add_number("total_docs_to_migrate", total_docs_to_migrate)
-
-        task_exec.add_event(f"files_status in {status} or article_pids={bool(article_pids)}")
-        if issue_proc.files_status in status:
-            task_exec.add_event("Migrate issue files")
-            total_files_to_migrate = issue_proc.get_files_from_classic_website(
-                user, force_update, controller.migrate_issue_files
-            )
-            task_exec.add_number("total_files_to_migrate", total_files_to_migrate)
 
         task_exec.add_event("Select articles to migrate and/or publish")
         query_by_status = (
@@ -1076,6 +1081,24 @@ def task_migrate_and_publish_articles_by_issue(
                 publication_year=issue_proc.issue.publication_year,
                 force_update=force_update,
             )
+
+        for website_label, api_data in zip((QA, PUBLIC), (qa_api_data, public_api_data)):
+            if not api_data:
+                api_data = get_api_data(issue_proc.collection, "issue", website_label)
+            if api_data and not api_data.get("error"):
+                try:
+                    task_exec.add_event(f"Syncing issue in {website_label} website")
+                    sync_issue(issue_proc, api_data)
+                    task_exec.add_event(f"Issue synced in {website_label} website")
+                except Exception as e:
+                    exc_type, exc_value, exc_traceback = sys.exc_info()
+                    task_exec.add_exception(
+                        {
+                            "website": website_label,
+                            "traceback": traceback.format_exc(),
+                        }
+                    )
+
         task_exec.finish()
     except Exception as e:
         exc_type, exc_value, exc_traceback = sys.exc_info()
@@ -1336,72 +1359,46 @@ def task_fetch_and_create_journal(
 
 ###############################
 
-@celery_app.task(bind=True)
-def task_exclude_article_repetition(self, username=None, user_id=None, collection_acron_list=None, journal_acron_list=None, issue_folder=None):
-    task_params = {
-        "collection_acron_list": collection_acron_list,
-        "journal_acron_list": journal_acron_list,
-        "issue_folder": issue_folder,
-    }
-    try:
-        user = _get_user(user_id=user_id, username=username)
-        kwargs = {}
-        if collection_acron_list:
-            kwargs["collection__acron__in"] = collection_acron_list
-        if journal_acron_list:
-            kwargs["journal_proc__acron__in"] = journal_acron_list
-        if issue_folder:
-            kwargs["issue_folder__contains"] = issue_folder
-        for issue_proc in IssueProc.objects.filter(**kwargs):
-            task_exclude_article_repetition_from_issue.delay(
-                issue_proc_id=issue_proc.id,
-                username=username,
-                user_id=user_id,
-            )
-    except Exception as e:
-        exc_type, exc_value, exc_traceback = sys.exc_info()
-        UnexpectedEvent.create(
-            item="",
-            action="task_exclude_article_repetition",
-            e=e,
-            exc_traceback=exc_traceback,
-            detail=task_params,
-        )
 
 @celery_app.task(bind=True)
-def task_exclude_article_repetition_from_issue(self, issue_proc_id, qa_api_data=None, public_api_data=None, username=None, user_id=None, timeout=None):
+def task_exclude_article_repetition(self, journal_proc_id, qa_api_data=None, public_api_data=None, username=None, user_id=None, timeout=None):
     task_params = {
-        "issue_proc_id": issue_proc_id,
+        "journal_proc_id": journal_proc_id,
         "qa_api_data": bool(qa_api_data),
         "public_api_data": bool(public_api_data),
     }
-    issue_proc_id_ = str(issue_proc_id)
+    journal_proc_str = str(journal_proc_id)
     task_exec = TaskExecution(
-        name="task_exclude_article_repetition_from_issue",
-        item=issue_proc_id_,
+        name="task_exclude_article_repetition",
+        item=journal_proc_str,
         params=task_params,
     )
     try:
         user = _get_user(user_id=user_id, username=username)
-        issue_proc = IssueProc.objects.select_related("collection").get(id=issue_proc_id)
-        task_exec.item = str(issue_proc)
-        issue_proc_id_ = str(issue_proc)
-        collection = issue_proc.collection
+        journal_proc = JournalProc.objects.get(id=journal_proc_id)
+        journal = journal_proc.journal
+        collection = journal_proc.collection
 
-        queryset = Article.objects.filter(issue=issue_proc.issue)
-        task_exec.add_number("total_articles_in_issue", queryset.count())
+        task_exec.item = str(journal_proc)
+        journal_proc_str = str(journal_proc)
 
-        response = Article.fix_sps_pkg_names(list(queryset))
+        journal_articles_qs = Article.objects.filter(journal=journal)
+        task_exec.add_number("total_articles_in_journal", journal_articles_qs.count())
+
+        journal_articles_to_fix_sps_pkg_names_qs = journal_articles_qs.filter(
+            Q(issue__supplement__isnull=True),
+            ~Q(sps_pkg__sps_pkg_name__contains="-s"),
+            sps_pkg__isnull=False,
+        )
+        response = Article.fix_sps_pkg_names(journal_articles_to_fix_sps_pkg_names_qs)
         task_exec.add_event(f"fixed sps_pkg_names: {response}")
 
+        issues = set()
         for field_name in ("pid_v2", "sps_pkg__sps_pkg_name"):
-            total_filtered = len(queryset)
-            task_exec.add_number(f"total_{field_name}", total_filtered)
-            if total_filtered == 0:
-                task_exec.add_event(f"Consulta novamente Article para obter artigos do issue ({field_name})")
-                queryset = Article.objects.filter(issue=issue_proc.issue)
-            repeated_items = Article.get_repeated_items(field_name, queryset)
+            repeated_items = Article.get_repeated_items(field_name, journal)
+            task_exec.add_number(f"repeated_by_{field_name}", repeated_items.count())
             task_exec.add_number(f"repeated_by_{field_name}", len(repeated_items))
+            task_exec.add_number(f"repeated_by_{field_name}", repeated_items.count())
             for repeated_value in repeated_items:
                 try:
                     events = Article.exclude_repetitions(user, field_name, repeated_value, timeout=timeout)
@@ -1411,22 +1408,6 @@ def task_exclude_article_repetition_from_issue(self, issue_proc_id, qa_api_data=
                     task_exec.add_exception(
                         {
                             f"repeated_by_{field_name}": repeated_value,
-                            "traceback": traceback.format_exc(),
-                        }
-                    )
-        for website_label, api_data in zip((QA, PUBLIC), (qa_api_data, public_api_data)):
-            if not api_data:
-                api_data = get_api_data(collection, "issue", website_label)
-            if api_data and not api_data.get("error"):
-                try:
-                    task_exec.add_event(f"Syncing issue in {website_label} website")
-                    sync_issue(issue_proc, api_data)
-                    task_exec.add_event(f"Issue synced in {website_label} website")
-                except Exception as e:
-                    exc_type, exc_value, exc_traceback = sys.exc_info()
-                    task_exec.add_exception(
-                        {
-                            "website": website_label,
                             "traceback": traceback.format_exc(),
                         }
                     )
@@ -1440,9 +1421,81 @@ def task_exclude_article_repetition_from_issue(self, issue_proc_id, qa_api_data=
             )
         except Exception:
             UnexpectedEvent.create(
-                item=issue_proc_id_,
-                action="proc.tasks.task_exclude_article_repetition_from_issue",
+                item=journal_proc_str,
+                action="proc.tasks.task_exclude_article_repetition",
                 e=e,
                 exc_traceback=exc_traceback,
                 detail=task_params,
             )
+
+
+@celery_app.task(bind=True)
+def task_remove_duplicate_issues(
+    self,
+    user_id=None,
+    username=None,
+    journal_id=None,
+):
+    """
+    Remove Issue duplicados.
+    
+    Args:
+        dry_run: Se True, apenas identifica duplicatas sem remover.
+    """
+    task_params = {
+        "user_id": user_id,
+        "username": username,
+        "journal_id": journal_id,
+    }
+    task_exec = TaskExecution(
+        name="proc.tasks.task_remove_duplicate_issues",
+        item=f"{journal_id or 'all'}",
+        params=task_params,
+    )
+    try:
+        user = _get_user(user_id, username)
+        stats = {}
+        journal = None
+        if journal_id:
+            journal = Journal.objects.get(id=journal_id)
+        
+        duplicates = Issue.get_duplicates(journal)
+        stats["total_duplicated_issues"] = duplicates.count()
+        task_exec.total_to_process = stats["total_duplicated_issues"]
+        duplicated_issues = []
+        for duplicated_issue_data in duplicates.iterator():
+            try:
+                duplicated_issues.append(duplicated_issue_data)
+                issues = list(Issue.objects.filter(**duplicated_issue_data).order_by("-updated"))
+                keep = issues[0]
+                task_exec.add_event(f"Remove duplicated Issues, (keeping {keep})")
+                for issue in issues[1:]:
+                    try:
+                        # Migra artigos para o Issue mantido
+                        Article.objects.filter(issue=issue).update(issue=keep)
+                        # Atualiza IssueProc se existir
+                        IssueProc.objects.filter(issue=issue).update(issue=keep)
+                        issue.delete()
+                    except Exception as e:
+                        exc_type, exc_value, exc_traceback = sys.exc_info()
+                        task_exec.add_exception(
+                            {
+                                "duplicated_issue_data": duplicated_issue_data,
+                                "issue_id": issue.id,
+                                "traceback": traceback.format_exc(),
+                            }
+                        )
+                task_exec.total_processed += 1
+            except Exception as e:
+                exc_type, exc_value, exc_traceback = sys.exc_info()
+                task_exec.add_exception(
+                    {
+                        "duplicated_issue_data": duplicated_issue_data,
+                        "traceback": traceback.format_exc(),
+                    }
+                )
+        task_exec.finish()
+        
+    except Exception as e:
+        exc_type, exc_value, exc_traceback = sys.exc_info()
+        task_exec.finish(exception=e, exc_traceback=exc_traceback)

--- a/proc/wagtail_hooks.py
+++ b/proc/wagtail_hooks.py
@@ -3,6 +3,7 @@ from django.utils.translation import gettext_lazy as _
 from wagtail import hooks
 from wagtail.snippets.models import register_snippet
 from wagtail.snippets.views.snippets import SnippetViewSetGroup
+import django_filters
 
 from config.menu import get_menu_order
 from core.views import CommonControlFieldViewSet
@@ -10,6 +11,64 @@ from htmlxml.models import HTMLXML
 from package.models import SPSPkg
 
 from .models import ArticleProc, IssueProc, JournalProc, ProcReport
+
+
+class HTMLXMLFilterSet(django_filters.FilterSet):
+    has_images = django_filters.BooleanFilter(
+        field_name='html_img_total',
+        lookup_expr='gt',
+        label=_('Has Images'),
+        method='filter_has_images'
+    )
+    
+    has_tables = django_filters.BooleanFilter(
+        field_name='html_table_total', 
+        lookup_expr='gt',
+        label=_('Has Tables'),
+        method='filter_has_tables'
+    )
+    
+    has_attention_demands = django_filters.BooleanFilter(
+        field_name='attention_demands',
+        lookup_expr='gt', 
+        label=_('Has Attention Demands'),
+        method='filter_has_attention_demands'
+    )
+    
+    def filter_has_images(self, queryset, name, value):
+        if value is True:
+            return queryset.filter(html_img_total__gt=0)
+        elif value is False:
+            return queryset.filter(html_img_total=0)
+        return queryset
+    
+    def filter_has_tables(self, queryset, name, value):
+        if value is True:
+            return queryset.filter(html_table_total__gt=0)
+        elif value is False:
+            return queryset.filter(html_table_total=0)
+        return queryset
+    
+    def filter_has_attention_demands(self, queryset, name, value):
+        if value is True:
+            return queryset.filter(attention_demands__gt=0)
+        elif value is False:
+            return queryset.filter(attention_demands=0)
+        return queryset
+
+    class Meta:
+        model = HTMLXML
+        fields = [
+            'html2xml_status',
+            'quality', 
+            'pdf_langs',
+            'html_translation_langs',
+            'article_type',
+            'empty_body',
+            'has_images',
+            'has_tables',
+            'has_attention_demands',
+        ]
 
 
 class JournalProcViewSet(CommonControlFieldViewSet):
@@ -89,6 +148,7 @@ class HTMLXMLViewSet(CommonControlFieldViewSet):
     menu_order = 300
     add_to_settings_menu = False
     inspect_view_enabled = True
+    filterset_class = HTMLXMLFilterSet
 
     list_per_page = 10
 
@@ -102,17 +162,6 @@ class HTMLXMLViewSet(CommonControlFieldViewSet):
         "n_paragraphs",
         "n_references",
         "created_updated",
-    ]
-    list_filter = [
-        "html2xml_status",
-        "quality",
-        "pdf_langs",
-        "html_translation_langs",
-        "article_type",
-        "empty_body",
-        "html_img_total",
-        "html_table_total",
-        "attention_demands",
     ]
     search_fields = [
         "migrated_article__pid",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -93,7 +93,7 @@ iso639-lang==2.6.3  # Mantendo versão maior
 -e git+https://github.com/scieloorg/packtools.git@4.13.6#egg=packtools
 -e git+https://github.com/scieloorg/scielo_scholarly_data#egg=scielo_scholarly_data
 -e git+https://github.com/scieloorg/opac_schema.git@v2.66#egg=opac_schema
--e git+https://github.com/scieloorg/scielo_migration.git@1.10.0#egg=scielo_classic_website
+-e git+https://github.com/scieloorg/scielo_migration.git@1.10.1#egg=scielo_classic_website
 
 # ========================================
 # Development & Testing


### PR DESCRIPTION
# Refatoração do fluxo de migração e tratamento de duplicações

## Resumo

Esta PR refatora o fluxo de migração de artigos e o tratamento de itens duplicados, movendo a exclusão de repetições para o nível de journal (ao invés de issue) e adicionando funcionalidade para remoção de issues duplicados.

## Principais mudanças

### Modelos

**article/models.py**
- `get_repeated_items`: alterado para receber `journal` ao invés de `queryset`, retornando queryset para melhor performance
- `exclude_repetitions`: reordenação da lógica e melhoria nos eventos de log

**issue/models.py**
- `Issue.get`: agora ordena por `-updated` para retornar o registro mais recente em caso de duplicatas
- Novo método `get_duplicates`: identifica issues duplicados por journal/volume/number/supplement

**package/models.py**
- Simplificação do tratamento de exceções ao deletar arquivos (remove logging desnecessário)

**htmlxml/models.py**
- Reordenação do fluxo em `generate_xml`: salva status DONE antes de gerar relatório, evitando perda de progresso em caso de erro no relatório
- Novo método `save_report` extraído para reutilização
- Melhoria no log de erros com traceback completo

**proc/models.py**
- `IssueProc.get_files_from_classic_website`: melhora lógica de `files_status` (PENDING/DONE/BLOCKED)
- `IssueProc.migrate_document_records`: `force_update` baseado na contagem de ArticleProc
- `ArticleProc.mark_for_reprocessing`: adiciona verificação de `docs_status` e `files_status` antes de marcar
- `ArticleProc.set_status`: simplificado para usar REPROC fixo
- `ArticleProc.get_xml`: usa `delete_files` ao invés de `os.unlink`

### Tarefas Celery

**proc/tasks.py**
- `task_migrate_and_publish_articles_by_journal`: agora chama `task_exclude_article_repetition` no início
- `task_migrate_and_publish_articles_by_issue`: 
  - Reordenação: migração de registros e arquivos antes de `mark_for_reprocessing`
  - Adicionado `sync_issue` para QA e PUBLIC ao final do processamento
- `task_exclude_article_repetition`: refatorada para processar por journal (antes era por issue)
- Nova task `task_remove_duplicate_issues`: remove issues duplicados mantendo o mais recente

### Interface Admin

**proc/wagtail_hooks.py**
- Novo `HTMLXMLFilterSet` com filtros booleanos personalizados (has_images, has_tables, has_attention_demands)

**article/wagtail_hooks.py**
- Adicionado `pid_v2` aos campos de busca

### Dependências

- Atualização de `scielo_migration` de 1.10.0 para 1.10.1

## Motivação

- Melhorar performance ao processar duplicações no nível de journal ao invés de issue
- Garantir que o status DONE seja salvo mesmo se houver erro na geração do relatório
- Adicionar funcionalidade para limpeza de issues duplicados
- Melhorar filtros na interface admin do HTMLXML

## Checklist

- [ ] Testes executados localmente
- [ ] Migrations geradas (se aplicável)
- [ ] Documentação atualizada (se aplicável)