### PR TITLE
Aprimora a tarefa task_migrate_and_publish_articles_by_issue quanto à publicação e sincronização de issue

### DIFF
--- a/proc/tasks.py
+++ b/proc/tasks.py
@@ -1250,16 +1250,13 @@ def task_publish_articles(
                 total_scheduled = 0
                 task_exec.total_to_process = items_to_publish.count()
                 for article_proc in items_to_publish:
-                    celery_app.send_task(
-                        'proc.tasks.task_publish_article',
-                        kwargs=dict(
-                            user_id=user_id,
-                            username=username,
-                            website_kind=website_kind,
-                            article_proc_id=article_proc.id,
-                            api_data=api_data,
-                            force_update=force_update,
-                        )
+                    task_publish_article.delay(
+                        user_id=user_id,
+                        username=username,
+                        website_kind=website_kind,
+                        article_proc_id=article_proc.id,
+                        api_data=api_data,
+                        force_update=force_update,
                     )
                     total_scheduled += 1
                 task_exec.total_processed = total_scheduled
@@ -1269,7 +1266,7 @@ def task_publish_articles(
         exc_type, exc_value, exc_traceback = sys.exc_info()
         UnexpectedEvent.create(
             item=title,
-            action="proc.tasks.task_migrate_and_publish_articles",
+            action="proc.tasks.task_publish_articles",
             e=e,
             exc_traceback=exc_traceback,
             detail=task_params,

--- a/publication/utils/document.py
+++ b/publication/utils/document.py
@@ -1,6 +1,6 @@
 import logging
 
-from packtools.sps.models.v2.article_abstract import XMLAbstracts
+from packtools.sps.models.v2.abstract import XMLAbstracts
 from packtools.sps.models.article_and_subarticles import ArticleAndSubArticles
 from packtools.sps.models.article_contribs import ArticleContribs
 from packtools.sps.models.article_doi_with_lang import DoiWithLang


### PR DESCRIPTION

## Resumo

Refatora o sistema de tracking de progresso e separa a publicação de artigos por website em uma nova task.

## Alterações principais

**TaskExecution:** Remove atributos locais `total_to_process` e `total_processed`, delegando para `task_tracker` via properties.

**Nova task `task_sync_issue`:** Publica artigos e sincroniza issue de forma separada por website (QA/PUBLIC), extraída de `task_migrate_and_publish_articles_by_issue`.

**Correções de contagem:** Ajusta uso de variáveis locais para contagem correta em `task_publish_issues`, `task_migrate_and_publish_articles` e `task_migrate_and_publish_articles_by_journal`.

**Import:** Atualiza caminho do `XMLAbstracts` no packtools.

## Motivação

- Centralizar estado de progresso no `task_tracker`
- Permitir publicação paralela por website
- Corrigir contagem incorreta em loops aninhados