### PR TITLE
Corrige publicacao artigo casos especiais de front

### DIFF
--- a/publication/api/document.py
+++ b/publication/api/document.py
@@ -46,7 +46,6 @@ class ArticlePayload:
     def __init__(self, data):
         self.data = data
         self.data["authors_meta"] = None
-        self.data["authors"] = None
         self.data["translated_titles"] = None
         self.data["translated_sections"] = None
         self.data["abstract"] = None
@@ -118,22 +117,10 @@ class ArticlePayload:
         # authors_meta"] = EmbeddedDocumentListField(AuthorMeta))
         self.data["authors_meta"] = self.data["authors_meta"] or []
         author = {}
-        author["surname"] = surname
-        author["given_names"] = given_names
-        author["suffix"] = suffix
         author["affiliation"] = affiliation
         author["orcid"] = orcid
+        author["name"] = format_author_name(surname, given_names, suffix)
         self.data["authors_meta"].append(author)
-
-        # # author
-        # if self.data["authors"] is None:
-        #     self.data["authors"] = []
-        # _author = format_author_name(
-        #     surname,
-        #     given_names,
-        #     suffix,
-        # )
-        # self.data["authors"].append(_author)
 
     def add_collab(self, name):
         # collab
@@ -160,6 +147,8 @@ class ArticlePayload:
 
     def add_abstract(self, language, text):
         # abstracts"] = EmbeddedDocumentListField(Abstract))
+        if not text:
+            return
         if self.data["abstracts"] is None:
             self.data["abstracts"] = []
         if self.data["abstract"] is None:

--- a/publication/utils/document.py
+++ b/publication/utils/document.py
@@ -183,7 +183,6 @@ class XMLArticle:
     def get_main_metadata(self):
         xml_article_titles = ArticleTitles(self.xmltree)
         xml_toc_section = ArticleTocSections(self.xmltree)
-        xml_abstracts = Abstract(self.xmltree)
         root = ArticleAndSubArticles(self.xmltree)
         xml_doi = DoiWithLang(self.xmltree)
 

--- a/publication/utils/document.py
+++ b/publication/utils/document.py
@@ -1,6 +1,6 @@
 import logging
 
-from packtools.sps.models.article_abstract import Abstract
+from packtools.sps.models.v2.article_abstract import XMLAbstracts
 from packtools.sps.models.article_and_subarticles import ArticleAndSubArticles
 from packtools.sps.models.article_contribs import ArticleContribs
 from packtools.sps.models.article_doi_with_lang import DoiWithLang
@@ -158,8 +158,12 @@ class XMLArticle:
 
     def get_abstracts(self):
         try:
-            for item in Abstract(self.xmltree).get_abstracts(style="only_p"):
-                yield {"language": item["lang"], "text": item["abstract"]}
+            for item in XMLAbstracts(self.xmltree).get_abstracts():
+                text = item.get("text")
+                lang = item.get("lang")
+                if not text:
+                    continue
+                yield {"language": lang, "text": text}
         except Exception as e:
             return []
 
@@ -172,15 +176,9 @@ class XMLArticle:
     def get_doi_with_lang(self):
         doi_with_lang = DoiWithLang(self.xmltree)
         for item in doi_with_lang.data:
+            if not item["value"]:
+                continue
             yield {"language": item["lang"], "doi": item["value"]}
-
-    def get_renditions(self):
-        root = ArticleAndSubArticles(self.xmltree)
-        for item in ArticleRenditions(self.xmltree).article_renditions:
-            yield {
-                "language": item["language"] or root.main_lang,
-                "uri": item.get("uri"),
-            }
 
     def get_main_metadata(self):
         xml_article_titles = ArticleTitles(self.xmltree)
@@ -189,9 +187,14 @@ class XMLArticle:
         root = ArticleAndSubArticles(self.xmltree)
         xml_doi = DoiWithLang(self.xmltree)
 
+        section = None
+        for sec in xml_toc_section.article_section:
+            section = sec.get("text")
+            break
+
         return dict(
-            title=xml_article_titles.article_title["text"],
-            section=xml_toc_section.article_section[0]["text"],
+            title=(xml_article_titles.article_title or {}).get("text"),
+            section=section,
             abstract=None,
             lang=root.main_lang,
             doi=xml_doi.main_doi,
@@ -201,11 +204,6 @@ class XMLArticle:
     def main_article_type(self):
         root = ArticleAndSubArticles(self.xmltree)
         return root.main_article_type
-
-    def get_htmls(self):
-        root = ArticleAndSubArticles(self.xmltree)
-        for item in root.data:
-            yield {"language": item["lang"]}
 
     def get_in_issue(self, order):
         aids = ArticleIds(self.xmltree)


### PR DESCRIPTION
### Descrição

Este PR contempla duas frentes principais de melhoria no módulo de publicações: a atualização da biblioteca de processamento de XML (`packtools`) para suporte à versão 2 dos abstracts e a correção da estrutura de metadados de autores enviada via API.

### Principais Mudanças

#### 1. Atualização da API de Abstracts (`publication/utils/document.py`)

* **Migração de Versão:** Substituição da classe `Abstract` pela `XMLAbstracts` do `packtools` v2.
* **Refatoração da Extração:** O acesso ao conteúdo agora utiliza o atributo `.text` em conformidade com o novo formato.
* **Resiliência de Código:** * Adicionada verificação de nulidade para o campo `DOI`.
* Tratamento de erro (`IndexError`) na extração de seções.
* Validação de nulidade no `article_title`.


* **Limpeza:** Remoção dos métodos obsoletos `get_renditions` e `get_htmls`.

#### 2. Correção no Payload de Autores (`publication/api/document.py`)

* **Persistência de Dados:** Removida a lógica que deletava acidentalmente a chave `authors` do payload original.
* **Simplificação de Metadados:** O método `add_author_meta` agora utiliza diretamente o nome formatado, reduzindo a complexidade da estrutura.
* **Validação:** Inclusão de check para textos vazios no método `add_abstract`.

---

### Issues Relacionadas

* **Fixes #801**: Erro na extração de abstracts após atualização do packtools.
* **Fixes #799**: Inconsistência no payload de autores e perda de dados na API.

### Como testar

1. Execute o processamento de um XML que contenha múltiplos abstracts (ex: pt, en).
2. Verifique se o campo `abstract` no JSON de saída contém o conteúdo textual correto (não o objeto XML bruto).
3. Valide via API se o payload de autores mantém a lista completa após a chamada do endpoint de documentos.
