### PR TITLE
Corrige problema pid provider para obter registro pelo v3

### DIFF
--- a/article/models.py
+++ b/article/models.py
@@ -260,7 +260,7 @@ class Article(ClusterableModel, CommonControlField):
     def add_pp_xml(self, save=False):
         if not self.pp_xml:
             try:
-                self.pp_xml = PidProviderXML.objects.get(v3=self.pid_v3)
+                self.pp_xml = PidProviderXML.get_by_pid_v3(pid_v3=self.pid_v3)
             except PidProviderXML.DoesNotExist:
                 pass
             else:
@@ -483,7 +483,7 @@ class Article(ClusterableModel, CommonControlField):
         try:
             if self.pp_xml is None:
                 try:
-                    self.pp_xml = PidProviderXML.objects.get(v3=self.pid_v3)
+                    self.pp_xml = PidProviderXML.get_by_pid_v3(self.pid_v3)
                 except PidProviderXML.DoesNotExist:
                     return False
             sps_pkg__pkg_name = self.sps_pkg.xml_with_pre.sps_pkg_name

--- a/pid_provider/models.py
+++ b/pid_provider/models.py
@@ -1265,12 +1265,24 @@ class PidProviderXML(BasePidProviderXML, CommonControlField, ClusterableModel):
             response.update({"error_msg": str(e), "error_type": str(type(e))})
             return response
         return {}
+    
+    @classmethod
+    def get_by_pid_v3(cls, pid_v3, partial_pid_v2=None, pid_v2=None):
+        params = {}
+        if pid_v2:
+            params["v2"] = pid_v2
+        if partial_pid_v2:
+            params["v2__contains"] = partial_pid_v2
+        try:
+            return cls.objects.get(v3=pid_v3, **params)
+        except cls.MultipleObjectsReturned as e:
+            return cls.objects.filter(v3=pid_v3, **params).order_by("-updated").first()
 
     @classmethod
     @profile_classmethod
     def fix_pid_v2(cls, user, pid_v3, correct_pid_v2):
         try:
-            item = cls.objects.get(v3=pid_v3)
+            item = cls.get_by_pid_v3(pid_v3)
         except cls.DoesNotExist as e:
             raise cls.DoesNotExist(f"{e}: {pid_v3}")
 

--- a/pid_provider/requester.py
+++ b/pid_provider/requester.py
@@ -272,8 +272,8 @@ class PidRequester(BasePidProvider):
         }
 
         try:
-            pid_provider_xml = PidProviderXML.objects.get(
-                v3=pid_v3, v2__contains=correct_pid_v2[:14]
+            pid_provider_xml = PidProviderXML.get_by_pid_v3(
+                pid_v3, partial_pid_v2=correct_pid_v2[:14]
             )
             fixed["pid_v2"] = pid_provider_xml.v2
         except PidProviderXML.DoesNotExist:


### PR DESCRIPTION
#### O que esse PR faz?

Este PR refatora a busca de objetos `PidProviderXML` para centralizar a lógica de consulta. Ele introduz o método `get_by_pid_v3`, que lida com casos de múltiplos registros retornados (retornando o mais recente baseado em `updated`), evitando exceções de `MultipleObjectsReturned` e garantindo consistência em diferentes partes do sistema.

#### Onde a revisão poderia começar?

A revisão deve começar por `pid_provider/models.py`, onde o método `classmethod` `get_by_pid_v3` foi implementado, pois ele é a base para as alterações nos outros arquivos.

#### Como este poderia ser testado manualmente?

1. Certifique-se de ter registros de `PidProviderXML` no banco de dados.
2. Tente forçar um cenário com dois registros possuindo o mesmo `v3` mas datas de `updated` diferentes.
3. Chame `PidProviderXML.get_by_pid_v3(seu_pid_v3)` via shell do Django e verifique se ele retorna o objeto mais recente sem estourar erro.
4. Verifique se as páginas de `Article` que dependem do `pp_xml` continuam carregando corretamente.

#### Algum cenário de contexto que queira dar?

Atualmente, o código utilizava `objects.get(v3=...)` diretamente em vários lugares. Se por algum motivo de concorrência ou erro de importação houvesse duplicidade de PIDs, o sistema quebrava. Centralizar isso em um método com critério de desempate (`order_by("-updated")`) torna o sistema mais resiliente.

### Screenshots

N/A (Alteração de lógica de backend).

#### Quais são tickets relevantes?
fixes #808 

### Referências

* Documentação do Django sobre [[QuerySet.first()](https://www.google.com/search?q=https://docs.djangoproject.com/en/stable/ref/models/querysets/%23first)](https://www.google.com/search?q=https://docs.djangoproject.com/en/stable/ref/models/querysets/%23first).
* Melhores práticas de refatoração DRY (Don't Repeat Yourself).
