### PR TITLE
Flexibiliza a busca de documentos no `PidProviderXML` (Compatibiliza pid provider core)

### DIFF
--- a/pid_provider/models.py
+++ b/pid_provider/models.py
@@ -1272,14 +1272,16 @@ class PidProviderXML(BasePidProviderXML, CommonControlField, ClusterableModel):
     @classmethod
     def get_by_pid_v3(cls, pid_v3, partial_pid_v2=None, pid_v2=None):
         params = {}
+        if pid_v3:
+            params["v3"] = pid_v3
         if pid_v2:
             params["v2"] = pid_v2
         if partial_pid_v2:
             params["v2__contains"] = partial_pid_v2
         try:
-            return cls.objects.get(v3=pid_v3, **params)
+            return cls.objects.get(**params)
         except cls.MultipleObjectsReturned as e:
-            return cls.objects.filter(v3=pid_v3, **params).order_by("-updated").first()
+            return cls.objects.filter(**params).order_by("-updated").first()
 
     @classmethod
     @profile_classmethod

--- a/pid_provider/query_params.py
+++ b/pid_provider/query_params.py
@@ -63,9 +63,19 @@ class QueryBuilderPidProviderXML:
     
     @cached_property
     def pkg_name(self):
-        """Nome do pacote do documento."""
+        """Nome do pacote do documento, parâmtro usado ao instanciar XMLAdapter"""
         return self.xml_adapter.pkg_name
-    
+
+    @cached_property
+    def sps_pkg_name(self):
+        """Nome do pacote do documento (deprecated)."""
+        return self.xml_adapter.sps_pkg_name
+
+    @cached_property
+    def deprecated_sps_pkg_name(self):
+        """Nome do pacote do documento (deprecated)."""
+        return self.xml_adapter.sps_pkg_name
+
     @cached_property
     def main_doi(self):
         """DOI principal do documento."""
@@ -176,8 +186,15 @@ class QueryBuilderPidProviderXML:
             q |= Q(v2=self.aop_pid) | Q(aop_pid=self.aop_pid)
             
         # Package name
+        pkg_names = set()
         if self.pkg_name:
-            q |= Q(pkg_name=self.pkg_name)
+            pkg_names.add(self.pkg_name)
+        if self.sps_pkg_name:
+            pkg_names.add(self.sps_pkg_name)
+        if self.deprecated_sps_pkg_name:
+            pkg_names.add(self.deprecated_sps_pkg_name)
+        if pkg_names:
+            q |= Q(pkg_name__in=pkg_names)
 
         # # DOI principal
         # if self.main_doi:


### PR DESCRIPTION
#### O que esse PR faz?

Flexibiliza a busca de documentos no `PidProviderXML` tornando `pid_v3` opcional em `get_by_pid_v3` e amplia as variantes de `pkg_name` consideradas pelo `QueryBuilderPidProviderXML`.

**`pid_provider/models.py`**
- Torna `pid_v3` condicional nos parâmetros de busca: o campo `v3` só é incluído no filtro quando o valor é fornecido, evitando falhas quando a busca é feita exclusivamente por `pid_v2` ou `partial_pid_v2`.

**`pid_provider/query_params.py`**
- Adiciona `cached_property sps_pkg_name` expondo `xml_adapter.sps_pkg_name`.
- Adiciona `cached_property deprecated_sps_pkg_name` como alias de `sps_pkg_name` para retrocompatibilidade.
- Consolida a busca por `pkg_name` usando `Q(pkg_name__in=pkg_names)`, considerando simultaneamente `pkg_name`, `sps_pkg_name` e `deprecated_sps_pkg_name`.

#### Onde a revisão poderia começar?

1. `pid_provider/models.py` → método `get_by_pid_v3`: verificar se a condicionalidade de `pid_v3` não abre margem para retornos ambíguos quando nenhum dos três parâmetros é fornecido.
2. `pid_provider/query_params.py` → propriedades `sps_pkg_name` / `deprecated_sps_pkg_name` e bloco de montagem do `Q` para `pkg_name`: confirmar que os três nomes cobrem todos os formatos de pacote em uso.

#### Como este poderia ser testado manualmente?

1. Chamar `get_by_pid_v3` passando apenas `pid_v2` (sem `pid_v3`) e verificar que o documento correto é retornado sem `DoesNotExist` ou `FieldError`.
2. Chamar `get_by_pid_v3` passando apenas `pid_v3` e confirmar comportamento inalterado.
3. Indexar um documento cujo `pkg_name` difere de `sps_pkg_name` e verificar que a busca via `QueryBuilderPidProviderXML` o localiza corretamente pelo `Q(pkg_name__in=...)`.
4. Verificar que documentos sem nenhum `pkg_name` válido não são retornados incorretamente.

#### Algum cenário de contexto que queira dar?

Em alguns fluxos do pipeline de ingestão o `pid_v3` pode não estar disponível no momento da consulta (ex.: documentos em fase de migração ou reprocessamento), fazendo com que a busca precise se apoiar exclusivamente em `pid_v2` ou `partial_pid_v2`. A rigidez anterior do `get_by_pid_v3` causava falhas nesses cenários.

Da mesma forma, diferentes versões do pacote SPS geram nomes de pacote em formatos distintos (`pkg_name` vs `sps_pkg_name`), e a busca anterior considerava apenas uma das variantes, deixando documentos legítimos fora do resultado.

### Screenshots

_N/A — alterações de lógica de consulta, sem impacto visual._

#### Quais são tickets relevantes?

_A preencher._

### Referências

- `PidProviderXML.get_by_pid_v3` — `pid_provider/models.py`
- `QueryBuilderPidProviderXML` — `pid_provider/query_params.py`