### PR TITLE
refactor(proc/tasks): corrige seleção de artigos para migração e publicação

### DIFF
--- a/migration/controller.py
+++ b/migration/controller.py
@@ -768,7 +768,7 @@ def import_journal_acron_id_records(
             if item["item_type"] == "article":
                 issue_pids.add(item["item_pid"][1:-5])
 
-        selected_issue_procs = journal_proc.issue_proc_set.filter(
+        selected_issue_procs = journal_proc.issueproc_set.filter(
             pid__in=issue_pids,
         )
         selected_issue_procs.exclude(

--- a/migration/controller.py
+++ b/migration/controller.py
@@ -778,13 +778,17 @@ def import_journal_acron_id_records(
             docs_status=tracker_choices.PROGRESS_STATUS_REPROC,
             updated_by=user,
         )
-        for issue_proc in selected_issue_procs:
-            issue_proc.article_proc_set.exclude(
-                xml_status__in=tracker_choices.PROGRESS_STATUS_REGULAR_TODO
-            ).update(
-                xml_status=tracker_choices.PROGRESS_STATUS_REPROC,
-                updated_by=user,
-            )
+        article_proc_model = (
+            selected_issue_procs.model.article_proc_set.rel.related_model
+        )
+        article_proc_model.objects.filter(
+            issue_proc__in=selected_issue_procs
+        ).exclude(
+            xml_status__in=tracker_choices.PROGRESS_STATUS_REGULAR_TODO
+        ).update(
+            xml_status=tracker_choices.PROGRESS_STATUS_REPROC,
+            updated_by=user,
+        )
 
         qs = journal_id_file.id_file_records.filter(item_type="article")
         total_id_file_records = qs.count()

--- a/migration/controller.py
+++ b/migration/controller.py
@@ -703,6 +703,7 @@ def get_migrated_xml_with_pre(article_proc):
 
 def import_journal_acron_id_records(
     user,
+    article_proc_model,
     journal_proc,
     force_update,
 ):
@@ -777,9 +778,6 @@ def import_journal_acron_id_records(
         ).update(
             docs_status=tracker_choices.PROGRESS_STATUS_REPROC,
             updated_by=user,
-        )
-        article_proc_model = (
-            selected_issue_procs.model.articleproc_set.rel.related_model
         )
         article_proc_model.objects.filter(
             issue_proc__in=selected_issue_procs

--- a/migration/controller.py
+++ b/migration/controller.py
@@ -752,7 +752,6 @@ def import_journal_acron_id_records(
 
         issue_pids = set()
 
-        total_id_file_records_to_migrate = 0
         for item in get_bases_work_acron_id_file_records(
             user,
             source_path,
@@ -767,7 +766,6 @@ def import_journal_acron_id_records(
                 **item,
             )
             if item["item_type"] == "article":
-                total_id_file_records_to_migrate += 1
                 issue_pids.add(item["item_pid"][1:-5])
 
         selected_issue_procs = journal_proc.issue_proc_set.filter(
@@ -790,6 +788,7 @@ def import_journal_acron_id_records(
 
         qs = journal_id_file.id_file_records.filter(item_type="article")
         total_id_file_records = qs.count()
+        total_id_file_records_to_migrate = qs.filter(todo=True).count()
     
         stats["total_id_file_records"] = total_id_file_records
         stats["total_id_file_records_to_migrate"] = total_id_file_records_to_migrate

--- a/migration/controller.py
+++ b/migration/controller.py
@@ -779,7 +779,7 @@ def import_journal_acron_id_records(
             updated_by=user,
         )
         article_proc_model = (
-            selected_issue_procs.model.article_proc_set.rel.related_model
+            selected_issue_procs.model.articleproc_set.rel.related_model
         )
         article_proc_model.objects.filter(
             issue_proc__in=selected_issue_procs

--- a/migration/controller.py
+++ b/migration/controller.py
@@ -701,7 +701,7 @@ def get_migrated_xml_with_pre(article_proc):
         )
 
 
-def register_acron_id_file_content(
+def import_journal_acron_id_records(
     user,
     journal_proc,
     force_update,
@@ -748,6 +748,10 @@ def register_acron_id_file_content(
             )
 
         logging.info(f"Updating IdFileRecord from {source_path}")
+
+        issue_pids = set()
+
+        total_id_file_records_to_migrate = 0
         for item in get_bases_work_acron_id_file_records(
             user,
             source_path,
@@ -760,18 +764,33 @@ def register_acron_id_file_content(
                 user,
                 journal_id_file,
                 **item,
-            )        
+            )
+            if item["item_type"] == "article":
+                total_id_file_records_to_migrate += 1
+                issue_pids.add(item["item_pid"][1:-5])
+
+        selected_issue_procs = journal_proc.issue_proc_set.filter(
+            pid__in=issue_pids,
+        )
+        selected_issue_procs.exclude(
+            docs_status__in=tracker_choices.PROGRESS_STATUS_REGULAR_TODO
+        ).update(
+            docs_status=tracker_choices.PROGRESS_STATUS_REPROC,
+            updated_by=user,
+        )
+        for issue_proc in selected_issue_procs:
+            issue_proc.article_proc_set.exclude(
+                xml_status__in=tracker_choices.PROGRESS_STATUS_REGULAR_TODO
+            ).update(
+                xml_status=tracker_choices.PROGRESS_STATUS_REPROC,
+                updated_by=user,
+            )
 
         qs = journal_id_file.id_file_records.filter(item_type="article")
         total_id_file_records = qs.count()
-        article_pids = list(qs.filter(todo=True).values_list("item_pid", flat=True).distinct())
-        
-        stats["total_id_file_records_resulting"] = total_id_file_records
-        stats["total_id_file_records_to_migrate_resulting"] = len(article_pids)
-        stats["total_id_file_records_new"] = journal_id_file.id_file_records.filter(
-            updated__gte=datetime_now,
-        ).count()
-        detail["article_pids"] = article_pids
+    
+        stats["total_id_file_records"] = total_id_file_records
+        stats["total_id_file_records_to_migrate"] = total_id_file_records_to_migrate
         detail["stats"] = stats
         detail["output"] = output
         return detail

--- a/migration/tasks.py
+++ b/migration/tasks.py
@@ -438,7 +438,7 @@
 #     try:
 #         user = _get_user(user_id, username)
 #         item = IssueProc.objects.get(pk=item_id)
-#         item.get_files_from_classic_website(
+#         item.migrate_document_files(
 #             user, force_update, controller.import_one_issue_files
 #         )
 #     except Exception as e:

--- a/proc/controller.py
+++ b/proc/controller.py
@@ -56,10 +56,7 @@ __all__ = [
     "create_or_update_migrated_issue",
     "create_collection_procs_from_pid_list",
     "migrate_journal",
-    "create_or_update_journal_acron_id_file",
     "migrate_issue",
-    "migrate_document_records",
-    "migrate_document_files",
     # Publication functions
     "publish_journals",
     "publish_issues",

--- a/proc/controller.py
+++ b/proc/controller.py
@@ -19,11 +19,8 @@ from proc.publisher import (
 # Imports do Classic Website
 from proc.source_classic_website import (
     create_collection_procs_from_pid_list,
-    create_or_update_journal_acron_id_file,
     create_or_update_migrated_issue,
     create_or_update_migrated_journal,
-    migrate_document_files,
-    migrate_document_records,
     migrate_issue,
     migrate_journal,
 )

--- a/proc/controller.py
+++ b/proc/controller.py
@@ -22,7 +22,7 @@ from proc.source_classic_website import (
     create_or_update_journal_acron_id_file,
     create_or_update_migrated_issue,
     create_or_update_migrated_journal,
-    get_files_from_classic_website,
+    migrate_document_files,
     migrate_document_records,
     migrate_issue,
     migrate_journal,
@@ -62,7 +62,7 @@ __all__ = [
     "create_or_update_journal_acron_id_file",
     "migrate_issue",
     "migrate_document_records",
-    "get_files_from_classic_website",
+    "migrate_document_files",
     # Publication functions
     "publish_journals",
     "publish_issues",

--- a/proc/forms.py
+++ b/proc/forms.py
@@ -6,7 +6,7 @@ from core.forms import CoreAdminModelForm
 class ProcAdminModelForm(CoreAdminModelForm):
     def save_all(self, user):
         s = super().save_all(user)
-        s.set_status()
+        s.propagate_reproc_or_todo_status()
         self.save()
         return s
 

--- a/proc/models.py
+++ b/proc/models.py
@@ -1894,10 +1894,10 @@ class ArticleProc(BaseProc, ClusterableModel):
         exclude_issue_proc_id_list = exclude_issue_proc_id_list or []
         
         params = {}
-        if journal_proc_id_list:
-            params["journal_proc__id__in"] = journal_proc_id_list
         if issue_proc_id_list:
             params["issue_proc__id__in"] = issue_proc_id_list
+        elif journal_proc_id_list:
+            params["issue_proc__journal_proc__id__in"] = journal_proc_id_list
         
         return cls.objects.filter(
             Q(migration_status__in=status_list)

--- a/proc/models.py
+++ b/proc/models.py
@@ -404,7 +404,7 @@ class BaseProc(CommonControlField):
     def __str__(self):
         return f"{self.collection} {self.pid}"
 
-    def set_status(self):
+    def propagate_reproc_or_todo_status(self):
         if self.migration_status == tracker_choices.PROGRESS_STATUS_REPROC:
             self.qa_ws_status = tracker_choices.PROGRESS_STATUS_REPROC
 
@@ -555,7 +555,7 @@ class BaseProc(CommonControlField):
                 )
 
     @classmethod
-    def get_queryset_to_process(cls, STATUS):
+    def filter_by_status(cls, STATUS):
         return (
             Q(migration_status__in=STATUS)
             | Q(qa_ws_status__in=STATUS)
@@ -580,7 +580,7 @@ class BaseProc(CommonControlField):
         if params is None:
             params = {}
 
-        q = cls.get_queryset_to_process(STATUS)
+        q = cls.filter_by_status(STATUS)
 
         return cls.objects.filter(
             q,
@@ -953,6 +953,24 @@ class JournalProc(BaseProc, ClusterableModel):
                 acron=item.journal_acron,
             )
 
+    @classmethod
+    def select_items(
+        cls,
+        collection_acron_list=None,
+        journal_acron_list=None,
+    ):  
+        collection_acron_list = collection_acron_list or []
+        journal_acron_list = journal_acron_list or []
+
+        params = {}
+        if collection_acron_list:
+            params["collection__acron__in"] = collection_acron_list
+        if journal_acron_list:
+            params["acron__in"] = journal_acron_list
+        return cls.objects.filter(
+            **params,
+        )
+
     @property
     def completeness(self):
         return {
@@ -967,7 +985,6 @@ class JournalProc(BaseProc, ClusterableModel):
     @property
     def issn_electronic(self):
         return self.journal and self.journal.issn_electronic
-
 
 ################################################
 class IssueGetOrCreateError(Exception): ...
@@ -1074,7 +1091,7 @@ class IssueProc(BaseProc, ClusterableModel):
         issue_proc.save()
         return issue_proc
 
-    def set_status(self):
+    def propagate_reproc_or_todo_status(self):
         # Propaga status para QA e Public WS
         if self.migration_status == tracker_choices.PROGRESS_STATUS_REPROC:
             self.qa_ws_status = tracker_choices.PROGRESS_STATUS_REPROC
@@ -1155,9 +1172,50 @@ class IssueProc(BaseProc, ClusterableModel):
                     journal_proc, issue_folder, type(e), e
                 )
             )
+        
+    @classmethod
+    def select_items(
+        cls,
+        collection_acron_list=None,
+        journal_acron_list=None,
+        journal_proc_id_list=None,
+        publication_year=None,
+        issue_folder=None,
+        status_list=None,
+        force_update=False,
+        to_migrate_articles=False,
+    ):  
+        status_list = tracker_choices.get_valid_status(status_list, force_update)
+        collection_acron_list = collection_acron_list or []
+        journal_acron_list = journal_acron_list or []
+        journal_proc_id_list = journal_proc_id_list or []
+        params = {}
+        if collection_acron_list:
+            params["journal_proc__collection__acron__in"] = collection_acron_list
+        if journal_acron_list:
+            params["journal_proc__acron__in"] = journal_acron_list
+        if journal_proc_id_list:
+            params["journal_proc__id__in"] = journal_proc_id_list
+        if issue_folder:
+            params["issue_folder"] = issue_folder
+        if publication_year:
+            params["issue__publication_year"] = publication_year
+
+        if to_migrate_articles:
+            return cls.objects.filter(
+                Q(docs_status__in=status_list)
+                | Q(files_status__in=status_list),
+                **params,
+            )
+        return cls.objects.filter(
+            Q(migration_status__in=status_list)
+            | Q(qa_ws_status__in=status_list)
+            | Q(public_ws_status__in=status_list),
+            **params,
+        )
 
     @classmethod
-    def get_queryset_to_process(cls, STATUS):
+    def filter_by_status(cls, STATUS):
         return (
             Q(migration_status__in=STATUS)
             | Q(qa_ws_status__in=STATUS)
@@ -1211,11 +1269,11 @@ class IssueProc(BaseProc, ClusterableModel):
             **params,
         )
 
-    def get_files_from_classic_website(
+    def migrate_document_files(
         self, user, force_update, migrate_issue_files_function
     ):
         try:
-            operation = self.start(user, "get_files_from_classic_website")
+            operation = self.start(user, "migrate_document_files")
             if self.files_status == tracker_choices.PROGRESS_STATUS_DONE and not force_update:
                 operation.finish(
                     user,
@@ -1258,7 +1316,7 @@ class IssueProc(BaseProc, ClusterableModel):
             return self.issue_files.count()
 
         except Exception as e:
-            logging.exception(f"Exception: get_files_from_classic_website: {e}")
+            logging.exception(f"Exception: migrate_document_files: {e}")
             exc_type, exc_value, exc_traceback = sys.exc_info()
             self.files_status = tracker_choices.PROGRESS_STATUS_BLOCKED
             self.save()
@@ -1346,7 +1404,7 @@ class IssueProc(BaseProc, ClusterableModel):
             q,
             journal_proc=journal_proc,
         ).values_list("id", "pid")
-
+    
     def migrate_document_records(self, user, force_update=None):
         try:
             total = 0
@@ -1359,20 +1417,20 @@ class IssueProc(BaseProc, ClusterableModel):
             if not self.journal_proc:
                 raise ValueError(f"IssueProc ({self}) has no journal_proc")
 
-            total_document_records = IdFileRecord.document_records_to_migrate(
-                collection=self.collection,
-                issue_pid=self.pid,
-                force_update=True,  # todos os registros encontrados em acron.id no momento
-            ).count()
-            detail["total_document_records"] = total_document_records
-
-            force_update = ArticleProc.objects.filter(issue_proc=self).count() < total_document_records
-
             id_file_records = IdFileRecord.document_records_to_migrate(
                 collection=self.collection,
                 issue_pid=self.pid,
-                force_update=force_update,
+                force_update=True,  # todos os registros encontrados em acron.id no momento
             )
+            total_document_records = id_file_records.count()
+            detail["total_document_records"] = total_document_records
+
+            if not force_update:
+                force_update = ArticleProc.objects.filter(issue_proc=self).count() < total_document_records
+            if not force_update:
+                # obtém somente os registros por fazer (todo=True)
+                id_file_records = id_file_records.filter(todo=True)
+
             detail["total_document_records_to_migrate"] = id_file_records.count()
             if detail["total_document_records_to_migrate"] == 0:
                 raise NoDocumentRecordsToMigrateError("No document records to migrate")
@@ -1600,20 +1658,12 @@ class ArticleProc(BaseProc, ClusterableModel):
         ]
 
     @classmethod
-    def mark_for_reprocessing(cls, issue_proc, article_pids=None):
+    def mark_for_reprocessing(cls, issue_proc, article_pids=None, article_proc_ids=None):
         params = {"issue_proc": issue_proc}
         if article_pids:
             params["pid__in"] = article_pids
-        if issue_proc.docs_status not in (
-            tracker_choices.PROGRESS_STATUS_DONE,
-            tracker_choices.PROGRESS_STATUS_PENDING,
-        ):
-            return
-        if issue_proc.files_status not in (
-            tracker_choices.PROGRESS_STATUS_DONE,
-            tracker_choices.PROGRESS_STATUS_PENDING,
-        ):
-            return
+        if article_proc_ids:
+            params["id__in"] = article_proc_ids
         cls.objects.filter(**params).update(
             xml_status=tracker_choices.PROGRESS_STATUS_REPROC,
             sps_pkg_status=tracker_choices.PROGRESS_STATUS_REPROC,
@@ -1622,7 +1672,7 @@ class ArticleProc(BaseProc, ClusterableModel):
             public_ws_status=tracker_choices.PROGRESS_STATUS_REPROC,
         )
 
-    def set_status(self):
+    def propagate_reproc_or_todo_status(self):
         if self.xml_status == tracker_choices.PROGRESS_STATUS_REPROC:
             self.sps_pkg_status = tracker_choices.PROGRESS_STATUS_REPROC
 
@@ -1666,6 +1716,10 @@ class ArticleProc(BaseProc, ClusterableModel):
             self.pkg_name = pkg_name
             self.main_lang = main_lang
             self.migration_status = migration_status or self.migration_status
+            self.xml_status = tracker_choices.PROGRESS_STATUS_TODO
+            self.sps_pkg_status = tracker_choices.PROGRESS_STATUS_TODO
+            self.qa_ws_status = tracker_choices.PROGRESS_STATUS_TODO
+            self.public_ws_status = tracker_choices.PROGRESS_STATUS_TODO
             self.save()
 
         except Exception as e:
@@ -1826,7 +1880,34 @@ class ArticleProc(BaseProc, ClusterableModel):
             )
 
     @classmethod
-    def get_queryset_to_process(cls, STATUS):
+    def select_items(
+        cls,
+        journal_proc_id_list=None,
+        issue_proc_id_list=None,
+        status_list=None,
+        force_update=False,
+    ):  
+        status_list = tracker_choices.get_valid_status(status_list, force_update)
+        journal_proc_id_list = journal_proc_id_list or []
+        issue_proc_id_list = issue_proc_id_list or []
+        
+        params = {}
+        if journal_proc_id_list:
+            params["journal_proc__id__in"] = journal_proc_id_list
+        if issue_proc_id_list:
+            params["issue_proc__id__in"] = issue_proc_id_list
+
+        return cls.objects.filter(
+            Q(migration_status__in=status_list)
+            | Q(xml_status__in=status_list)
+            | Q(sps_pkg_status__in=status_list)
+            | Q(qa_ws_status__in=status_list)
+            | Q(public_ws_status__in=status_list),
+            **params,
+        )
+
+    @classmethod
+    def filter_by_status(cls, STATUS):
         return (
             Q(migration_status__in=STATUS)
             | Q(qa_ws_status__in=STATUS)
@@ -2081,12 +2162,18 @@ class ArticleProc(BaseProc, ClusterableModel):
     def migrate_article(self, user, force_update):
         if force_update:
             self.xml_status = tracker_choices.PROGRESS_STATUS_REPROC
-            self.set_status()
+            self.propagate_reproc_or_todo_status()
         if not self.get_xml(user):
             return None
         if not self.generate_sps_package(user):
             return None
-        return self.create_or_update_item(user, force_update, create_or_update_article)
+        article = self.create_or_update_item(user, force_update, create_or_update_article)
+        if not article:
+            return None
+        self.qa_ws_status = tracker_choices.PROGRESS_STATUS_TODO
+        self.public_ws_status = tracker_choices.PROGRESS_STATUS_TODO
+        self.save()
+        return article
 
     def synchronize(self, user):
         try:

--- a/proc/models.py
+++ b/proc/models.py
@@ -1884,19 +1884,21 @@ class ArticleProc(BaseProc, ClusterableModel):
         cls,
         journal_proc_id_list=None,
         issue_proc_id_list=None,
+        exclude_issue_proc_id_list=None,
         status_list=None,
         force_update=False,
     ):  
         status_list = tracker_choices.get_valid_status(status_list, force_update)
         journal_proc_id_list = journal_proc_id_list or []
         issue_proc_id_list = issue_proc_id_list or []
+        exclude_issue_proc_id_list = exclude_issue_proc_id_list or []
         
         params = {}
         if journal_proc_id_list:
             params["journal_proc__id__in"] = journal_proc_id_list
         if issue_proc_id_list:
             params["issue_proc__id__in"] = issue_proc_id_list
-
+        
         return cls.objects.filter(
             Q(migration_status__in=status_list)
             | Q(xml_status__in=status_list)
@@ -1904,7 +1906,7 @@ class ArticleProc(BaseProc, ClusterableModel):
             | Q(qa_ws_status__in=status_list)
             | Q(public_ws_status__in=status_list),
             **params,
-        )
+        ).exclude(issue_proc__id__in=exclude_issue_proc_id_list)
 
     @classmethod
     def filter_by_status(cls, STATUS):

--- a/proc/source_classic_website.py
+++ b/proc/source_classic_website.py
@@ -257,7 +257,7 @@ def create_or_update_journal_acron_id_file(
     logging.info(f"create_or_update_journal_acron_id_file - JournalProc params: collection={collection.acron}, journal_filter={journal_filter} - {items.count()} items found")
     for journal_proc in items:
         logging.info(f"create_or_update_journal_acron_id_file - JournalProc {journal_proc}")
-        controller.register_acron_id_file_content(
+        controller.import_journal_acron_id_records(
             user,
             journal_proc,
             force_update=force_update,
@@ -359,7 +359,7 @@ def migrate_document_records(
     # )
 
 
-def get_files_from_classic_website(
+def migrate_document_files(
     user,
     collection_acron=None,
     journal_acron=None,
@@ -389,10 +389,10 @@ def get_files_from_classic_website(
         "journal_proc",
         "issue",
     ).filter(**params)
-    logging.info(f"get_files_from_classic_website - IssueProc params: {params} - {items.count()} items found")
+    logging.info(f"migrate_document_files - IssueProc params: {params} - {items.count()} items found")
     for issue_proc in items:
-        logging.info(f"get_files_from_classic_website - IssueProc {issue_proc}")
-        issue_proc.get_files_from_classic_website(
+        logging.info(f"migrate_document_files - IssueProc {issue_proc}")
+        issue_proc.migrate_document_files(
             user, force_update, controller.migrate_issue_files
         )
         ArticleProc.mark_for_reprocessing(issue_proc)

--- a/proc/source_classic_website.py
+++ b/proc/source_classic_website.py
@@ -7,7 +7,6 @@ import sys
 
 from migration import controller
 from proc.models import ArticleProc, IssueProc, JournalProc
-from tracker import choices as tracker_choices
 from tracker.models import UnexpectedEvent
 
 
@@ -241,27 +240,27 @@ def migrate_journal(
         )
 
 
-def create_or_update_journal_acron_id_file(
-    user, collection, journal_filter, force_update=None
-):
-    """
-    Cria ou atualiza arquivos de ID baseados em acrônimos de journals.
-    """
-    items = JournalProc.objects.select_related(
-        "collection",
-        "journal",
-    ).filter(
-        collection=collection,
-        **journal_filter,
-    )
-    logging.info(f"create_or_update_journal_acron_id_file - JournalProc params: collection={collection.acron}, journal_filter={journal_filter} - {items.count()} items found")
-    for journal_proc in items:
-        logging.info(f"create_or_update_journal_acron_id_file - JournalProc {journal_proc}")
-        controller.import_journal_acron_id_records(
-            user,
-            journal_proc,
-            force_update=force_update,
-        )
+# def create_or_update_journal_acron_id_file(
+#     user, collection, journal_filter, force_update=None
+# ):
+#     """
+#     Cria ou atualiza arquivos de ID baseados em acrônimos de journals.
+#     """
+#     items = JournalProc.objects.select_related(
+#         "collection",
+#         "journal",
+#     ).filter(
+#         collection=collection,
+#         **journal_filter,
+#     )
+#     logging.info(f"create_or_update_journal_acron_id_file - JournalProc params: collection={collection.acron}, journal_filter={journal_filter} - {items.count()} items found")
+#     for journal_proc in items:
+#         logging.info(f"create_or_update_journal_acron_id_file - JournalProc {journal_proc}")
+#         controller.import_journal_acron_id_records(
+#             user,
+#             journal_proc,
+#             force_update=force_update,
+#         )
 
 
 def migrate_issue(user, issue_proc, force_update):
@@ -310,89 +309,89 @@ def migrate_issue(user, issue_proc, force_update):
         )
 
 
-def migrate_document_records(
-    user,
-    collection_acron=None,
-    journal_acron=None,
-    issue_folder=None,
-    publication_year=None,
-    status=None,
-    force_update=None,
-    skip_migrate_pending_document_records=None,
-):
-    """
-    Executa a migração de registros de documentos do site clássico.
-    """
-    params = {}
-    if collection_acron:
-        params["collection__acron"] = collection_acron
-    if journal_acron:
-        params["journal_proc__acron"] = journal_acron
-    if issue_folder:
-        params["issue_folder"] = str(issue_folder)
-    if publication_year:
-        params["issue__publication_year"] = str(publication_year)
-    if status:
-        params["docs_status__in"] = tracker_choices.get_valid_status(
-            status, force_update
-        )
+# def migrate_document_records(
+#     user,
+#     collection_acron=None,
+#     journal_acron=None,
+#     issue_folder=None,
+#     publication_year=None,
+#     status=None,
+#     force_update=None,
+#     skip_migrate_pending_document_records=None,
+# ):
+#     """
+#     Executa a migração de registros de documentos do site clássico.
+#     """
+#     params = {}
+#     if collection_acron:
+#         params["collection__acron"] = collection_acron
+#     if journal_acron:
+#         params["journal_proc__acron"] = journal_acron
+#     if issue_folder:
+#         params["issue_folder"] = str(issue_folder)
+#     if publication_year:
+#         params["issue__publication_year"] = str(publication_year)
+#     if status:
+#         params["docs_status__in"] = tracker_choices.get_valid_status(
+#             status, force_update
+#         )
 
-    logging.info(f"migrate_document_records - IssueProc params: {params}")
-    for issue_proc in IssueProc.objects.select_related(
-        "collection",
-        "journal_proc",
-        "issue",
-    ).filter(**params):
-        logging.info(f"migrate_document_records - IssueProc {issue_proc}")
-        issue_proc.migrate_document_records(user, force_update)
-        ArticleProc.mark_for_reprocessing(issue_proc)
+#     logging.info(f"migrate_document_records - IssueProc params: {params}")
+#     for issue_proc in IssueProc.objects.select_related(
+#         "collection",
+#         "journal_proc",
+#         "issue",
+#     ).filter(**params):
+#         logging.info(f"migrate_document_records - IssueProc {issue_proc}")
+#         issue_proc.migrate_document_records(user, force_update)
+#         ArticleProc.mark_for_reprocessing(issue_proc)
 
-    # if skip_migrate_pending_document_records:
-    #     return
+#     # if skip_migrate_pending_document_records:
+#     #     return
 
-    # IssueProc.migrate_pending_document_records(
-    #     user,
-    #     collection_acron,
-    #     journal_acron,
-    #     issue_folder,
-    #     publication_year,
-    # )
+#     # IssueProc.migrate_pending_document_records(
+#     #     user,
+#     #     collection_acron,
+#     #     journal_acron,
+#     #     issue_folder,
+#     #     publication_year,
+#     # )
 
 
-def migrate_document_files(
-    user,
-    collection_acron=None,
-    journal_acron=None,
-    issue_folder=None,
-    publication_year=None,
-    status=None,
-    force_update=None,
-):
-    """
-    Obtém arquivos do site clássico para processamento.
-    """
-    params = {}
-    if collection_acron:
-        params["collection__acron"] = collection_acron
-    if journal_acron:
-        params["journal_proc__acron"] = journal_acron
-    if issue_folder:
-        params["issue_folder"] = str(issue_folder)
-    if publication_year:
-        params["issue__publication_year"] = str(publication_year)
-    if status:
-        params["files_status__in"] = tracker_choices.get_valid_status(
-            status, force_update
-        )
-    items = IssueProc.objects.select_related(
-        "collection",
-        "journal_proc",
-        "issue",
-    ).filter(**params)
-    logging.info(f"migrate_document_files - IssueProc params: {params} - {items.count()} items found")
-    for issue_proc in items:
-        logging.info(f"migrate_document_files - IssueProc {issue_proc}")
-        issue_proc.migrate_document_files(
-            user, force_update, controller.migrate_issue_files
-        )
-        ArticleProc.mark_for_reprocessing(issue_proc)
+# def migrate_document_files(
+#     user,
+#     collection_acron=None,
+#     journal_acron=None,
+#     issue_folder=None,
+#     publication_year=None,
+#     status=None,
+#     force_update=None,
+# ):
+#     """
+#     Obtém arquivos do site clássico para processamento.
+#     """
+#     params = {}
+#     if collection_acron:
+#         params["collection__acron"] = collection_acron
+#     if journal_acron:
+#         params["journal_proc__acron"] = journal_acron
+#     if issue_folder:
+#         params["issue_folder"] = str(issue_folder)
+#     if publication_year:
+#         params["issue__publication_year"] = str(publication_year)
+#     if status:
+#         params["files_status__in"] = tracker_choices.get_valid_status(
+#             status, force_update
+#         )
+#     items = IssueProc.objects.select_related(
+#         "collection",
+#         "journal_proc",
+#         "issue",
+#     ).filter(**params)
+#     logging.info(f"migrate_document_files - IssueProc params: {params} - {items.count()} items found")
+#     for issue_proc in items:
+#         logging.info(f"migrate_document_files - IssueProc {issue_proc}")
+#         issue_proc.migrate_document_files(
+#             user, force_update, controller.migrate_issue_files
+#         )
+#         ArticleProc.mark_for_reprocessing(issue_proc)

--- a/proc/tasks.py
+++ b/proc/tasks.py
@@ -940,6 +940,7 @@ def task_migrate_and_publish_articles_by_journal(
         task_exec.add_event("Read journal acron id file")
         response = controller.import_journal_acron_id_records(
             user,
+            ArticleProc,
             journal_proc,
             force_update=force_import_acron_id_file,
         )

--- a/proc/tasks.py
+++ b/proc/tasks.py
@@ -816,18 +816,35 @@ def task_migrate_and_publish_articles(
         journal_acron_list = journal_acron_list or []
         if journal_acron:
             journal_acron_list += [journal_acron]
-        if journal_acron_list:
-            params["acron__in"] = journal_acron_list
         collection_acron_list = collection_acron_list or []
         if collection_acron:
             collection_acron_list += [collection_acron]
-        if collection_acron_list:
-            params["collection__acron__in"] = collection_acron_list
 
-        task_exec.add_event(_("Select journals by collection"))
-        journal_collection_pairs = JournalProc.objects.filter(**params).values_list("acron", "collection__acron").distinct()
+        items_to_process = {}
+        if publication_year or issue_folder:
+            task_exec.add_event(_("Select issues by {} and {}").format(issue_folder, publication_year))
+            selected_issue_procs = IssueProc.select_items(
+                collection_acron_list=collection_acron_list,
+                journal_acron_list=journal_acron_list,
+                publication_year=publication_year,
+                issue_folder=issue_folder,
+                status_list=status,
+                force_update=force_migrate_document_records or force_migrate_document_files,
+                to_migrate_articles=True,
+            )
+            issue_proc_ids = selected_issue_procs.values_list("journal_proc_id", "id").distinct()
+            
+            for journal_proc_id, issue_proc_id in issue_proc_ids:
+                items_to_process.setdefault(journal_proc_id, []).append(issue_proc_id)
+        else:
+            task_exec.add_event(_("Select journals by collection"))
+            journal_proc_ids = JournalProc.select_items(
+                collection_acron_list=collection_acron_list,
+                journal_acron_list=journal_acron_list,
+            ).values_list("id", flat=True)
+            items_to_process = {journal_proc_id: None for journal_proc_id in journal_proc_ids}
 
-        total_journals_to_process = journal_collection_pairs.count()
+        total_journals_to_process = len(items_to_process)
         task_exec.add_number("total_journals_to_process", total_journals_to_process)
 
         kwargs_ = {}
@@ -837,11 +854,11 @@ def task_migrate_and_publish_articles(
 
         task_exec.total_to_process = total_journals_to_process
         total_processed = 0
-        for journal_acron, collection_acron in journal_collection_pairs:
+        for journal_proc_id, issue_proc_id_list in items_to_process.items():
             kwargs = {}
             kwargs.update(kwargs_)
-            kwargs["journal_acron"] = journal_acron
-            kwargs["collection_acron"] = collection_acron
+            kwargs["journal_proc_id"] = journal_proc_id
+            kwargs["issue_proc_id_list"] = issue_proc_id_list
             total_processed += 1
             task_migrate_and_publish_articles_by_journal.delay(**kwargs)
 
@@ -870,6 +887,8 @@ def task_migrate_and_publish_articles_by_journal(
     self,
     user_id=None,
     username=None,
+    journal_proc_id=None,
+    issue_proc_id_list=None,
     collection_acron=None,
     journal_acron=None,
     publication_year=None,
@@ -902,14 +921,15 @@ def task_migrate_and_publish_articles_by_journal(
         params=task_params,
     )
     try:
+        if not journal_proc_id:
+            raise ValueError("journal_proc_id is required")
+
+        journal_proc = JournalProc.objects.get(id=journal_proc_id)
+
         user = _get_user(user_id, username)
-        journal_proc = JournalProc.objects.select_related("collection").get(
-            collection__acron=collection_acron,
-            acron=journal_acron,
-        )
 
         task_exclude_article_repetition(
-            journal_proc.id,
+            journal_proc_id,
             qa_api_data=None,
             public_api_data=None,
             username=user.username,
@@ -918,86 +938,55 @@ def task_migrate_and_publish_articles_by_journal(
         )
 
         task_exec.add_event("Read journal acron id file")
-        response = controller.register_acron_id_file_content(
+        response = controller.import_journal_acron_id_records(
             user,
             journal_proc,
             force_update=force_import_acron_id_file,
         )
 
-        try:
-            article_pids = response.pop("article_pids")
-        except KeyError:
-            article_pids = []
-        task_exec.add_event(f"acron.id response: {response}")
-        task_exec.total_to_process = len(article_pids)
-        task_exec.add_number("total_articles_to_process", len(article_pids))
-        
-        # Agrupa os article_pids por issue_pid
-        task_exec.add_event("Group article pids by issue")
-        article_pids_by_issue = {}
-        for article_pid in article_pids:
-            if len(article_pid) >= 23:  # Verificação de segurança para PID válido
-                issue_pid = article_pid[1:-5]
-                article_pids_by_issue.setdefault(issue_pid, set()).add(article_pid)
-
-        # Lista de issue_pids a serem processados
-        issue_pids = list(article_pids_by_issue.keys())
-        task_exec.add_number("total_issues_with_articles_to_process", len(issue_pids))
-
-        status = tracker_choices.get_valid_status(status, force_update)
-        task_exec.add_event(f"Select journal issues which docs_status or files_status in {status} and/or has articles to process")
-
-        events = []
-        article_issue_proc_list = ArticleProc.objects.filter(issue_proc__journal_proc=journal_proc).filter(
-            Q(migration_status__in=status)
-            | Q(xml_status__in=status)
-            | Q(sps_pkg_status__in=status)
-            | Q(qa_ws_status__in=status)
-            | Q(public_ws_status__in=status)
-        ).values_list("issue_proc__id", "issue_proc__pid").distinct()
-
-        issue_proc_list = IssueProc.get_id_and_pid_list_to_process(
-            journal_proc,
-            issue_folder,
-            publication_year,
-            issue_pids,
-            status,
-            events,
-        )
-
-        issue_proc_list = set(issue_proc_list) | set(article_issue_proc_list)
-        total_issues_to_process = len(issue_proc_list)
-        task_exec.add_event(events)
-        task_exec.add_number("total_issues_to_process", total_issues_to_process)
-        task_exec.total_to_process = total_issues_to_process
-        
-        if not total_issues_to_process:
-            task_exec.finish()
-            return
-    
-        task_exec.add_event("Schedule to process articles by issue")
-        # para cada issue:
-        # - (docs_status) obtém os registros dos documentos (IdFileRecord -> ArticleProc)
-        # - (files_status) obtém os arquivos dos documentos (img, pdf, translation, xml, etc)
-        # - processamento de artigos
         qa_api_data = get_api_data(journal_proc.collection, "issue", "QA")
         public_api_data = get_api_data(journal_proc.collection, "issue", "PUBLIC")
         total_processed = 0
-        for issue_proc_id, issue_pid in issue_proc_list:
+        total_to_process = 0
+
+        if not issue_proc_id_list:
+            selected_issue_procs = IssueProc.select_items(
+                journal_proc_id_list=[journal_proc_id],
+                status_list=status,
+                force_update=force_migrate_document_records or force_migrate_document_files,
+                to_migrate_articles=True,
+            )
+            issue_proc_id_list = selected_issue_procs.values_list("id", flat=True)
+        
+        items_to_process = {
+            issue_proc_id: None for issue_proc_id in (issue_proc_id_list or [])
+        }
+
+        selected_article_proc_items = ArticleProc.select_items(
+            issue_proc_id_list=issue_proc_id_list,
+            status_list=status,
+            force_update=force_update,
+        ).values_list("issue_proc_id", "id").distinct()
+        for issue_proc_id, article_proc_id in selected_article_proc_items:
+            items_to_process.setdefault(issue_proc_id, []).append(article_proc_id)
+
+        total_to_process = len(items_to_process)
+        for issue_proc_id, article_proc_id_list in items_to_process.items():
             total_processed += 1
             task_migrate_and_publish_articles_by_issue.delay(
                 user_id=user_id,
                 username=username,
                 issue_proc_id=issue_proc_id,
-                article_pids=list(article_pids_by_issue.get(issue_pid) or []),
+                article_proc_id_list=article_proc_id_list,
                 status=status,
                 force_update=force_update,
                 force_migrate_document_records=force_migrate_document_records,
                 force_migrate_document_files=force_migrate_document_files,
                 qa_api_data=qa_api_data,
                 public_api_data=public_api_data,
-        )
+        )   
         task_exec.total_processed = total_processed
+        task_exec.total_to_process = total_to_process
         task_exec.finish()
     
     except Exception as e:
@@ -1014,7 +1003,7 @@ def task_migrate_and_publish_articles_by_issue(
     user_id=None,
     username=None,
     issue_proc_id=None,
-    article_pids=None,
+    article_proc_id_list=None,
     status=None,
     force_update=False,
     force_migrate_document_records=False,
@@ -1026,7 +1015,7 @@ def task_migrate_and_publish_articles_by_issue(
         "user_id": user_id,
         "username": username,
         "issue_proc_id": issue_proc_id,
-        "article_pids": article_pids,
+        "article_proc_id_list": article_proc_id_list,
         "status": status,
         "force_update": force_update,
         "force_migrate_document_records": force_migrate_document_records,
@@ -1042,41 +1031,45 @@ def task_migrate_and_publish_articles_by_issue(
         issue_proc = IssueProc.objects.select_related(
             "collection", "journal_proc",
         ).get(id=issue_proc_id)
+        status = tracker_choices.get_valid_status(status, force_update)
+
         task_exec.item = str(issue_proc)
-        task_exec.total_to_process = len(article_pids)
-        task_exec.add_event(f"STATUS={status}")
-        task_exec.add_event(f"docs_status: {issue_proc.docs_status}")
 
-        task_exec.add_event("Migrate document records")
-        total_migrated_records = issue_proc.migrate_document_records(user, force_migrate_document_records)
-        task_exec.add_number("total_migrated_records", total_migrated_records)
+        if not article_proc_id_list:
+            task_exec.add_event("Migrate document records")
+            total_migrated_records = issue_proc.migrate_document_records(user, force_migrate_document_records)
+            task_exec.add_number("total_migrated_records", total_migrated_records)
 
-        task_exec.add_event("Migrate issue files")
-        total_migrated_files = issue_proc.get_files_from_classic_website(
-            user, force_migrate_document_files, controller.migrate_issue_files
-        )
-        task_exec.add_number("total_migrated_files", total_migrated_files)
+            task_exec.add_event("Migrate document files")
+            total_migrated_files = issue_proc.migrate_document_files(
+                user, force_migrate_document_files, controller.migrate_issue_files
+            )
+            task_exec.add_number("total_migrated_files", total_migrated_files)
 
-        task_exec.add_event("Mark articles for reprocessing")
-        ArticleProc.mark_for_reprocessing(issue_proc, article_pids)
-
-        task_exec.add_event("Select articles to migrate and/or publish")
-        query_by_status = (
-            Q(migration_status__in=status)
-            | Q(xml_status__in=status)
-            | Q(sps_pkg_status__in=status)
-        )
-        articles_to_process = ArticleProc.objects.select_related(
-            "issue_proc",
-        ).filter(
-            query_by_status, issue_proc=issue_proc,
-        )
-        total_articles_to_process = articles_to_process.count()
+        if article_proc_id_list:
+            total_articles_to_process = len(article_proc_id_list)
+            article_procs = ArticleProc.objects.select_related(
+                "issue_proc",
+            ).filter(
+                id__in=article_proc_id_list
+            )
+        else:
+            task_exec.add_event("Select articles to migrate")
+            article_procs = ArticleProc.objects.select_related(
+                "issue_proc",
+            ).filter(
+                Q(migration_status__in=status)
+                | Q(xml_status__in=status)
+                | Q(sps_pkg_status__in=status),
+                issue_proc=issue_proc,
+            )
+            total_articles_to_process = article_procs.count()
         task_exec.total_to_process = total_articles_to_process
+
         task_exec.add_event("Migrate articles")
         total_processed = 0
         exceptions = {}
-        for article_proc in articles_to_process:
+        for article_proc in article_procs:
             try:
                 article = article_proc.migrate_article(user, force_update)
                 total_processed += 1
@@ -1178,6 +1171,7 @@ def task_sync_issue(
 
         for article_proc_id in article_ids_to_publish:
             try:
+                # executa de forma síncrona para evitar muitos processos em paralelo, o que pode causar lentidão e instabilidade no ambiente de origem (ex: site clássico)
                 task_publish_article(
                     user_id=user_id,
                     username=username,

--- a/proc/tasks.py
+++ b/proc/tasks.py
@@ -963,7 +963,7 @@ def task_migrate_and_publish_articles_by_journal(
                 force_update=force_migrate_document_records or force_migrate_document_files,
                 to_migrate_articles=True,
             )
-            issue_proc_id_list = selected_issue_procs.values_list("id", flat=True)
+            issue_proc_id_list = list(selected_issue_procs.values_list("id", flat=True))
             issue_proc_and_related_article_proc_id_list = {
                 issue_proc_id: [] for issue_proc_id in (issue_proc_id_list or [])
             }

--- a/proc/tasks.py
+++ b/proc/tasks.py
@@ -956,8 +956,16 @@ def task_migrate_and_publish_articles_by_journal(
                 force_update=force_migrate_document_records or force_migrate_document_files,
                 to_migrate_articles=True,
             )
-            issue_proc_id_list = selected_issue_procs.values_list("id", flat=True)
-        
+            selected_article_issue_proc_ids = ArticleProc.select_items(
+                journal_proc_id_list=[journal_proc_id],
+                status_list=status,
+                force_update=force_update,
+            ).values_list("issue_proc_id", flat=True).distinct()
+            issue_proc_id_list = list(
+                set(selected_issue_procs.values_list("id", flat=True)).union(
+                    set(selected_article_issue_proc_ids)
+                )
+            )
         items_to_process = {
             issue_proc_id: None for issue_proc_id in (issue_proc_id_list or [])
         }

--- a/proc/tasks.py
+++ b/proc/tasks.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 import traceback
+import json
 
 from django.contrib.auth import get_user_model
 from django.db.models import Q
@@ -93,12 +94,26 @@ class TaskExecution:
 
         self.stats["total_to_process"] = self.total_to_process
         self.stats["total_processed"] = self.total_processed
+
         detail = {
             "params": self.params,
             "stats": self.stats,
             "events": self.events,
             "exceptions": self.exceptions,
         }
+        # adiciona este tratamento para garantir que o detail seja serializável, evitando que a task fique travada tentando salvar um detail com dados não serializáveis
+        try:
+            json.dumps(detail)
+        except Exception as exc_detail:
+            fixed_detail = {}
+            for key, value in detail.items():
+                try:
+                    json.dumps(value)
+                    fixed_detail[key] = value
+                except Exception:
+                    fixed_detail[key] = str(value)
+            detail = fixed_detail
+
         self.task_tracker.finish(
             completed=completed,
             exception=exception,

--- a/proc/tasks.py
+++ b/proc/tasks.py
@@ -949,37 +949,37 @@ def task_migrate_and_publish_articles_by_journal(
         total_processed = 0
         total_to_process = 0
 
-        if not issue_proc_id_list:
+        selected_issue_procs = None
+        if issue_proc_id_list:
+            issue_proc_and_related_article_proc_id_list = {
+                issue_proc_id: [] for issue_proc_id in issue_proc_id_list
+            }
+        else:
+            # identifica os issue_procs para processar com base nos status
             selected_issue_procs = IssueProc.select_items(
                 journal_proc_id_list=[journal_proc_id],
                 status_list=status,
                 force_update=force_migrate_document_records or force_migrate_document_files,
                 to_migrate_articles=True,
             )
-            selected_article_issue_proc_ids = ArticleProc.select_items(
+            issue_proc_id_list = selected_issue_procs.values_list("id", flat=True)
+            issue_proc_and_related_article_proc_id_list = {
+                issue_proc_id: [] for issue_proc_id in (issue_proc_id_list or [])
+            }
+
+            # identifica os article_procs e respectivo issue_proc_id para processar com base nos status dos article_proc
+            selected_article_proc_items = ArticleProc.select_items(
                 journal_proc_id_list=[journal_proc_id],
+                exclude_issue_proc_id_list=list(issue_proc_id_list),
                 status_list=status,
                 force_update=force_update,
-            ).values_list("issue_proc_id", flat=True).distinct()
-            issue_proc_id_list = list(
-                set(selected_issue_procs.values_list("id", flat=True)).union(
-                    set(selected_article_issue_proc_ids)
-                )
-            )
-        items_to_process = {
-            issue_proc_id: None for issue_proc_id in (issue_proc_id_list or [])
-        }
+            ).values_list("issue_proc_id", "id").distinct()
 
-        selected_article_proc_items = ArticleProc.select_items(
-            issue_proc_id_list=issue_proc_id_list,
-            status_list=status,
-            force_update=force_update,
-        ).values_list("issue_proc_id", "id").distinct()
-        for issue_proc_id, article_proc_id in selected_article_proc_items:
-            items_to_process.setdefault(issue_proc_id, []).append(article_proc_id)
+            for issue_proc_id, article_proc_id in selected_article_proc_items:
+                issue_proc_and_related_article_proc_id_list.setdefault(issue_proc_id, []).append(article_proc_id)
 
-        total_to_process = len(items_to_process)
-        for issue_proc_id, article_proc_id_list in items_to_process.items():
+        total_to_process = len(issue_proc_and_related_article_proc_id_list)
+        for issue_proc_id, article_proc_id_list in issue_proc_and_related_article_proc_id_list.items():
             total_processed += 1
             task_migrate_and_publish_articles_by_issue.delay(
                 user_id=user_id,
@@ -1043,7 +1043,16 @@ def task_migrate_and_publish_articles_by_issue(
 
         task_exec.item = str(issue_proc)
 
-        if not article_proc_id_list:
+        if article_proc_id_list:
+            # supõe-se que os registros e arquivos já foram migrados
+            # (issue_proc.docs_status e issue_proc.files_status estão como DONE)
+            total_articles_to_process = len(article_proc_id_list)
+            article_procs = ArticleProc.objects.select_related(
+                "issue_proc",
+            ).filter(
+                id__in=article_proc_id_list
+            )
+        else:
             task_exec.add_event("Migrate document records")
             total_migrated_records = issue_proc.migrate_document_records(user, force_migrate_document_records)
             task_exec.add_number("total_migrated_records", total_migrated_records)
@@ -1054,22 +1063,11 @@ def task_migrate_and_publish_articles_by_issue(
             )
             task_exec.add_number("total_migrated_files", total_migrated_files)
 
-        if article_proc_id_list:
-            total_articles_to_process = len(article_proc_id_list)
-            article_procs = ArticleProc.objects.select_related(
-                "issue_proc",
-            ).filter(
-                id__in=article_proc_id_list
-            )
-        else:
             task_exec.add_event("Select articles to migrate")
-            article_procs = ArticleProc.objects.select_related(
-                "issue_proc",
-            ).filter(
-                Q(migration_status__in=status)
-                | Q(xml_status__in=status)
-                | Q(sps_pkg_status__in=status),
-                issue_proc=issue_proc,
+            article_procs = ArticleProc.select_items(
+                issue_proc_id_list=[issue_proc_id],
+                status_list=status,
+                force_update=force_update,
             )
             total_articles_to_process = article_procs.count()
         task_exec.total_to_process = total_articles_to_process

--- a/tracker/choices.py
+++ b/tracker/choices.py
@@ -63,6 +63,16 @@ VALID_STATUS = PROGRESS_STATUS_FORCE_UPDATE + [PROGRESS_STATUS_DOING]
 
 
 def get_valid_status(status, force_update):
+    """
+    Retorna a lista de status a considerar no filtro de itens a processar.
+
+    - Se `status` for informado, verifica se os valores são válidos.
+    - Se `force_update` for True, retorna PROGRESS_STATUS_FORCE_UPDATE
+      (todos os status exceto DOING e IGNORED), permitindo reprocessar
+      inclusive itens já concluídos (DONE).
+    - Caso contrário, retorna PROGRESS_STATUS_REGULAR_TODO (REPROC + TODO),
+      processando apenas itens que ainda não foram concluídos.
+    """
     if status:
         status_list = set()
         if isinstance(status, str):
@@ -78,6 +88,15 @@ def get_valid_status(status, force_update):
 
 
 def allowed_to_run(status, force_update):
+    """
+    Indica se um item com o `status` dado pode ser executado.
+
+    - Permite executar itens com status DOING apenas quando `force_update`
+      é True (evita execuções concorrentes em condições normais).
+    - Permite executar itens cujo status está em PROGRESS_STATUS_FORCE_UPDATE
+      quando `force_update` é True, ou em PROGRESS_STATUS_REGULAR_TODO
+      independentemente de `force_update`.
+    """
     if force_update and status == PROGRESS_STATUS_DOING:
         return True
     return (


### PR DESCRIPTION
# refactor(proc/tasks): corrige seleção de artigos para migração e publicação

## O que esse PR faz

Refatora a cadeia de seleção de artigos na migração (`task_migrate_and_publish_articles` → `task_migrate_and_publish_articles_by_journal` → `task_migrate_and_publish_articles_by_issue`), substituindo a seleção baseada em strings PID (`article_pids` extraídos do `acron.id`) por seleção baseada em IDs de banco (`journal_proc_id`, `issue_proc_id`, `article_proc_id`).

O defeito principal era que os parâmetros `issue_folder` e `publication_year` eram silenciosamente ignorados na seleção de artigos. A filtragem anterior montava `params` mas os aplicava apenas para filtrar `JournalProc`, sem restringir os issues processados. Na prática, qualquer chamada com filtro por ano ou folder acabava reprocessando todos os artigos do journal/collection, anulando o propósito desses filtros e causando impacto desnecessário em tempo, recursos e estabilidade do ambiente de origem.

Além desse defeito, a abordagem anterior dependia de manipulação frágil de PIDs (slicing `article_pid[1:-5]` para agrupar por issue), cruzamento manual entre PIDs do `acron.id` e queries de status no banco, e union de sets de tuplas `(issue_proc_id, issue_pid)`. Inconsistências entre os PIDs e os registros reais no banco faziam artigos serem ignorados ou processados desnecessariamente.

Fix #919

### Mudanças principais

**Tasks (`proc/tasks.py`)**
- `task_migrate_and_publish_articles`: seleciona `journal_proc_id`s via `JournalProc.select_items()` e, quando há filtro por ano/folder, seleciona `issue_proc_id`s via `IssueProc.select_items(to_migrate_articles=True)`, agrupando por journal
- `task_migrate_and_publish_articles_by_journal`: recebe `journal_proc_id` e opcionalmente `issue_proc_id_list`. Dois caminhos distintos: (a) quando `issue_proc_id_list` vem da task pai (filtro por ano/folder), despacha apenas esses issues com lista vazia de articles, respeitando o escopo do filtro; (b) quando descobre localmente, seleciona issues via `IssueProc.select_items` e busca artigos órfãos (com status pendente em issues já concluídos) via `ArticleProc.select_items(exclude_issue_proc_id_list=...)` para não duplicar artigos já cobertos pelos issues selecionados
- `task_migrate_and_publish_articles_by_issue`: recebe `article_proc_id_list` (artigos específicos, supondo registros/arquivos já migrados) ou lista vazia (descobre quais processar via `migrate_document_records`/`migrate_document_files` + seleção por status via `ArticleProc.select_items`); normaliza `status` via `get_valid_status` no início

**Models (`proc/models.py`)**
- `JournalProc.select_items()`: novo classmethod para filtrar journals por collection e/ou acron
- `IssueProc.select_items()`: novo classmethod com suporte a filtro por collection, journal, ano, folder, status e modo `to_migrate_articles` (filtra por `docs_status`/`files_status`)
- `ArticleProc.select_items()`: novo classmethod para filtrar articles por journal, issue e status; suporta `exclude_issue_proc_id_list` para excluir artigos de issues já cobertos por outro caminho de seleção
- `set_status()` → `propagate_reproc_or_todo_status()`: renomeação para clareza
- `get_queryset_to_process()` → `filter_by_status()`: renomeação para clareza
- `get_files_from_classic_website()` → `migrate_document_files()`: renomeação para clareza
- `ArticleProc.mark_for_reprocessing()`: remove guards por `docs_status`/`files_status` do `issue_proc`, adiciona parâmetro `article_proc_ids`
- `ArticleProc.update_or_create`: seta `xml_status`, `sps_pkg_status`, `qa_ws_status` e `public_ws_status` como `TODO` ao criar/atualizar
- `ArticleProc.migrate_article`: seta `qa_ws_status` e `public_ws_status` como `TODO` após `create_or_update_item` bem-sucedido
- `IssueProc.migrate_document_records`: evita query duplicada ao banco; reutiliza queryset filtrando por `todo=True` quando não é `force_update`

**Controller (`migration/controller.py`)**
- `register_acron_id_file_content` → `import_journal_acron_id_records`: renomeação; agora propaga `REPROC` para `IssueProc.docs_status` e `ArticleProc.xml_status` dos registros afetados, garantindo que os `select_items` subsequentes os encontrem
- Corrige nome do related manager: `article_proc_set` → `articleproc_set` (convenção Django para nomes de model sem underscore)
- Remove retorno de `article_pids` no `detail`; retorna stats com contadores

**Outros**
- `tracker/choices.py`: adiciona docstrings a `get_valid_status()` e `allowed_to_run()`
- `proc/source_classic_website.py`: remove funções que não são mais chamadas (`create_or_update_journal_acron_id_file`, `migrate_document_records`, `migrate_document_files`) e o import de `tracker_choices` que só era usado por elas
- `proc/controller.py`: remove imports das funções removidas de `source_classic_website` (`create_or_update_journal_acron_id_file`, `migrate_document_records`, `migrate_document_files`)
- `proc/forms.py`: atualiza chamada `set_status` → `propagate_reproc_or_todo_status`

## Onde a revisão poderia começar

1. `proc/tasks.py` — a cadeia `task_migrate_and_publish_articles` → `_by_journal` → `_by_issue`, que é onde a lógica de seleção mudou de fato
2. `proc/models.py` — os novos `select_items()` e as mudanças em `migrate_article` / `update_or_create` / `migrate_document_records`
3. `migration/controller.py` — a propagação de `REPROC` em `import_journal_acron_id_records`

## Como testar manualmente

1. **Caso básico (sem filtros):** chamar `task_migrate_and_publish_articles` sem `publication_year`/`issue_folder` e verificar que todos os journals da collection são processados
2. **Com filtro por ano:** chamar com `publication_year=2024` e verificar que apenas issues daquele ano são selecionados, agrupados por journal
3. **Com filtro por folder:** chamar com `issue_folder="v50n1"` e verificar seleção restrita
4. **Reprocessamento:** alterar um registro no `acron.id` (novo artigo), rodar `task_migrate_and_publish_articles_by_journal` e verificar que o `IssueProc.docs_status` e `ArticleProc.xml_status` foram marcados como `REPROC`, e que os artigos novos são processados
5. **Issue novo (sem artigos):** verificar que quando `article_proc_id_list` é `None`, a task executa `migrate_document_records` e `migrate_document_files` antes de selecionar artigos
6. **Artigos órfãos (sem filtro por ano/folder):** chamar `task_migrate_and_publish_articles` sem `publication_year`/`issue_folder`, verificar que artigos com status pendente em issues já concluídos (DONE) são capturados pelo `exclude_issue_proc_id_list` e despachados corretamente
7. **Publicação:** verificar que após `migrate_article`, `qa_ws_status` e `public_ws_status` ficam como `TODO` e são processados pelo `task_sync_issue`

## Contexto

O defeito principal que motivou esta refatoração era os filtros `issue_folder` e `publication_year` serem silenciosamente ignorados — a query anterior os aplicava apenas no nível de `JournalProc`, não restringindo os issues processados. Isso fazia com que qualquer tentativa de processar um subconjunto específico acabasse reprocessando todos os artigos, com impacto direto em tempo, recursos e estabilidade do ambiente de origem. A refatoração corrige isso aplicando os filtros corretamente via `IssueProc.select_items()`. Além disso, substitui a seleção baseada em strings PID (frágil e propensa a inconsistências) por IDs de banco, com propagação explícita de status para garantir que registros afetados sejam encontrados pelas queries. A busca de artigos órfãos (com status pendente em issues já concluídos) é feita via `exclude_issue_proc_id_list` apenas quando a seleção é local, preservando o escopo de filtros quando informados pela task pai.