### PR TITLE
refactor(proc): reescreve reconciliação de PIDs em ClassicWebsiteArticlePidTracker

### DIFF
--- a/proc/article_controller.py
+++ b/proc/article_controller.py
@@ -232,8 +232,6 @@ class ClassicWebsiteArticlePidTracker:
                 creator=self.user,
                 collection=self.collection,
                 pid=pid,
-                data=None,
-                force_update=False,
                 pid_status=migration_choices.PID_STATUS_MISSING,
             )
 

--- a/proc/article_controller.py
+++ b/proc/article_controller.py
@@ -241,11 +241,12 @@ class ClassicWebsiteArticlePidTracker:
         ).values_list("pid", flat=True))
         pids_to_check = pids_to_check - migrated_and_matched_pids
 
-        # 2. Promove para MATCHED os registros que estavam MISSING mas já
+        # 2. Promove para MATCHED os registros que estavam com status diferente de MATCHED mas já
         #    possuem dados migrados e constam na lista do site clássico.
         migrated_pids = set(qs.filter(
             migrated_data__isnull=False,
-            pid_status=migration_choices.PID_STATUS_MISSING,
+        ).exclude(
+            pid_status=migration_choices.PID_STATUS_MATCHED,
         ).values_list("pid", flat=True))
         matched_pids = pids_to_check.intersection(migrated_pids)
         qs.filter(pid__in=matched_pids).update(pid_status=migration_choices.PID_STATUS_MATCHED)
@@ -259,7 +260,11 @@ class ClassicWebsiteArticlePidTracker:
 
         exceding_pids = unmatched_pids - pids_to_check
         if exceding_pids:
-            qs.filter(pid__in=exceding_pids).update(pid_status=migration_choices.PID_STATUS_EXCEEDING)
+            qs.filter(
+                pid__in=exceding_pids,
+            ).exclude(
+                pid_status=migration_choices.PID_STATUS_EXCEEDING
+            ).update(pid_status=migration_choices.PID_STATUS_EXCEEDING)
 
         # Retorna os PIDs que ainda não têm registro na base (precisam ser criados)
         return pids_to_check - unmatched_pids

--- a/proc/article_controller.py
+++ b/proc/article_controller.py
@@ -228,15 +228,14 @@ class ClassicWebsiteArticlePidTracker:
             return []
         for pid in new_pids:
             # Cria ou recupera o ArticleProc para este PID dentro da coleção
-            article_proc = ArticleProc.create_or_update(
-                issue_proc=self,
-                user=self.user,
+            yield ArticleProc(
+                creator=self.user,
+                collection=self.collection,
                 pid=pid,
                 data=None,
                 force_update=False,
+                pid_status=migration_choices.PID_STATUS_MISSING,
             )
-            if article_proc:
-                yield article_proc
 
     def update_pid_status(self, classic_website_pids):
         """

--- a/proc/article_controller.py
+++ b/proc/article_controller.py
@@ -196,16 +196,10 @@ class ClassicWebsiteArticlePidTracker:
         self.user = user
         self.collection = collection
 
-    def create_article_proc_for_pids(self, pids):
-        if not pids:
+    def create_article_proc_for_pids(self, new_pids):
+        if not new_pids:
             return []
-        registered_pids = set(
-            ArticleProc.objects.filter(
-                collection=self.collection, pid__in=pids
-            ).values_list("pid", flat=True)
-        )
-        todo = set(pids) - registered_pids
-        for pid in todo:
+        for pid in new_pids:
             yield ArticleProc(
                 pid=pid,
                 collection=self.collection,
@@ -214,38 +208,61 @@ class ClassicWebsiteArticlePidTracker:
             )
 
     def update_pid_status(self, classic_website_pids):
+        """
+        Reconcilia os PIDs do site clássico com os registros de ArticleProc
+        da coleção, atualizando o campo pid_status conforme necessário.
 
-        pids = set(classic_website_pids)
+        Regras aplicadas, em ordem:
+        1. PIDs já MATCHED com dados migrados são considerados concluídos e
+           removidos do conjunto de verificação (nenhuma ação necessária).
+        2. PIDs MISSING que agora possuem dados migrados são promovidos para
+           MATCHED.
+        3. PIDs presentes nos registros da base mas ausentes no site clássico
+           (excedentes) são marcados como EXCEEDING.
 
+        Args:
+            classic_website_pids: Conjunto (set) de PIDs provenientes do
+                site clássico para esta coleção.
+
+        Returns:
+            set: PIDs do site clássico que ainda não possuem registro
+                correspondente na base e precisam ser criados (novos PIDs).
+        """
         qs = ArticleProc.objects.filter(
-            collection=self.collection
-        ).exclude(
-            pid_status__in=[
-                migration_choices.PID_STATUS_EXCEEDING,
-            ]
+            collection=self.collection,
         )
-        
-        qs.filter(
+        pids_to_check = classic_website_pids
+
+        # 1. Remove do conjunto de verificação os PIDs que já estão MATCHED
+        #    e possuem dados migrados — não há nada mais a fazer para eles.
+        migrated_and_matched_pids = set(qs.filter(
             migrated_data__isnull=False,
-        ).exclude(
-            pid_status__in=[migration_choices.PID_STATUS_MATCHED]
-        ).update(pid_status=migration_choices.PID_STATUS_MATCHED)
-        pids = pids - set(qs.filter(pid_status=migration_choices.PID_STATUS_MATCHED).values_list("pid", flat=True))
+            pid_status=migration_choices.PID_STATUS_MATCHED,
+        ).values_list("pid", flat=True))
+        pids_to_check = pids_to_check - migrated_and_matched_pids
 
-        qs.filter(
-            migrated_data__isnull=True,
-        ).exclude(
-            pid_status__in=[migration_choices.PID_STATUS_MISSING],
-        ).update(pid_status=migration_choices.PID_STATUS_MISSING)
-        pids = pids - set(qs.filter(pid_status=migration_choices.PID_STATUS_MISSING).values_list("pid", flat=True))
+        # 2. Promove para MATCHED os registros que estavam MISSING mas já
+        #    possuem dados migrados e constam na lista do site clássico.
+        migrated_pids = set(qs.filter(
+            migrated_data__isnull=False,
+            pid_status=migration_choices.PID_STATUS_MISSING,
+        ).values_list("pid", flat=True))
+        matched_pids = pids_to_check.intersection(migrated_pids)
+        qs.filter(pid__in=matched_pids).update(pid_status=migration_choices.PID_STATUS_MATCHED)
+        pids_to_check = pids_to_check - matched_pids
 
-        qs.exclude(
-            pid_status__in=[migration_choices.PID_STATUS_MATCHED,
-                            migration_choices.PID_STATUS_MISSING]
-        ).update(pid_status=migration_choices.PID_STATUS_EXCEEDING)
-        pids = pids - set(qs.filter(pid_status=migration_choices.PID_STATUS_EXCEEDING).values_list("pid", flat=True))
+        # 3. Marca como EXCEEDING os registros que existem na base mas não
+        #    constam mais no site clássico (foram removidos ou são inválidos).
+        unmatched_pids = set(qs.exclude(
+            pid_status=migration_choices.PID_STATUS_MATCHED,
+        ).values_list("pid", flat=True))
 
-        return pids
+        exceding_pids = unmatched_pids - pids_to_check
+        if exceding_pids:
+            qs.filter(pid__in=exceding_pids).update(pid_status=migration_choices.PID_STATUS_EXCEEDING)
+
+        # Retorna os PIDs que ainda não têm registro na base (precisam ser criados)
+        return pids_to_check - unmatched_pids
     
     def bulk_create(self, new_pids):
         if new_pids:

--- a/proc/article_controller.py
+++ b/proc/article_controller.py
@@ -190,35 +190,69 @@ def publish_collection_articles(
 
 
 class ClassicWebsiteArticlePidTracker:
+    """
+    Rastreia e reconcilia os PIDs de artigos do site clássico com os registros
+    de ArticleProc de uma coleção.
+
+    Compara a lista de PIDs exportada pelo site clássico com os registros
+    existentes na base, atualizando os status (MATCHED, EXCEEDING) e criando
+    novos registros para PIDs ainda não cadastrados.
+    """
+
     TASK_NAME = "proc.source_classic_website.track_classic_website_article_pids"
 
     def __init__(self, user, collection):
+        """
+        Args:
+            user: Usuário responsável pelas operações de criação/atualização.
+            collection: Instância de Collection a ser rastreada.
+        """
         self.user = user
         self.collection = collection
 
     def create_article_proc_for_pids(self, new_pids):
+        """
+        Gera instâncias de ArticleProc para PIDs ainda não cadastrados.
+
+        Para cada PID em new_pids, tenta criar ou recuperar o ArticleProc
+        correspondente via ArticleProc.create_or_update. Apenas instâncias
+        criadas com sucesso são produzidas pelo gerador.
+
+        Args:
+            new_pids: Iterável de strings de PID a registrar.
+
+        Yields:
+            ArticleProc: Instância criada/atualizada para cada PID válido.
+        """
         if not new_pids:
             return []
         for pid in new_pids:
-            yield ArticleProc(
+            # Cria ou recupera o ArticleProc para este PID dentro da coleção
+            article_proc = ArticleProc.create_or_update(
+                issue_proc=self,
+                user=self.user,
                 pid=pid,
-                collection=self.collection,
-                creator=self.user,
-                pid_status=migration_choices.PID_STATUS_MISSING,
+                data=None,
+                force_update=False,
             )
+            if article_proc:
+                yield article_proc
 
     def update_pid_status(self, classic_website_pids):
         """
         Reconcilia os PIDs do site clássico com os registros de ArticleProc
         da coleção, atualizando o campo pid_status conforme necessário.
 
-        Regras aplicadas, em ordem:
+        Passos executados, em ordem:
         1. PIDs já MATCHED com dados migrados são considerados concluídos e
            removidos do conjunto de verificação (nenhuma ação necessária).
-        2. PIDs MISSING que agora possuem dados migrados são promovidos para
-           MATCHED.
-        3. PIDs presentes nos registros da base mas ausentes no site clássico
-           (excedentes) são marcados como EXCEEDING.
+        2. Registros com dados migrados mas com status diferente de MATCHED
+           que constam na lista do site clássico são promovidos para MATCHED.
+        3. Obtém o conjunto de PIDs registrados na base exceto os já MATCHED,
+           usado como referência para identificar novos e excedentes.
+        4. PIDs presentes na base (exceto MATCHED) mas ausentes no site clássico
+           são marcados como EXCEEDING; já EXCEEDING são ignorados para evitar
+           atualizações desnecessárias.
 
         Args:
             classic_website_pids: Conjunto (set) de PIDs provenientes do
@@ -241,8 +275,8 @@ class ClassicWebsiteArticlePidTracker:
         ).values_list("pid", flat=True))
         pids_to_check = pids_to_check - migrated_and_matched_pids
 
-        # 2. Promove para MATCHED os registros que estavam com status diferente de MATCHED mas já
-        #    possuem dados migrados e constam na lista do site clássico.
+        # 2. Promove para MATCHED os registros que possuem dados migrados mas
+        #    ainda não estão MATCHED e constam na lista do site clássico.
         migrated_pids = set(qs.filter(
             migrated_data__isnull=False,
         ).exclude(
@@ -252,24 +286,35 @@ class ClassicWebsiteArticlePidTracker:
         qs.filter(pid__in=matched_pids).update(pid_status=migration_choices.PID_STATUS_MATCHED)
         pids_to_check = pids_to_check - matched_pids
 
-        # 3. Marca como EXCEEDING os registros que existem na base mas não
-        #    constam mais no site clássico (foram removidos ou são inválidos).
-        unmatched_pids = set(qs.exclude(
+        # 3. Obtém os PIDs registrados exceto os já MATCHED para comparação com a lista do site clássico
+        registered_pids_except_matched = set(qs.exclude(
             pid_status=migration_choices.PID_STATUS_MATCHED,
         ).values_list("pid", flat=True))
 
-        exceding_pids = unmatched_pids - pids_to_check
-        if exceding_pids:
+        # 4. Marca como EXCEEDING os registros que existem na base mas não
+        #    constam mais no site clássico (foram removidos ou são inválidos).
+        exceeding_pids = registered_pids_except_matched - pids_to_check
+        if exceeding_pids:
             qs.filter(
-                pid__in=exceding_pids,
+                pid__in=exceeding_pids,
             ).exclude(
                 pid_status=migration_choices.PID_STATUS_EXCEEDING
             ).update(pid_status=migration_choices.PID_STATUS_EXCEEDING)
 
         # Retorna os PIDs que ainda não têm registro na base (precisam ser criados)
-        return pids_to_check - unmatched_pids
+        return pids_to_check - registered_pids_except_matched
     
     def bulk_create(self, new_pids):
+        """
+        Persiste em lote os ArticleProc gerados para os novos PIDs.
+
+        Delega a geração das instâncias a create_article_proc_for_pids e
+        executa o INSERT em lotes de 500 registros para reduzir o número de
+        queries ao banco.
+
+        Args:
+            new_pids: Conjunto de PIDs a criar; ignorado se vazio.
+        """
         if new_pids:
             ArticleProc.objects.bulk_create(self.create_article_proc_for_pids(new_pids), batch_size=500)
 

--- a/proc/models.py
+++ b/proc/models.py
@@ -476,6 +476,11 @@ class BaseProc(CommonControlField):
         try:
             obj = None
             operation = None
+            detail = {
+                "collection": collection.acron,
+                "pid": pid,
+                "had_data": bool(data),
+            }
             obj = cls.get_or_create(user, collection, pid)
             if (
                 obj.migration_status != tracker_choices.PROGRESS_STATUS_TODO
@@ -484,15 +489,18 @@ class BaseProc(CommonControlField):
                 return obj
 
             operation = obj.start(user, f"get data from classic website {pid}")
-            obj.migrated_data = cls.MigratedDataClass.register_classic_website_data(
-                user,
-                collection,
-                pid,
-                data,
-                content_type,
-                force_update,
-            )
-            obj.migration_status = obj.migrated_data.migration_status
+
+            if data:
+                obj.migrated_data = cls.MigratedDataClass.register_classic_website_data(
+                    user,
+                    collection,
+                    pid,
+                    data,
+                    content_type,
+                    force_update,
+                )
+                obj.migration_status = obj.migrated_data.migration_status
+                detail = obj.migrated_data.data
             obj.save()
             operation.finish(
                 user,
@@ -500,7 +508,7 @@ class BaseProc(CommonControlField):
                     obj.migration_status == tracker_choices.PROGRESS_STATUS_TODO
                 ),
                 message=None,
-                detail=obj.migrated_data.data,
+                detail=detail,
             )
             return obj
         except Exception as e:
@@ -1448,8 +1456,12 @@ class IssueProc(BaseProc, ClusterableModel):
                         journal_data,
                         issue_data,
                     )
-                    article_proc = self.create_or_update_article_proc(
-                        user, record.item_pid, data["data"], force_update
+                    article_proc = ArticleProc.create_or_update(
+                        issue_proc=self,
+                        user=user,
+                        pid=record.item_pid,
+                        data=data["data"],
+                        force_update=force_update,
                     )
                     total += 1
                     if not article_proc:
@@ -1501,35 +1513,6 @@ class IssueProc(BaseProc, ClusterableModel):
         if total_migrated_articles == total_document_records:
             return tracker_choices.PROGRESS_STATUS_DONE
         return tracker_choices.PROGRESS_STATUS_PENDING
-
-    def create_or_update_article_proc(self, user, pid, data, force_update):
-        article_proc = ArticleProc.register_classic_website_data(
-            user=user,
-            collection=self.collection,
-            pid=pid,
-            data=data,
-            content_type="article",
-            force_update=force_update,
-        )
-        if not article_proc:
-            raise ArticleProc.DoesNotExist(f"Unable to create ArticleProc for {pid}")
-
-        migrated_article = article_proc.migrated_data
-        document = migrated_article.document
-
-        if not migrated_article.file_type:
-            migrated_article.file_type = document.file_type
-            migrated_article.save()
-
-        article_proc.update(
-            issue_proc=self,
-            pkg_name=document.filename_without_extension,
-            migration_status=tracker_choices.PROGRESS_STATUS_TODO,
-            user=user,
-            main_lang=document.original_language,
-            force_update=force_update,
-        )
-        return article_proc
 
     @staticmethod
     def get_issue_pid(issue):
@@ -1658,6 +1641,42 @@ class ArticleProc(BaseProc, ClusterableModel):
         ]
 
     @classmethod
+    def create_or_update(cls, issue_proc, user, pid, data, force_update):
+        article_proc = cls.register_classic_website_data(
+            user=user,
+            collection=issue_proc.collection,
+            pid=pid,
+            data=data,
+            content_type="article",
+            force_update=force_update,
+        )
+        if not article_proc:
+            raise cls.DoesNotExist(f"Unable to create ArticleProc for {pid}")
+
+        pkg_name = None
+        main_lang = None
+        migrated_article = article_proc.migrated_data
+
+        if migrated_article:
+            document = migrated_article.document
+            pkg_name = document.filename_without_extension
+            main_lang = document.original_language
+
+            if not migrated_article.file_type:
+                migrated_article.file_type = document.file_type
+                migrated_article.save()
+        
+        article_proc.update(
+            issue_proc=issue_proc,
+            pkg_name=pkg_name,
+            migration_status=tracker_choices.PROGRESS_STATUS_TODO,
+            user=user,
+            main_lang=main_lang,
+            force_update=force_update,
+        )
+        return article_proc
+
+    @classmethod
     def mark_for_reprocessing(cls, issue_proc, article_pids=None, article_proc_ids=None):
         params = {"issue_proc": issue_proc}
         if article_pids:
@@ -1716,6 +1735,8 @@ class ArticleProc(BaseProc, ClusterableModel):
             self.pkg_name = pkg_name
             self.main_lang = main_lang
             self.migration_status = migration_status or self.migration_status
+            if not self.migrated_data or not self.migrated_data.data:
+                self.pid_status = migration_choices.PID_STATUS_MISSING
             self.xml_status = tracker_choices.PROGRESS_STATUS_TODO
             self.sps_pkg_status = tracker_choices.PROGRESS_STATUS_TODO
             self.qa_ws_status = tracker_choices.PROGRESS_STATUS_TODO


### PR DESCRIPTION
### O que esse PR faz

Reescreve os métodos `update_pid_status` e `create_article_proc_for_pids` da classe `ClassicWebsiteArticlePidTracker` para tornar a lógica de reconciliação de PIDs mais clara, correta e eficiente.

A versão anterior executava múltiplos `update` + `filter` + `values_list` sequenciais com lógica de exclusão difícil de acompanhar. A nova versão segue 3 etapas explícitas:
1. Remove do conjunto de verificação os PIDs já `MATCHED` com dados migrados (nada a fazer).
2. Promove para `MATCHED` os registros com **qualquer status diferente de `MATCHED`** que já possuem `migrated_data` e constam no site clássico — cobre não apenas `MISSING` mas também estados intermediários como `EXCEEDING` que tenham recebido dados migrados.
3. Marca como `EXCEEDING` os registros presentes na base mas ausentes no site clássico, **apenas se ainda não estiverem nesse status** (evita writes desnecessários ao banco).

O método agora retorna apenas os PIDs que precisam ser criados, eliminando a necessidade de `create_article_proc_for_pids` fazer sua própria consulta de deduplicação.

Fixes #922

### Onde a revisão poderia começar

`proc/article_controller.py`, método `update_pid_status` — a docstring descreve o contrato completo. Atenção especial à etapa 2 (`exclude(MATCHED)` em vez de `filter(MISSING)`) e à etapa 3 (`exclude(EXCEEDING)` antes do update).

### Como testar manualmente

1. Executar o fluxo de reconciliação para uma coleção com artigos em estados variados (`MATCHED`, `MISSING`, `EXCEEDING`).
2. Verificar que PIDs já migrados e matched não são reprocessados.
3. Verificar que PIDs com `migrated_data` em **qualquer status diferente de MATCHED** (ex: `MISSING`, `EXCEEDING`) são promovidos para matched.
4. Verificar que PIDs ausentes no site clássico são marcados como exceeding, e que registros já `EXCEEDING` não geram update redundante.
5. Verificar que apenas PIDs novos (sem registro na base) são retornados para criação.

### Contexto

A lógica anterior era funcional mas difícil de manter: múltiplas queries encadeadas com `exclude` tornavam o fluxo de dados opaco. A reescrita prioriza legibilidade e reduz o número de roundtrips ao banco.