### PR TITLE
fix: adiciona setuptools aos wheels para resolver ModuleNotFoundError: pkg_resources

### DIFF
--- a/compose/production/django/Dockerfile
+++ b/compose/production/django/Dockerfile
@@ -22,7 +22,10 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 COPY ./requirements .
 
 # Update pip
-RUN python -m pip install --upgrade pip
+RUN python -m pip install --upgrade pip setuptools wheel
+
+# Garantir que setuptools esteja nos wheels
+RUN pip wheel --wheel-dir /usr/src/app/wheels setuptools>=68.2.2
 
 # Create Python Dependency and Sub-Dependency Wheels.
 RUN pip wheel --wheel-dir /usr/src/app/wheels  \


### PR DESCRIPTION
## Descrição

### Problema

O container de produção falhava ao iniciar com o erro:

```
ModuleNotFoundError: No module named 'pkg_resources'
```

O erro ocorria porque a biblioteca `packtools` depende do `pkg_resources` (parte do `setuptools`), mas o `setuptools` não estava sendo incluído nos wheels durante o build.

### Causa raiz

O Dockerfile usa `--no-index` na instalação dos wheels, impedindo acesso ao PyPI. Como o `setuptools` não era explicitamente adicionado aos wheels no build stage, ele não era instalado no container final.

### Solução

- Atualizado o comando de upgrade do pip para incluir `setuptools` e `wheel`
- Adicionado comando para gerar wheel do `setuptools>=68.2.2` antes das demais dependências

Fixes #841 

### Arquivos alterados

- `compose/production/django/Dockerfile`

### Teste

```bash
docker-compose -f production.yml build --no-cache
docker-compose -f production.yml run --rm django python -c "import pkg_resources; print('OK')"
```