### PR TITLE
Add install sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,13 +1,22 @@
 #!/bin/bash
+#
+# Bash script for SciELO Upload Installation/Update
+#
+# How it works:
+#       ./install <Upload version>
+#
+#     Check the tag version at https://github.com/scieloorg/scms-upload/releases
 
-upload_version=$1
+
 if [ ! $1 ]; then
+    # Version is mandatory
     echo "Version not informed. Please, inform the Upload version. E.g.: v2.3.4, ./install.sh v2.3.4"
     exit 128
 fi
 
 UPLOAD_DIR=./upload
 ENV_FILES_DIR=.envs/.production
+IS_UPDATE=0
 
 echo "Checking directory $UPLOAD_DIR$ENV_FILES_DIR ..."
 
@@ -24,19 +33,26 @@ else
     echo "  Downloading files from Git repository ..."
     cd $UPLOAD_DIR
     wget -O Makefile https://raw.githubusercontent.com/scieloorg/scms-upload/refs/tags/$1/Makefile
-    #wget -O production.yml https://raw.githubusercontent.com/scieloorg/scms-upload/refs/tags/$1/production.yml
+    wget -O production.yml https://raw.githubusercontent.com/scieloorg/scms-upload/refs/tags/$1/production.yml
+    IS_UPDATE=1
 fi
-
 
 echo $1 > VERSION
 
 echo "Version $(cat VERSION) installed/updated!"
 
-read -p "Enter the Docker login user: " DOCKER_USER
-docker login -u $DOCKER_USER
+if [ $IS_UPDATE -eq 1 ]; then
+    # For installation: make Docker login and build DB
+    read -p "Enter the Docker login user: " DOCKER_USER
+    docker login -u $DOCKER_USER
+    make build compose=production.yml
+    make django_migrate compose=production.yml
+else
+    # For updating: update Django containers and make DB migrations
+    make update_webapp compose=production.yml
+    make django_migrate_fresh_migrations compose=production.yml
+fi
 
-make build compose=production.yml
-make django_migrate compose=production.yml
 make up compose=production.yml
 make ps compose=production.yml
 

--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ UPLOAD_DIR=./upload
 ENV_FILES_DIR=.envs/.production
 IS_UPDATE=0
 
-echo "Checking directory $UPLOAD_DIR$ENV_FILES_DIR ..."
+echo "Checking directory $UPLOAD_DIR/$ENV_FILES_DIR ..."
 
 if [ ! -d "$UPLOAD_DIR/$ENV_FILES_DIR" ]; then
     echo "Installing version $1 ..."

--- a/install.sh
+++ b/install.sh
@@ -3,10 +3,11 @@
 # Bash script for SciELO Upload Installation/Update
 #
 # How it works:
-#       ./install <Upload version>
+#       ./install.sh <Upload version>
 #
 #     Check the tag version at https://github.com/scieloorg/scms-upload/releases
 
+set -euo pipefail
 
 if [ -z "$1" ]; then
     # Version is mandatory
@@ -22,35 +23,35 @@ echo "Checking directory $UPLOAD_DIR$ENV_FILES_DIR ..."
 
 if [ ! -d "$UPLOAD_DIR/$ENV_FILES_DIR" ]; then
     echo "Installing version $1 ..."
-    git clone --no-checkout --filter=blob:none --depth=1 --branch $1 --sparse https://github.com/scieloorg/scms-upload $UPLOAD_DIR
-    cd $UPLOAD_DIR
+    git clone --no-checkout --filter=blob:none --depth=1 --branch "$1" --sparse https://github.com/scieloorg/scms-upload $UPLOAD_DIR
+    cd "$UPLOAD_DIR"
     git sparse-checkout init --cone
-    git sparse-checkout set .envs/.production-template compose/production/postgres/maintenance
-    git checkout $1
-    mv .envs/.production-template $ENV_FILES_DIR
+    git sparse-checkout set .envs/.production-template compose/production/postgres/maintenance Makefile production.yml
+    git checkout "$1"
+    mv .envs/.production-template "$ENV_FILES_DIR"
 else
     echo "Updating to version $1 ..."
     echo "  Downloading files from Git repository ..."
-    cd $UPLOAD_DIR
-    wget -O Makefile https://raw.githubusercontent.com/scieloorg/scms-upload/refs/tags/$1/Makefile
-    wget -O production.yml https://raw.githubusercontent.com/scieloorg/scms-upload/refs/tags/$1/production.yml
+    cd "$UPLOAD_DIR"
+    wget -O Makefile "https://raw.githubusercontent.com/scieloorg/scms-upload/refs/tags/$1/Makefile"
+    wget -O production.yml "https://raw.githubusercontent.com/scieloorg/scms-upload/refs/tags/$1/production.yml"
     IS_UPDATE=1
 fi
 
-echo $1 > VERSION
+echo "$1" > VERSION
 
 echo "Version $(cat VERSION) installed/updated!"
 
-if [ $IS_UPDATE -eq 1 ]; then
+if [ "$IS_UPDATE" -eq 1 ]; then
+    # For updating: update Django containers and make DB migrations
+    make update_webapp compose=production.yml
+    make django_migrate_fresh_migrations compose=production.yml
+else
     # For installation: make Docker login and build DB
     read -p "Enter the Docker login user: " DOCKER_USER
     docker login -u $DOCKER_USER
     make build compose=production.yml
     make django_migrate compose=production.yml
-else
-    # For updating: update Django containers and make DB migrations
-    make update_webapp compose=production.yml
-    make django_migrate_fresh_migrations compose=production.yml
 fi
 
 make up compose=production.yml

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@
 #     Check the tag version at https://github.com/scieloorg/scms-upload/releases
 
 
-if [ ! $1 ]; then
+if [ -z "$1" ]; then
     # Version is mandatory
     echo "Version not informed. Please, inform the Upload version. E.g.: v2.3.4, ./install.sh v2.3.4"
     exit 128

--- a/install.sh
+++ b/install.sh
@@ -23,7 +23,7 @@ echo "Checking directory $UPLOAD_DIR$ENV_FILES_DIR ..."
 
 if [ ! -d "$UPLOAD_DIR/$ENV_FILES_DIR" ]; then
     echo "Installing version $1 ..."
-    git clone --no-checkout --filter=blob:none --depth=1 --branch "$1" --sparse https://github.com/scieloorg/scms-upload $UPLOAD_DIR
+    git clone --no-checkout --filter=blob:none --depth=1 --branch "$1" --sparse https://github.com/scieloorg/scms-upload "$UPLOAD_DIR"
     cd "$UPLOAD_DIR"
     git sparse-checkout init --cone
     git sparse-checkout set .envs/.production-template compose/production/postgres/maintenance Makefile production.yml
@@ -49,7 +49,7 @@ if [ "$IS_UPDATE" -eq 1 ]; then
 else
     # For installation: make Docker login and build DB
     read -p "Enter the Docker login user: " DOCKER_USER
-    docker login -u $DOCKER_USER
+    docker login -u "$DOCKER_USER"
     make build compose=production.yml
     make django_migrate compose=production.yml
 fi

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+upload_version=$1
+if [ ! $1 ]; then
+    echo "Version not informed. Please, inform the Upload version. E.g.: v2.3.4, ./install.sh v2.3.4"
+    exit 128
+fi
+
+UPLOAD_DIR=./upload
+ENV_FILES_DIR=.envs/.production
+
+echo "Checking directory $UPLOAD_DIR$ENV_FILES_DIR ..."
+
+if [ ! -d "$UPLOAD_DIR/$ENV_FILES_DIR" ]; then
+    echo "Installing version $1 ..."
+    git clone --no-checkout --filter=blob:none --depth=1 --branch $1 --sparse https://github.com/scieloorg/scms-upload $UPLOAD_DIR
+    cd $UPLOAD_DIR
+    git sparse-checkout init --cone
+    git sparse-checkout set .envs/.production-template compose/production/postgres/maintenance
+    git checkout $1
+    mv .envs/.production-template $ENV_FILES_DIR
+else
+    echo "Updating to version $1 ..."
+    echo "  Downloading files from Git repository ..."
+    cd $UPLOAD_DIR
+    wget -O Makefile https://raw.githubusercontent.com/scieloorg/scms-upload/refs/tags/$1/Makefile
+    #wget -O production.yml https://raw.githubusercontent.com/scieloorg/scms-upload/refs/tags/$1/production.yml
+fi
+
+
+echo $1 > VERSION
+
+echo "Version $(cat VERSION) installed/updated!"
+
+read -p "Enter the Docker login user: " DOCKER_USER
+docker login -u $DOCKER_USER
+
+make build compose=production.yml
+make django_migrate compose=production.yml
+make up compose=production.yml
+make ps compose=production.yml
+
+cd -
+exit 0 
+


### PR DESCRIPTION
#### O que esse PR faz?
Automatiza os passos da instalação descritos no documento https://github.com/scieloorg/opac_5/wiki/Upload-application-installation e de atualização descritos em https://github.com/scieloorg/opac_5/wiki/How-to-update-opac_5-and-upload#how-to-update-upload. Após script encorporado, o documento será atualizado para a execução do script.

#### Onde a revisão poderia começar?
Em `install.sh`

#### Como este poderia ser testado manualmente?

##### Para a instalação
1. Baixar o script `install.sh` em um diretório vazio, onde o diretório da aplicação será criado
2. Alterar o chmod do script para que seja executável: `chmod +x install.sh`
3. Executar script com a versão a ser instalada: `./install.sh v2.11.9`
4. O resultado final é ter os conteineres do Upload rodando com a versão instalada

##### Para a atualização
1. Baixar o script `install.sh` em um diretório onde está o diretório do upload. Ex.: path do upload: `/var/www/upload`, path do script: `/var/www/install.sh`
2. Alterar o chmod do script para que seja executável: `chmod +x install.sh`
3. Executar script com a versão a ser atualizada: `./install.sh v2.11.9`
4. O resultado final é ter os conteineres do Upload rodando com a nova versão

#### Algum cenário de contexto que queira dar?
Melhorias no processo de instalação da nova plataforma

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
.

