### PR TITLE
Garante processamento de issues com artigos pendentes, limita coleta no OPAC e remove xml_with_pre do registro

### DIFF
--- a/pid_provider/requester.py
+++ b/pid_provider/requester.py
@@ -246,13 +246,19 @@ class PidRequester(BasePidProvider):
                 resp["synchronized"] = registered.get("registered_in_core") and bool(
                     resp.get("v3")
                 )
-                registered.update(resp)
+                try:
+                    resp.pop("xml_with_pre")
+                except KeyError:
+                    pass
 
                 detail = resp
+                registered.update(resp)
 
             op.finish(user, completed=True, detail=detail)
             return resp
         except Exception as e:
+            logging.exception(e)
+            logging.error(detail)
             exc_type, exc_value, exc_traceback = sys.exc_info()
             op.finish(user, completed=False, exception=e, exc_traceback=exc_traceback)
             return {"error_msg": str(e), "error_type": str(type(e))}

--- a/pid_provider/tasks.py
+++ b/pid_provider/tasks.py
@@ -80,6 +80,7 @@ def task_load_records_from_counter_dict(
     timeout=None,
     force_update=None,
     opac_domain=None,
+    stop=None,
 ):
     """
     Coleta documentos de uma coleção específica via endpoint counter_dict do OPAC.
@@ -100,6 +101,8 @@ def task_load_records_from_counter_dict(
         timeout (int, optional): Timeout em segundos para requisições HTTP
         force_update (bool, optional): Força atualização mesmo se já existe
         opac_domain (str, optional): Domínio do OPAC (default: "www.scielo.br")
+        stop (int, optional): Quantidade máxima de itens a coletar.
+            Se None, coleta todos os itens disponíveis.
 
     Returns:
         None
@@ -134,6 +137,7 @@ def task_load_records_from_counter_dict(
         )
 
         # Itera sobre documentos e dispara tarefas individuais
+        count = 0
         for document in harvester.harvest_documents():
             origin_date = document.get("origin_date")
             task_load_record_from_xml_url.delay(
@@ -145,6 +149,9 @@ def task_load_records_from_counter_dict(
                 origin_date=origin_date,
                 force_update=force_update,
             )
+            count += 1
+            if stop and count >= stop:
+                break
 
     except Exception as e:
         exc_type, exc_value, exc_traceback = sys.exc_info()
@@ -244,4 +251,5 @@ def task_load_record_from_xml_url(
                 "force_update": force_update,
             },
         )
+
 

--- a/proc/tasks.py
+++ b/proc/tasks.py
@@ -948,6 +948,14 @@ def task_migrate_and_publish_articles_by_journal(
         task_exec.add_event(f"Select journal issues which docs_status or files_status in {status} and/or has articles to process")
 
         events = []
+        article_issue_proc_list = ArticleProc.objects.filter(issue_proc__journal_proc=journal_proc).filter(
+            Q(migration_status__in=status)
+            | Q(xml_status__in=status)
+            | Q(sps_pkg_status__in=status)
+            | Q(qa_ws_status__in=status)
+            | Q(public_ws_status__in=status)
+        ).values_list("issue_proc__id", "issue_proc__pid").distinct()
+
         issue_proc_list = IssueProc.get_id_and_pid_list_to_process(
             journal_proc,
             issue_folder,
@@ -956,7 +964,9 @@ def task_migrate_and_publish_articles_by_journal(
             status,
             events,
         )
-        total_issues_to_process = issue_proc_list.count()
+
+        issue_proc_list = set(issue_proc_list) | set(article_issue_proc_list)
+        total_issues_to_process = len(issue_proc_list)
         task_exec.add_event(events)
         task_exec.add_number("total_issues_to_process", total_issues_to_process)
         task_exec.total_to_process = total_issues_to_process


### PR DESCRIPTION
#### O que esse PR faz?

Corrige e aprimora o fluxo de registro de PIDs, a coleta de documentos via counter_dict e a seleção de issues para migração/publicação de artigos.

As principais mudanças são:

1. **PidRequester (`pid_provider/requester.py`):** Remove a chave `xml_with_pre` do dicionário de resposta antes de atualizar o registro, evitando armazenar dados desnecessários. Adiciona `logging.exception` e `logging.error` no bloco de exceção para facilitar a depuração de falhas.

2. **Task de coleta via counter_dict (`pid_provider/tasks.py`):** Introduz o parâmetro opcional `stop` que permite limitar a quantidade de itens coletados do OPAC, útil para testes e execuções controladas.

3. **Seleção de issues para processamento (`proc/tasks.py`):** Amplia a lógica de seleção de issues incluindo aquelas que possuem artigos (`ArticleProc`) com status pendente em qualquer uma das etapas do pipeline (migration, xml, sps_pkg, qa_ws, public_ws), garantindo que não sejam ignoradas pela consulta original em `IssueProc`.

#### Onde a revisão poderia começar?

Por `proc/tasks.py`, na função `task_migrate_and_publish_articles_by_journal`, onde a nova consulta em `ArticleProc` é feita e unida à lista existente de `issue_proc_list`. Em seguida, `pid_provider/requester.py` para verificar a remoção do `xml_with_pre` e o logging adicionado.

#### Como este poderia ser testado manualmente?

- **requester.py:** Executar o fluxo de registro de um PID e verificar nos logs que, em caso de erro, o `detail` e o traceback completo são registrados. Confirmar que o campo `xml_with_pre` não aparece no dicionário `registered` após a atualização.
- **tasks.py (counter_dict):** Chamar `task_load_records_from_counter_dict` com `stop=5` e verificar que apenas 5 tarefas individuais são disparadas. Chamar sem `stop` e confirmar que todos os itens são coletados normalmente.
- **tasks.py (proc):** Criar um cenário onde um `ArticleProc` tenha, por exemplo, `migration_status` pendente mas o `IssueProc` correspondente não esteja na lista retornada por `get_id_and_pid_list_to_process`. Verificar que a issue agora é incluída no processamento.

#### Algum cenário de contexto que queira dar?

O problema principal que motivou a mudança em `proc/tasks.py` é que issues cujo `IssueProc` não atendia aos critérios de `get_id_and_pid_list_to_process` eram ignoradas mesmo contendo artigos com status pendente, causando artigos "presos" no pipeline. A união das duas listas resolve esse gap.

A remoção do `xml_with_pre` em `requester.py` evita que dados volumosos de XML sejam propagados desnecessariamente no dicionário de registro, reduzindo uso de memória e ruído nos logs.

O parâmetro `stop` na task de coleta é uma adição prática para execuções de teste e depuração em ambientes com grandes volumes de documentos.

### Screenshots

N/A

#### Quais são tickets relevantes?

(preencher com os tickets relacionados)

### Referências

N/A