### PR TITLE
Corrige a obtencao data de publicacao

### DIFF
--- a/package/models.py
+++ b/package/models.py
@@ -891,8 +891,14 @@ class SPSPkg(CommonControlField, ClusterableModel):
 
     @property
     def pub_date(self):
-        try:
-            xml_with_pre = self.xml_with_pre
-            return xml_with_pre.article_publication_date
-        except Exception as e:
-            return xml_with_pre.get_complete_publication_date()
+        # esta data deveria ser completa (AAAA-MM-DD)
+        xml_with_pre = self.xml_with_pre
+        if not xml_with_pre:
+            return None
+        pub_date = xml_with_pre.article_publication_date
+        if not pub_date:
+            return None
+        if len(pub_date) == 10:
+            return pub_date
+        # em caso de data incompleta, tenta retornar a data completa, completando com 06 o mes ausente e com 15 o dia ausente
+        return xml_with_pre.get_complete_publication_date()


### PR DESCRIPTION
## Pull Request: Melhoria no tratamento de datas de publicação

### Título
Refatora tratamento de datas de publicação em SPSPkg e ArticleProc

### Descrição

Este PR melhora a robustez no tratamento de datas de publicação de artigos, garantindo que sempre seja retornada uma data completa no formato `AAAA-MM-DD`.

### Mudanças realizadas

**package/models.py**
- Refatora a propriedade `pub_date` em `SPSPkg` substituindo o bloco `try/except` genérico por um fluxo condicional explícito
- Adiciona verificações de nulidade para `xml_with_pre` e `pub_date`
- Valida se a data possui 10 caracteres antes de retorná-la diretamente
- Utiliza `get_complete_publication_date()` apenas quando a data está incompleta

**proc/models.py**
- Separa o tratamento de exceções em `get_xml_from_native` para melhor rastreabilidade
- Isola a correção de `fig/inline-graphic` em bloco próprio
- Implementa lógica para garantir data de publicação completa:
  - Prioriza `processing_date` do documento migrado quando disponível
  - Aplica `get_complete_publication_date()` como fallback para completar mês (06) e dia (15) ausentes
- Atualiza o `article_publication_date` diretamente no `xml_with_pre` quando necessário

### Motivação

Artigos com datas de publicação incompletas (apenas ano ou ano-mês) causavam inconsistências em exportações e integrações. Esta mudança garante que todas as datas sejam normalizadas para o formato completo, utilizando fontes alternativas quando disponíveis.

### Testes sugeridos

- Verificar artigos com data completa (AAAA-MM-DD) - deve retornar sem alteração
- Verificar artigos com data parcial (AAAA ou AAAA-MM) - deve completar apropriadamente
- Verificar artigos sem `xml_with_pre` - deve retornar `None` sem erro
- Verificar migração de artigos com `processing_date` disponível