### PR TITLE
Corrige problema ao tentar registrar erros na importação dos arquivos do site clássico 

### DIFF
--- a/migration/controller.py
+++ b/migration/controller.py
@@ -463,11 +463,15 @@ def migrate_issue_files(user, collection, journal_acron, issue_folder, force_upd
             issue_folder,
         )
         for file in files_and_exceptions:
+            exception = {}
             try:
                 if not file:
                     continue
+
+                exception["file"] = file.get("path")
                 if file.get("error"):
-                    exceptions.append(file)
+                    exception["error"] = file["error"]
+                    exceptions.append(exception)
                     continue
 
                 component_type = check_component_type(file)
@@ -491,7 +495,9 @@ def migrate_issue_files(user, collection, journal_acron, issue_folder, force_upd
                 )
 
             except Exception as e:
-                exceptions.append({"error": str(e), "type": str(type(e)), "file": file})
+                exception["error"] = str(e)
+                exception["type"] = str(type(e))
+                exceptions.append(exception)
 
     except Exception as e:
         exceptions.append(


### PR DESCRIPTION
#### O que esse PR faz?

Este PR refatora a captura de erros na função `migrate_issue_files`. Ele soluciona o problema de logs inconsistentes ao garantir que todas as exceções (sejam de validação ou de runtime) capturem obrigatoriamente o caminho do arquivo e a mensagem de erro em um formato padronizado.

#### Onde a revisão poderia começar?

A revisão deve focar no arquivo `migration/controller.py`, especificamente dentro do loop de `files_and_exceptions` (linhas 463-497), onde a lógica de montagem do dicionário `exception` foi centralizada.

#### Como este poderia ser testado manualmente?

1. Execute o script de migração apontando para um diretório que contenha arquivos com erro (ex: falta de permissão ou XML inválido).
2. Verifique o retorno da lista `exceptions`.
3. Valide se cada entrada da lista contém as chaves `"file"`, `"error"` e, em caso de erro de execução, a chave `"type"`.

#### Algum cenário de contexto que queira dar?

Anteriormente, alguns erros adicionavam o objeto `file` inteiro à lista de exceções, o que gerava logs muito grandes e de difícil leitura. A mudança isola apenas os metadados necessários para o diagnóstico do erro.

### Screenshots

*Não aplicável (alteração de backend).*

#### Quais são tickets relevantes?

#810 

### Referências

*Documentação interna de padronização de logs de migração.*
