### PR TITLE
corrige uma exceção fatal do tipo `SPSPkg.DoesNotExist` que interrompia o processamento da tarefa de correção de nomes de pacotes SPStrata exceção DoesNotExist ao corrigir nomes de pacotes SPS

### DIFF
--- a/article/models.py
+++ b/article/models.py
@@ -513,7 +513,7 @@ class Article(ClusterableModel, CommonControlField):
 
                 try:
                     data["pp_xml__pkg_name"] = item.pp_xml.pkg_name
-                    data["pp_xml__pkg_name_fixed"] = item.pp_xml.fix_pkg_name(data["sps_pkg__pkg_name"])
+                    data["pp_xml__pkg_name_fixed"] = item.pp_xml.fix_pkg_name(data.get("sps_pkg__pkg_name"))
                 except Exception as e:
                     data["pp_xml__pkg_name_exception"] = traceback.format_exc()
 

--- a/pid_provider/models.py
+++ b/pid_provider/models.py
@@ -1428,7 +1428,9 @@ class PidProviderXML(BasePidProviderXML, CommonControlField, ClusterableModel):
             )
 
     def fix_pkg_name(self, pkg_name):
-        if self.pkg_name != pkg_name:
+        if not pkg_name:
+            pkg_name = self.xml_with_pre.sps_pkg_name
+        if pkg_name and self.pkg_name != pkg_name:
             self.pkg_name = pkg_name
             self.save()
             return True


### PR DESCRIPTION
#### O que esse PR faz?

Este PR corrige uma exceção fatal do tipo `SPSPkg.DoesNotExist` que interrompia o processamento da tarefa de correção de nomes de pacotes SPS. A alteração torna o método `fix_sps_pkg_names` mais resiliente, garantindo que a ausência de um relacionamento no banco de dados (como um `sps_pkg` ou `pp_xml` órfão) não cause o crash de todo o lote de processamento.

#### Onde a revisão poderia começar?

A revisão deve começar pelo arquivo `article/models.py`, especificamente no método `fix_sps_pkg_names` (linha 500) e na nova verificação de segurança em `fix_sps_pkg_name` (linha 525).

#### Como este poderia ser testado manualmente?

1. Certifique-se de ter um ambiente com registros de `Article` que **não** possuem um `SPSPkg` associado (ou delete a relação de um artigo específico via shell).
2. Execute a tarefa/método `fix_sps_pkg_names` passando uma query que inclua este artigo problemático.
3. **Resultado esperado:** O processo deve concluir com sucesso. O dicionário retornado para o artigo sem o pacote deve conter a chave `sps_pkg__pkg_name_exception` com o traceback, em vez de interromper a execução do código.

#### Algum cenário de contexto que queira dar?

O erro ocorria porque o Django tenta buscar o objeto relacionado ao acessar `item.sps_pkg`. Quando esse registro não existe fisicamente na tabela relacionada, uma exceção `DoesNotExist` é lançada. Como o código anterior acessava o atributo diretamente dentro de um dicionário e em condições `if` sem o devido tratamento granular, a falha em um único artigo impedia a correção de todos os outros 400+ artigos do jornal.

### Screenshots

*Não se aplica (alteração de lógica de backend).*

#### Quais são tickets relevantes?

* Relacionado à correção de processamento do Journal ID: 15 (Enfermería Scielo Costa Rica).
* Reportado via Traceback em `task_exclude_article_repetition`.

### Referências

* [[Django Documentation - Related objects](https://www.google.com/search?q=https://docs.djangoproject.com/en/stable/ref/models/relations/)](https://www.google.com/search?q=https://docs.djangoproject.com/en/stable/ref/models/relations/)
* [[Python Traceback module](https://docs.python.org/3/library/traceback.html)](https://docs.python.org/3/library/traceback.html)
