### PR TITLE
Corrige a possível causa da duplicação de Article

### DIFF
--- a/article/models.py
+++ b/article/models.py
@@ -235,6 +235,7 @@ class Article(ClusterableModel, CommonControlField):
         except cls.MultipleObjectsReturned:
             items = cls.objects.filter(pid_v2=pid_v2).order_by("-updated")
             obj = items.first()
+            obj.updated_by = user
             for item in items[1:]:
                 item.delete()
         except cls.DoesNotExist:
@@ -267,35 +268,6 @@ class Article(ClusterableModel, CommonControlField):
         obj.add_article_titles(user)
         obj.add_doi_with_lang(user, xml_with_pre.article_doi_with_lang)
         return obj
-
-    def delete(self, using=None, keep_parents=False):
-        """
-        Remove o artigo e seus objetos auxiliares exclusivos.
-
-        Antes de excluir o registro de Article, preserva referências para
-        SPSPkg e PidProviderXML (cujos FKs são SET_NULL e não seriam
-        removidos automaticamente). Após a exclusão do Article — que
-        aciona CASCADE em ArticleDOIWithLang, ArticleTitle, RelatedItem e
-        RequestArticleChange — os objetos auxiliares são deletados.
-
-        Args:
-            using: Alias do banco de dados a utilizar (repassado ao super).
-            keep_parents: Se True, mantém registros pai em herança multi-tabela.
-        """
-        # Preserva referências antes de a exclusão zerá-las (SET_NULL)
-        sps_pkg = self.sps_pkg
-        pp_xml = self.pp_xml
-
-        with transaction.atomic():
-            # Exclui o Article e todos os relacionamentos CASCADE
-            super().delete(using=using, keep_parents=keep_parents)
-
-            # Remove SPSPkg e PidProviderXML que pertenciam exclusivamente
-            # a este artigo e não seriam limpos pelo CASCADE
-            if sps_pkg:
-                sps_pkg.delete()
-            if pp_xml:
-                pp_xml.delete()
 
     def add_doi_with_lang(self, user, article_doi_with_lang):
         for item in article_doi_with_lang:

--- a/article/models.py
+++ b/article/models.py
@@ -15,6 +15,7 @@ from wagtail.admin.panels import FieldPanel, InlinePanel, MultiFieldPanel
 from wagtail.models import Orderable
 from wagtailautocomplete.edit_handlers import AutocompletePanel
 
+from migration.models import MigratedArticle
 from article.forms import ArticleForm, RelatedItemForm, RequestArticleChangeForm
 from collection.models import Language
 from core.models import CommonControlField, HTMLTextModel
@@ -217,21 +218,28 @@ class Article(ClusterableModel, CommonControlField):
 
     @classmethod
     def create_or_update(cls, user, sps_pkg, issue=None, journal=None, position=None):
-        if not sps_pkg or sps_pkg.pid_v3 is None:
-            raise ValueError("create_article requires sps_pkg with pid_v3")
+        if not sps_pkg:
+            raise ValueError("create_article requires sps_pkg with pid_v2")
 
+        xml_with_pre = sps_pkg.xml_with_pre
+        if not xml_with_pre:
+            raise ValueError(f"SPSPkg {sps_pkg} is missing xml_with_pre")
+        
+        pid_v2 = xml_with_pre.v2
+        if not pid_v2:
+            raise ValueError(f"SPSPkg {sps_pkg} xml_with_pre is missing pid_v2")
         try:
-            obj = cls.get(sps_pkg.pid_v3)
+            # usa pid_v2 para evitar duplicação por usar o pid_v3 como chave única, e o pid_v2 é o mesmo para artigos duplicados
+            obj = cls.objects.get(pid_v2=pid_v2)
             obj.updated_by = user
         except cls.DoesNotExist:
             obj = cls()
             obj.pid_v3 = sps_pkg.pid_v3
+            obj.pid_v2 = pid_v2
             obj.creator = user
 
         obj.sps_pkg = sps_pkg
-
-        xml_with_pre = sps_pkg.xml_with_pre
-        obj.pid_v2 = xml_with_pre.v2
+        obj.pid_v2 = pid_v2
         obj.article_type = xml_with_pre.xmltree.find(".").get("article-type")
 
         if journal:
@@ -477,23 +485,6 @@ class Article(ClusterableModel, CommonControlField):
             .values_list(field_name, flat=True)
         )
 
-    @staticmethod
-    def has_valid_pid_v2(pid_v2, order):
-        """
-        Check if pid_v2 last 5 digits match the order value
-        (from MigratedArticle.document.order / v121) padded with zeros.
-        """
-        try:
-            if not pid_v2 or not order:
-                return True
-            if len(pid_v2) < 5:
-                return True
-            expected_suffix = str(int(str(order).strip())).zfill(5)
-            actual_suffix = pid_v2[-5:]
-            return actual_suffix == expected_suffix
-        except (TypeError, IndexError, ValueError):
-            return True
-
     @classmethod
     def exclude_articles_with_invalid_pid_v2(cls, issue=None):
         """
@@ -505,6 +496,7 @@ class Article(ClusterableModel, CommonControlField):
         from proc.models import ArticleProc
 
         filters = {
+            "pid_v2__isnull": False,
             "migrated_data__isnull": False,
             "sps_pkg__isnull": False,
         }
@@ -521,7 +513,7 @@ class Article(ClusterableModel, CommonControlField):
         ]
         articles_by_sps_pkg = {}
         if sps_pkg_id_list:
-            for article in Article.objects.filter(
+            for article in Article.objects.select_related("sps_pkg", "pp_xml").filter(
                 sps_pkg_id__in=sps_pkg_id_list
             ).only("id", "pid_v2", "sps_pkg_id", "pp_xml_id"):
                 articles_by_sps_pkg[article.sps_pkg_id] = article
@@ -536,29 +528,15 @@ class Article(ClusterableModel, CommonControlField):
                 article = articles_by_sps_pkg.get(article_proc.sps_pkg_id)
                 if not article or not article.pid_v2:
                     continue
-
-                order = article_proc.migrated_data.document.order
-                if not order:
-                    continue
-
-                if not cls.has_valid_pid_v2(article.pid_v2, order):
-                    try:
-                        expected_suffix = str(int(str(order).strip())).zfill(5)
-                    except (TypeError, ValueError):
-                        expected_suffix = str(order)
-                    events.append(
-                        f"Invalid pid_v2: {article.pid_v2} "
-                        f"(order={order}, "
-                        f"expected suffix={expected_suffix}, "
-                        f"actual suffix={article.pid_v2[-5:]})"
-                    )
+                if MigratedArticle.valid_pid(article.pid_v2):
+                    # houve um erro o sistema de migração que criou pid_v2 aleatoriamente no lugar de usar o pid_v2 original
                     article_ids.append(article.id)
                     if article.sps_pkg_id:
                         sps_pkg_ids.add(article.sps_pkg_id)
                     if article.pp_xml_id:
                         pp_xml_ids.add(article.pp_xml_id)
             except Exception as e:
-                logging.exception(
+                events.append(
                     f"Error checking pid_v2 for ArticleProc {article_proc}: {e}"
                 )
 

--- a/article/models.py
+++ b/article/models.py
@@ -232,6 +232,11 @@ class Article(ClusterableModel, CommonControlField):
             # usa pid_v2 para evitar duplicação por usar o pid_v3 como chave única, e o pid_v2 é o mesmo para artigos duplicados
             obj = cls.objects.get(pid_v2=pid_v2)
             obj.updated_by = user
+        except cls.MultipleObjectsReturned:
+            items = cls.objects.filter(pid_v2=pid_v2).order_by("-updated")
+            obj = items.first()
+            for item in items[1:]:
+                item.delete()
         except cls.DoesNotExist:
             obj = cls()
             obj.pid_v3 = sps_pkg.pid_v3
@@ -262,6 +267,35 @@ class Article(ClusterableModel, CommonControlField):
         obj.add_article_titles(user)
         obj.add_doi_with_lang(user, xml_with_pre.article_doi_with_lang)
         return obj
+
+    def delete(self, using=None, keep_parents=False):
+        """
+        Remove o artigo e seus objetos auxiliares exclusivos.
+
+        Antes de excluir o registro de Article, preserva referências para
+        SPSPkg e PidProviderXML (cujos FKs são SET_NULL e não seriam
+        removidos automaticamente). Após a exclusão do Article — que
+        aciona CASCADE em ArticleDOIWithLang, ArticleTitle, RelatedItem e
+        RequestArticleChange — os objetos auxiliares são deletados.
+
+        Args:
+            using: Alias do banco de dados a utilizar (repassado ao super).
+            keep_parents: Se True, mantém registros pai em herança multi-tabela.
+        """
+        # Preserva referências antes de a exclusão zerá-las (SET_NULL)
+        sps_pkg = self.sps_pkg
+        pp_xml = self.pp_xml
+
+        with transaction.atomic():
+            # Exclui o Article e todos os relacionamentos CASCADE
+            super().delete(using=using, keep_parents=keep_parents)
+
+            # Remove SPSPkg e PidProviderXML que pertenciam exclusivamente
+            # a este artigo e não seriam limpos pelo CASCADE
+            if sps_pkg:
+                sps_pkg.delete()
+            if pp_xml:
+                pp_xml.delete()
 
     def add_doi_with_lang(self, user, article_doi_with_lang):
         for item in article_doi_with_lang:
@@ -496,7 +530,7 @@ class Article(ClusterableModel, CommonControlField):
         from proc.models import ArticleProc
 
         filters = {
-            "pid_v2__isnull": False,
+            "pid__isnull": False,
             "migrated_data__isnull": False,
             "sps_pkg__isnull": False,
         }
@@ -528,7 +562,7 @@ class Article(ClusterableModel, CommonControlField):
                 article = articles_by_sps_pkg.get(article_proc.sps_pkg_id)
                 if not article or not article.pid_v2:
                     continue
-                if MigratedArticle.valid_pid(article.pid_v2):
+                if not MigratedArticle.valid_pid(article.pid_v2):
                     # houve um erro o sistema de migração que criou pid_v2 aleatoriamente no lugar de usar o pid_v2 original
                     article_ids.append(article.id)
                     if article.sps_pkg_id:

--- a/article/test_models.py
+++ b/article/test_models.py
@@ -2,91 +2,79 @@ import unittest
 from unittest.mock import MagicMock, Mock, patch
 
 from article.models import Article
+from migration.models import MigratedArticle
 
 
-class ArticleHasValidPidV2TestCase(unittest.TestCase):
-    """Test cases for Article.has_valid_pid_v2() static method."""
+class MigratedArticleValidPidTestCase(unittest.TestCase):
+    """Test cases for MigratedArticle.valid_pid() class method.
 
-    def test_valid_pid_v2_matching_order(self):
-        """pid_v2 last 5 digits match order zero-padded."""
-        self.assertTrue(Article.has_valid_pid_v2("S0034-77442021000600036", "00036"))
+    A PID é válido se, e somente se, tem exatamente 23 caracteres e existe
+    um registro MigratedArticle correspondente no banco de dados.
+    """
 
-    def test_valid_pid_v2_matching_order_without_leading_zeros(self):
-        """pid_v2 last 5 digits match order even when order has no leading zeros."""
-        self.assertTrue(Article.has_valid_pid_v2("S0034-77442021000600036", "36"))
+    PID_23 = "S0034-77442021000600036"  # exatamente 23 caracteres
 
-    def test_invalid_pid_v2_not_matching_order(self):
-        """pid_v2 last 5 digits don't match order."""
-        self.assertFalse(Article.has_valid_pid_v2("S0034-77442021060626158", "36"))
+    @patch("migration.models.MigratedArticle.objects")
+    def test_valid_pid_length_23_exists_in_db(self, mock_objects):
+        """Returns True when pid has 23 chars and exists in DB."""
+        mock_objects.filter.return_value.exists.return_value = True
+        self.assertTrue(MigratedArticle.valid_pid(self.PID_23))
 
-    def test_valid_when_pid_v2_is_none(self):
-        """Returns True when pid_v2 is None (can't validate)."""
-        self.assertTrue(Article.has_valid_pid_v2(None, "36"))
+    @patch("migration.models.MigratedArticle.objects")
+    def test_invalid_pid_not_in_db(self, mock_objects):
+        """Returns False when pid has 23 chars but does not exist in DB."""
+        mock_objects.filter.return_value.exists.return_value = False
+        self.assertFalse(MigratedArticle.valid_pid(self.PID_23))
 
-    def test_valid_when_order_is_none(self):
-        """Returns True when order is None (can't validate)."""
-        self.assertTrue(Article.has_valid_pid_v2("S0034-77442021000600036", None))
+    def test_invalid_when_pid_is_none(self):
+        """Returns False when pid is None (falsy)."""
+        self.assertFalse(MigratedArticle.valid_pid(None))
 
-    def test_valid_when_order_is_empty(self):
-        """Returns True when order is empty string (can't validate)."""
-        self.assertTrue(Article.has_valid_pid_v2("S0034-77442021000600036", ""))
+    def test_invalid_when_pid_is_empty(self):
+        """Returns False when pid is empty string (falsy)."""
+        self.assertFalse(MigratedArticle.valid_pid(""))
 
-    def test_valid_with_order_zero(self):
-        """Order 0 matches suffix 00000."""
-        self.assertTrue(Article.has_valid_pid_v2("S003477442021000600000", "0"))
+    def test_invalid_when_pid_too_short(self):
+        """Returns False when pid has fewer than 23 chars."""
+        self.assertFalse(MigratedArticle.valid_pid(self.PID_23[:-1]))  # 22 chars
 
-    def test_invalid_with_order_1(self):
-        """Order 1 should match suffix 00001, not 26158."""
-        self.assertFalse(Article.has_valid_pid_v2("S0034-77442021060626158", "1"))
-
-    def test_valid_when_pid_v2_too_short(self):
-        """Returns True when pid_v2 has fewer than 5 chars."""
-        self.assertTrue(Article.has_valid_pid_v2("S034", "36"))
-
-    def test_valid_when_pid_v2_is_empty(self):
-        """Returns True when pid_v2 is empty string."""
-        self.assertTrue(Article.has_valid_pid_v2("", "36"))
-
-    def test_valid_when_order_is_non_numeric(self):
-        """Returns True when order is non-numeric (can't validate)."""
-        self.assertTrue(Article.has_valid_pid_v2("S0034-77442021000600036", "abc"))
+    def test_invalid_when_pid_too_long(self):
+        """Returns False when pid has more than 23 chars."""
+        self.assertFalse(MigratedArticle.valid_pid(self.PID_23 + "0"))  # 24 chars
 
 
 class ArticleExcludeArticlesWithInvalidPidV2TestCase(unittest.TestCase):
     """Test cases for Article.exclude_articles_with_invalid_pid_v2()."""
 
-    def _make_article_proc(self, article_id, pid_v2, order, sps_pkg_id=1, pp_xml_id=1):
+    def _make_article_proc(self, article_id, pid_v2, sps_pkg_id=1, pp_xml_id=1):
         mock_article = Mock()
         mock_article.id = article_id
         mock_article.pid_v2 = pid_v2
         mock_article.sps_pkg_id = sps_pkg_id
         mock_article.pp_xml_id = pp_xml_id
 
-        mock_document = Mock()
-        mock_document.order = order
-
-        mock_migrated_data = Mock()
-        mock_migrated_data.document = mock_document
-
         mock_article_proc = Mock()
         mock_article_proc.sps_pkg_id = sps_pkg_id
-        mock_article_proc.migrated_data = mock_migrated_data
         return mock_article_proc, mock_article
 
+    @patch("migration.models.MigratedArticle.valid_pid", return_value=True)
     @patch("article.models.Article.objects")
-    def test_no_invalid_articles(self, mock_objects):
+    def test_no_invalid_articles(self, mock_article_objects, mock_valid_pid):
         """No articles deleted when all have valid pid_v2."""
         mock_article_proc, mock_article = self._make_article_proc(
-            article_id=1, pid_v2="S0034-77442021000600036", order="36"
+            article_id=1, pid_v2="S0034-77442021000600036"
         )
 
         mock_ap_qs = MagicMock()
         mock_ap_qs.filter.return_value = mock_ap_qs
         mock_ap_qs.select_related.return_value = [mock_article_proc]
 
-        mock_article_qs = MagicMock()
-        mock_article_qs.only.return_value = [mock_article]
-        mock_objects.filter.return_value = mock_article_qs
+        # Article.objects.select_related(...).filter(...).only(...) chain
+        mock_article_filter_qs = MagicMock()
+        mock_article_filter_qs.only.return_value = [mock_article]
+        mock_article_select_qs = MagicMock()
+        mock_article_select_qs.filter.return_value = mock_article_filter_qs
+        mock_article_objects.select_related.return_value = mock_article_select_qs
 
         with patch("proc.models.ArticleProc.objects", mock_ap_qs):
             events = Article.exclude_articles_with_invalid_pid_v2()
@@ -96,11 +84,12 @@ class ArticleExcludeArticlesWithInvalidPidV2TestCase(unittest.TestCase):
     @patch("article.models.transaction")
     @patch("article.models.PidProviderXML")
     @patch("article.models.SPSPkg")
+    @patch("migration.models.MigratedArticle.valid_pid", return_value=False)
     @patch("article.models.Article.objects")
-    def test_deletes_invalid_article(self, mock_objects, mock_sps_pkg, mock_pp_xml, mock_transaction):
+    def test_deletes_invalid_article(self, mock_article_objects, mock_valid_pid, mock_sps_pkg, mock_pp_xml, mock_transaction):
         """Deletes migrated article with invalid pid_v2."""
         mock_article_proc, mock_article = self._make_article_proc(
-            article_id=42, pid_v2="S0034-77442021060626158", order="36",
+            article_id=42, pid_v2="S0034-77442021060626158",
             sps_pkg_id=10, pp_xml_id=20
         )
 
@@ -108,14 +97,17 @@ class ArticleExcludeArticlesWithInvalidPidV2TestCase(unittest.TestCase):
         mock_ap_qs.filter.return_value = mock_ap_qs
         mock_ap_qs.select_related.return_value = [mock_article_proc]
 
-        mock_article_qs = MagicMock()
-        mock_article_qs.only.return_value = [mock_article]
+        # Article.objects.select_related(...).filter(...).only(...) — bulk-fetch articles
+        mock_article_filter_qs = MagicMock()
+        mock_article_filter_qs.only.return_value = [mock_article]
+        mock_article_select_qs = MagicMock()
+        mock_article_select_qs.filter.return_value = mock_article_filter_qs
+        mock_article_objects.select_related.return_value = mock_article_select_qs
 
+        # Article.objects.filter(id__in=...).delete() — delete invalid articles
         mock_delete_qs = MagicMock()
         mock_delete_qs.delete.return_value = (1, {})
-
-        # First call: bulk fetch articles; subsequent calls: delete operations
-        mock_objects.filter.side_effect = [mock_article_qs, mock_delete_qs]
+        mock_article_objects.filter.return_value = mock_delete_qs
 
         mock_sps_pkg_qs = MagicMock()
         mock_sps_pkg_qs.delete.return_value = (1, {})
@@ -131,24 +123,24 @@ class ArticleExcludeArticlesWithInvalidPidV2TestCase(unittest.TestCase):
         with patch("proc.models.ArticleProc.objects", mock_ap_qs):
             events = Article.exclude_articles_with_invalid_pid_v2()
 
-        self.assertTrue(any("Invalid pid_v2" in e for e in events))
         self.assertTrue(any("Articles deletados" in e for e in events))
 
-    def test_with_journal_filter(self):
-        """Filters ArticleProc by journal when provided."""
-        mock_journal = Mock()
+    def test_with_issue_filter(self):
+        """Filters ArticleProc by issue when provided."""
+        mock_issue = Mock()
 
         mock_ap_qs = MagicMock()
         mock_ap_qs.filter.return_value = mock_ap_qs
         mock_ap_qs.select_related.return_value = []
 
         with patch("proc.models.ArticleProc.objects", mock_ap_qs):
-            events = Article.exclude_articles_with_invalid_pid_v2(journal=mock_journal)
+            events = Article.exclude_articles_with_invalid_pid_v2(issue=mock_issue)
 
         mock_ap_qs.filter.assert_called_once_with(
+            pid__isnull=False,
             migrated_data__isnull=False,
             sps_pkg__isnull=False,
-            issue_proc__journal_proc__journal=mock_journal,
+            issue_proc__issue=mock_issue,
         )
 
 
@@ -167,12 +159,12 @@ class ArticleExcludeInconvenientArticlesTestCase(unittest.TestCase):
         mock_repeated_qs.__iter__ = Mock(return_value=iter([]))
         mock_repeated.return_value = mock_repeated_qs
 
-        mock_journal = Mock()
+        mock_issue = Mock()
         mock_user = Mock()
 
-        results = Article.exclude_inconvenient_articles(mock_journal, mock_user)
+        results = Article.exclude_inconvenient_articles(mock_issue, mock_user)
 
-        mock_invalid.assert_called_once_with(mock_journal)
+        mock_invalid.assert_called_once_with(mock_issue)
         self.assertEqual(mock_repeated.call_count, 2)
         self.assertIn("invalid pid_v2 event", results["events"])
 

--- a/migration/models.py
+++ b/migration/models.py
@@ -714,14 +714,9 @@ class MigratedArticle(MigratedData):
 
     @classmethod
     def valid_pid(cls, pid):
-        try:
-            MigratedArticle.objects.get(pid=pid)
-            return True
-        except MigratedArticle.DoesNotExist:
+        if not pid or len(pid) != 23:
             return False
-        except MigratedArticle.MultipleObjectsReturned:
-            # ok, pois significa que é válido
-            return True
+        return MigratedArticle.objects.filter(pid=pid).exists()
 
 
 class JournalAcronIdFile(CommonControlField, ClusterableModel):

--- a/migration/models.py
+++ b/migration/models.py
@@ -712,6 +712,17 @@ class MigratedArticle(MigratedData):
             article = self.pid[-5:]
             return f"{journal}/{issue}/{article}"
 
+    @classmethod
+    def valid_pid(cls, pid):
+        try:
+            MigratedArticle.objects.get(pid=pid)
+            return True
+        except MigratedArticle.DoesNotExist:
+            return False
+        except MigratedArticle.MultipleObjectsReturned:
+            # ok, pois significa que é válido
+            return True
+
 
 class JournalAcronIdFile(CommonControlField, ClusterableModel):
     collection = models.ForeignKey(


### PR DESCRIPTION
#### O que esse PR faz?

Corrige a lógica de identificação e deduplicação de artigos, substituindo `pid_v3` por `pid_v2` como chave de busca em `Article.create_or_update`, e substituindo a validação de `pid_v2` por sufixo de order por uma consulta direta à tabela `MigratedArticle`.

**Problemas que resolve:**

- **Duplicação de artigos:** ao usar `pid_v3` como chave de busca, artigos que mudavam de `pid_v3` mas mantinham o mesmo `pid_v2` eram criados em duplicata. Agora a busca é feita por `pid_v2`, que é estável para o mesmo artigo.
- **Validação frágil de `pid_v2`:** o método `has_valid_pid_v2` comparava os últimos 5 dígitos do `pid_v2` com o campo `order` do documento migrado, uma heurística que podia falhar silenciosamente. Agora a validação é feita consultando diretamente se o `pid_v2` existe na tabela `MigratedArticle` (método `MigratedArticle.valid_pid`).
- **Queries N+1:** adiciona `select_related('sps_pkg', 'pp_xml')` na consulta de artigos em `exclude_articles_with_invalid_pid_v2`.

#### Onde a revisão poderia começar?

1. `migration/models.py` — novo método `MigratedArticle.valid_pid`
2. `article/models.py` — alterações em `create_or_update` e `exclude_articles_with_invalid_pid_v2`

#### Como este poderia ser testado manualmente?

1. **Deduplicação (`create_or_update`):**
   - Ter um artigo já cadastrado com um dado `pid_v2`
   - Submeter um pacote SPS com o mesmo `pid_v2` mas `pid_v3` diferente
   - Verificar que o artigo existente é atualizado (não duplicado)

2. **Validação de `pid_v2` (`exclude_articles_with_invalid_pid_v2`):**
   - Ter artigos com `pid_v2` que existem em `MigratedArticle` e artigos com `pid_v2` que não existem
   - Executar `Article.exclude_articles_with_invalid_pid_v2()` para um issue
   - Verificar que apenas artigos cujo `pid_v2` é encontrado em `MigratedArticle` são marcados para exclusão

3. **Validações de entrada:**
   - Submeter `sps_pkg` sem `xml_with_pre` → deve lançar `ValueError`
   - Submeter `sps_pkg` cujo `xml_with_pre.v2` é `None` → deve lançar `ValueError`

#### Algum cenário de contexto que queira dar?

O sistema de migração, em alguns casos, gerou `pid_v2` aleatórios em vez de preservar o `pid_v2` original do artigo. A validação anterior (comparação de sufixo com `order`) não detectava todos esses casos. Com a nova abordagem, verificamos diretamente se o `pid_v2` consta na tabela de artigos migrados — se não consta, é um `pid_v2` inválido gerado erroneamente.

Além disso, usar `pid_v3` como chave de busca em `create_or_update` causava duplicação quando o mesmo artigo recebia um novo `pid_v3` em reprocessamento, mas o `pid_v2` permanecia o mesmo.

### Screenshots

N/A

#### Quais são tickets relevantes?
#950 

### Referências
n/a