### PR TITLE
Refatora busca e deduplicação de SPSPkg e Article para priorizar sps_pkg_name como chave principal

### DIFF
--- a/article/models.py
+++ b/article/models.py
@@ -259,10 +259,10 @@ class Article(ClusterableModel, CommonControlField):
                 obj = cls.delete_items_duplicated_by_pid_v2(pid_v2)
             except cls.DoesNotExist:
                 obj = cls()
+                obj.creator = user
                 
         obj.pid_v3 = sps_pkg.pid_v3
         obj.pid_v2 = sps_pkg.pid_v2
-        obj.creator = user
         obj.sps_pkg = sps_pkg
         obj.article_type = xml_with_pre.xmltree.find(".").get("article-type")
 

--- a/article/models.py
+++ b/article/models.py
@@ -215,6 +215,30 @@ class Article(ClusterableModel, CommonControlField):
                 qs.exclude(pk=obj.pk).delete()
                 return obj
         raise ValueError("Article.get requires pid_v3")
+    
+    @classmethod
+    def delete_items_duplicated_by_pid_v2(cls, pid_v2):
+        try:
+            return cls.objects.get(pid_v2=pid_v2)
+        except cls.MultipleObjectsReturned:
+            items = cls.objects.filter(pid_v2=pid_v2).order_by("-updated")
+            obj = items.first()
+            items.exclude(id=obj.id).delete()
+            return obj
+        except cls.DoesNotExist:
+            raise
+
+    @classmethod
+    def delete_items_duplicated_by_sps_pkg_name(cls, sps_pkg_name):
+        try:
+            return cls.objects.get(sps_pkg__sps_pkg_name=sps_pkg_name)
+        except cls.MultipleObjectsReturned:
+            items = cls.objects.filter(sps_pkg__sps_pkg_name=sps_pkg_name).order_by("-updated")
+            obj = items.first()
+            items.exclude(id=obj.id).delete()
+            return obj
+        except cls.DoesNotExist:
+            raise
 
     @classmethod
     def create_or_update(cls, user, sps_pkg, issue=None, journal=None, position=None):
@@ -229,23 +253,17 @@ class Article(ClusterableModel, CommonControlField):
         if not pid_v2:
             raise ValueError(f"SPSPkg {sps_pkg} xml_with_pre is missing pid_v2")
         try:
-            # usa pid_v2 para evitar duplicação por usar o pid_v3 como chave única, e o pid_v2 é o mesmo para artigos duplicados
-            obj = cls.objects.get(pid_v2=pid_v2)
-            obj.updated_by = user
-        except cls.MultipleObjectsReturned:
-            items = cls.objects.filter(pid_v2=pid_v2).order_by("-updated")
-            obj = items.first()
-            obj.updated_by = user
-            for item in items[1:]:
-                item.delete()
+            obj = cls.delete_items_duplicated_by_sps_pkg_name(sps_pkg.sps_pkg_name)
         except cls.DoesNotExist:
-            obj = cls()
-            obj.pid_v3 = sps_pkg.pid_v3
-            obj.pid_v2 = pid_v2
-            obj.creator = user
-
+            try:
+                obj = cls.delete_items_duplicated_by_pid_v2(pid_v2)
+            except cls.DoesNotExist:
+                obj = cls()
+                
+        obj.pid_v3 = sps_pkg.pid_v3
+        obj.pid_v2 = sps_pkg.pid_v2
+        obj.creator = user
         obj.sps_pkg = sps_pkg
-        obj.pid_v2 = pid_v2
         obj.article_type = xml_with_pre.xmltree.find(".").get("article-type")
 
         if journal:

--- a/package/models.py
+++ b/package/models.py
@@ -575,7 +575,7 @@ class SPSPkg(CommonControlField, ClusterableModel):
                     registered_in_core=response.get("registered_in_core"),
                 )
 
-                if response.get("xml_changed") or response.get("apply_xml_changes"):
+                if response.get("changed"):
                     update_zip_file(zip_xml_file_path, response["filename"], xml_with_pre)
 
                 operation.finish(

--- a/package/models.py
+++ b/package/models.py
@@ -422,17 +422,18 @@ class SPSPkg(CommonControlField, ClusterableModel):
     @classmethod
     def _get_or_create(cls, user, pid_v3, sps_pkg_name, registered_in_core):
         try:
-            obj = cls.objects.get(pid_v3=pid_v3)
-            obj.updated_by = user
+            obj = cls.objects.get(sps_pkg_name=sps_pkg_name)            
         except cls.MultipleObjectsReturned:
-            obj = cls.objects.filter(pid_v3=pid_v3, sps_pkg_name=sps_pkg_name).order_by("-updated").first()
-            obj.updated_by = user
+            items = cls.objects.filter(sps_pkg_name=sps_pkg_name).order_by("-updated")
+            obj = items.first()
+            items.exclude(id=obj.id).delete()
         except cls.DoesNotExist:
             obj = cls()
             obj.creator = user
-            obj.pid_v3 = pid_v3
-        obj.sps_pkg_name = sps_pkg_name
+            obj.sps_pkg_name = sps_pkg_name
+        obj.pid_v3 = pid_v3
         obj.registered_in_core = registered_in_core
+        obj.updated_by = user
         obj.save()
         return obj
 
@@ -574,7 +575,7 @@ class SPSPkg(CommonControlField, ClusterableModel):
                     registered_in_core=response.get("registered_in_core"),
                 )
 
-                if response.get("changed"):
+                if response.get("xml_changed") or response.get("apply_xml_changes"):
                     update_zip_file(zip_xml_file_path, response["filename"], xml_with_pre)
 
                 operation.finish(


### PR DESCRIPTION
#### O que esse PR faz?

Refatora a lógica de busca e deduplicação nos modelos `SPSPkg` e `Article` para priorizar o `sps_pkg_name` como chave de busca principal, em vez do `pid_v3`.

No modelo `SPSPkg`, o método `_get_or_create` passa a buscar pelo `sps_pkg_name`, eliminando duplicatas quando encontradas.

No modelo `Article`, são adicionados dois métodos auxiliares (`delete_items_duplicated_by_pid_v2` e `delete_items_duplicated_by_sps_pkg_name`) que encapsulam a lógica de deduplicação. O método `create_or_update` é refatorado para buscar primeiro por `sps_pkg_name` e, em caso de inexistência, buscar por `pid_v2`, evitando a criação de registros duplicados.

#### Onde a revisão poderia começar?

`package/models.py` — método `SPSPkg._get_or_create`, pois é a dependência base. Em seguida, `article/models.py` — métodos `delete_items_duplicated_by_sps_pkg_name`, `delete_items_duplicated_by_pid_v2` e `Article.create_or_update`.

#### Como este poderia ser testado manualmente?

1. Criar um cenário com registros duplicados de `SPSPkg` com o mesmo `sps_pkg_name` e verificar que `_get_or_create` mantém apenas o mais recente.
2. Criar registros duplicados de `Article` com o mesmo `sps_pkg_name` e chamar `create_or_update` — verificar que a deduplicação ocorre e o artigo correto é retornado.
3. Repetir o teste anterior com duplicatas por `pid_v2` (sem correspondência por `sps_pkg_name`) e verificar que o fallback funciona corretamente.
4. Criar um `Article` novo (sem correspondência por `sps_pkg_name` nem por `pid_v2`) e verificar que um registro é criado corretamente.

#### Algum cenário de contexto que queira dar?

A busca anterior por `pid_v3` no `SPSPkg` e por `pid_v2` no `Article` permitia a criação de registros duplicados quando o mesmo pacote era processado mais de uma vez com `pid_v3` diferentes. Ao priorizar o `sps_pkg_name` como identificador principal, garantimos unicidade com base no nome real do pacote SPS, que é o identificador estável do conteúdo. O fallback por `pid_v2` no `Article` preserva a compatibilidade com registros legados.

### Screenshots

N/A

#### Quais são tickets relevantes?

Closes #950

### Referências

N/A