### PR TITLE
Corrige filtro de items to check url and content

### DIFF
--- a/article/models.py
+++ b/article/models.py
@@ -11,7 +11,7 @@ from modelcluster.fields import ParentalKey
 from modelcluster.models import ClusterableModel
 from packtools.sps.models.article_titles import ArticleTitles
 from packtools.sps.models.article_toc_sections import ArticleTocSections
-from wagtail.admin.panels import FieldPanel, InlinePanel, MultiFieldPanel
+from wagtail.admin.panels import FieldPanel, InlinePanel, MultiFieldPanel, TabbedInterface, ObjectList
 from wagtail.models import Orderable
 from wagtailautocomplete.edit_handlers import AutocompletePanel
 
@@ -32,6 +32,24 @@ from . import choices
 from .permission_helper import MAKE_ARTICLE_CHANGE, REQUEST_ARTICLE_CHANGE
 
 User = get_user_model()
+
+
+def get_compiled_status(status_list):
+    """Recalcula status a partir das ArticleWebPage filhas."""
+    
+    if not status_list:
+        return choices.ARTICLE_WEBPAGE_STATUS_NOT_CHECKED
+    if len(status_list) == 1:
+        return status_list[0]
+    order = (
+        choices.ARTICLE_WEBPAGE_STATUS_VALID_CONTENT,
+        choices.ARTICLE_WEBPAGE_STATUS_CONTENT_MISMATCH,
+        choices.ARTICLE_WEBPAGE_STATUS_AVAILABLE,
+        choices.ARTICLE_WEBPAGE_STATUS_UNAVAILABLE,
+    )
+    for item in order:
+        if item in status_list:
+            return item
 
 
 def get_pid_status_from_webpage_status(website, article_status: str) -> str:
@@ -57,7 +75,7 @@ def get_pid_status_from_webpage_status(website, article_status: str) -> str:
 
 
     # Retorna o valor mapeado ou o status de 'not found' por padrão
-    return mapping.get(website).get(article_status, migration_choices.PID_STATUS_UNKNOWN)
+    return mapping.get(website).get(article_status) or migration_choices.PID_STATUS_UNKNOWN
 
 
 # ============================================================
@@ -147,7 +165,6 @@ class Article(ClusterableModel, CommonControlField):
         related_name="related_to",
     )
     sections = models.ManyToManyField(JournalSection, verbose_name=_("sections"))
-
     panel_article_ids = MultiFieldPanel(
         heading="Article identifiers", classname="collapsible"
     )
@@ -168,20 +185,40 @@ class Article(ClusterableModel, CommonControlField):
         FieldPanel("fpage", read_only=True),
         FieldPanel("lpage", read_only=True),
     ]
+
     panel_collections = MultiFieldPanel(
         heading=_("Collections"), classname="collapsible"
     )
     panel_collections.children = [
         InlinePanel(relation_name="article_collections", label="Collections"),
+    ]
+    panel_webpages = MultiFieldPanel(
+        heading=_("Webpages"), classname="collapsible"
+    )
+    panel_webpages.children = [
         InlinePanel(relation_name="pages", label=_("Web pages")),
     ]
 
-    panels = [
-        panel_article_ids,
-        panel_article_details,
-        FieldPanel("issue", classname="collapsible", read_only=True),
-        panel_collections,
-    ]
+    edit_handler = TabbedInterface(
+        [
+            ObjectList(
+                [panel_article_ids, panel_article_details],
+                heading="Article",
+            ),
+            ObjectList(
+                [FieldPanel("issue", read_only=True)],
+                heading="Issue",
+            ),
+            ObjectList(
+                [panel_collections],
+                heading="Collections",
+            ),
+            ObjectList(
+                [panel_webpages],
+                heading=_("Webpages"),
+            ),
+        ]
+    )
 
     base_form_class = ArticleForm
 
@@ -808,14 +845,17 @@ class Article(ClusterableModel, CommonControlField):
         return data
 
     def _available_on_website(self, collection, purpose=None):
-        article_collection = self.article_collections.filter(
-            collection=collection
-        ).first()
-        if not article_collection:
-            return {"valid": None, "new_pid_status": None, "error": "No collection", "collecion": collection.acron, "purpose": purpose}
-        status = article_collection.get_compiled_status(purpose)
+        status_list = list(self.pages.filter(collection=collection, purpose=purpose).values_list("status", flat=True))
+        status = get_compiled_status(status_list)
         valid = status == choices.ARTICLE_WEBPAGE_STATUS_VALID_CONTENT
-        return {"valid": valid, "new_pid_status": get_pid_status_from_webpage_status(purpose, status)}
+        return {
+            "collection": collection.acron,
+            "purpose": purpose,
+            "valid": valid,
+            "new_pid_status": get_pid_status_from_webpage_status(purpose, status),
+            "status_list": status_list,
+            "status": status,
+        }
         
     def available_on_classic_website(self, collection=None):
         return self._available_on_website(collection, choices.ARTICLE_WEBPAGE_PURPOSE_CLASSIC)
@@ -843,34 +883,39 @@ class Article(ClusterableModel, CommonControlField):
         total_deletado = 0
         
         # Estrutura exata solicitada por você
-        items_to_delete = {
+        response = {
             "sps_pkg_with_invalid_pid_v2": [],
             "ppxml_invalid": [],
             "repeated_sps_pkg_name": [],
             "repeated_pid_v2": [],
-            "ppxml_ids": [],
-            "sps_pkg_ids": [],
+            "deleted_ppxml_ids": [],
+            "deleted_sps_pkg_ids": [],
+            "deleted_article_ids": [],
+            "total_deleted_items": 0
         }
         ppxml_to_delete = set()
         sps_pkg_to_delete = set()
         
         events = []
+        exceptions = []
 
         qs = cls.objects.select_related("pp_xml", "sps_pkg").filter(issue=issue)
-        
+        q = Q(sps_pkg__isnull=True)
         if sps_pkg_id_list:
-            qs = qs.filter(sps_pkg__id__in=sps_pkg_id_list)
-            if qs.exists():
-                sps_pkg_names = []
-                for pp_xml_id, sps_pkg_name, sps_pkg_id in qs.values_list("pp_xml_id", "sps_pkg__sps_pkg_name", "sps_pkg_id"):
-                    if pp_xml_id:
-                        ppxml_to_delete.add(pp_xml_id)
-                    if sps_pkg_id:
-                        sps_pkg_to_delete.add(sps_pkg_id)
-                        sps_pkg_names.append(sps_pkg_name)
-                items_to_delete["sps_pkg_with_invalid_pid_v2"] = sps_pkg_names
-                qtd_deleted, _ = qs.delete()
-                total_deletado += qtd_deleted
+            q |= Q(sps_pkg__id__in=sps_pkg_id_list)
+        
+        qs = qs.filter(q)
+        if qs.exists():
+            sps_pkg_names = []
+            for pp_xml_id, sps_pkg_name, sps_pkg_id in qs.values_list("pp_xml_id", "sps_pkg__sps_pkg_name", "sps_pkg_id"):
+                if pp_xml_id:
+                    ppxml_to_delete.add(pp_xml_id)
+                if sps_pkg_id:
+                    sps_pkg_to_delete.add(sps_pkg_id)
+                    sps_pkg_names.append(sps_pkg_name)
+            response["sps_pkg_with_invalid_pid_v2"] = sps_pkg_names
+            qtd_deleted, _ = qs.delete()
+            total_deletado += qtd_deleted
 
         # 1. Remoção por falta de pp_xml
         qs = cls.objects.select_related("pp_xml").filter(issue=issue)
@@ -887,7 +932,7 @@ class Article(ClusterableModel, CommonControlField):
                     sps_pkg_to_delete.add(item.sps_pkg.id)
                     sps_pkg_names.append(item.sps_pkg.sps_pkg_name)
         if article_ids:
-            items_to_delete["ppxml_invalid"] = sps_pkg_names
+            response["ppxml_invalid"] = sps_pkg_names
             qtd_deleted, _ = qs.filter(id__in=article_ids).delete()
             total_deletado += qtd_deleted
 
@@ -919,7 +964,7 @@ class Article(ClusterableModel, CommonControlField):
                             keep = item
                             break
                     except Exception as e:
-                        events.append(_("Checking {} is available. Result: {}").format(item, e))
+                        exceptions.append(_("Checking {} is available. Result: {}").format(item, e))
                 
                 # Separa os que serão deletados
                 remover_qs = duplicados.exclude(id=keep.id)
@@ -934,7 +979,7 @@ class Article(ClusterableModel, CommonControlField):
                             sps_pkg_names.append(sps_pkg_name)
                     
                     # Alimenta a chave dinâmica: "repeated_sps_pkg_name" ou "repeated_pid_v2"
-                    items_to_delete[f"repeated_{field_name}"].append((value, sps_pkg_names))
+                    response[f"repeated_{field_name}"].append((value, sps_pkg_names))
                     
                     # Executa a deleção e soma ao totalizador
                     qtd_deletada, _ = remover_qs.delete()
@@ -947,10 +992,19 @@ class Article(ClusterableModel, CommonControlField):
             PidProviderXML.objects.filter(id__in=ppxml_to_delete).delete()
         if sps_pkg_to_delete:
             SPSPkg.objects.filter(id__in=sps_pkg_to_delete).delete()
-        items_to_delete["ppxml_ids"] = ppxml_to_delete
-        items_to_delete["sps_pkg_ids"] = sps_pkg_to_delete
         
-        return items_to_delete
+        response["deleted_ppxml_ids"] = list(ppxml_to_delete)
+        response["deleted_sps_pkg_ids"] = list(sps_pkg_to_delete)
+        
+        qs = cls.objects.filter(Q(sps_pkg__isnull=True) | Q(pp_xml__isnull=True), issue=issue)
+        response["deleted_article_ids"] = list(qs.values_list("id", flat=True))
+        qtd_deleted, _ = qs.delete()
+        total_deletado += qtd_deleted
+        
+        response["total_deleted_items"] = total_deletado
+        response["events"] = events
+        response["exceptions"] = exceptions
+        return response
 
  
 # ============================================================
@@ -1156,27 +1210,13 @@ class ArticleCollection(CommonControlField):
 
     def update_aggregate_status(self, user):
         """Recalcula status a partir das ArticleWebPage filhas."""
-        self.status = self.get_compiled_status()
+        status_list = ArticleWebPage.objects.filter(
+            collection=self.collection,
+        ).values_list("status", flat=True)
+        
+        self.status = get_compiled_status(status_list)
         self.updated_by = user
         self.save(update_fields=["status", "updated_by"])
-
-    def get_compiled_status(self, purpose=None):
-        """Recalcula status a partir das ArticleWebPage filhas."""
-        purpose = purpose or choices.ARTICLE_WEBPAGE_PURPOSE_PUBLIC
-        selected_pages = self.pages.filter(purpose=purpose)
-        status = list(selected_pages.values_list("status", flat=True).distinct())
-        if not status:
-            return choices.ARTICLE_WEBPAGE_STATUS_NOT_CHECKED
-        if len(status) == 1:
-            return status[0]
-        if choices.ARTICLE_WEBPAGE_STATUS_VALID_CONTENT in status:
-            return choices.ARTICLE_WEBPAGE_STATUS_VALID_CONTENT
-        if choices.ARTICLE_WEBPAGE_STATUS_CONTENT_MISMATCH in status:
-            return choices.ARTICLE_WEBPAGE_STATUS_CONTENT_MISMATCH
-        if choices.ARTICLE_WEBPAGE_STATUS_AVAILABLE in status:
-            return choices.ARTICLE_WEBPAGE_STATUS_AVAILABLE
-        if choices.ARTICLE_WEBPAGE_STATUS_UNAVAILABLE in status:
-            return choices.ARTICLE_WEBPAGE_STATUS_UNAVAILABLE
 
     # ── get_or_create ──
 
@@ -1436,15 +1476,6 @@ class ArticleWebPage(CommonControlField):
     def __str__(self):
         return f"{self.url} [{self.purpose}/{self.fmt}/{self.lang}] {self.status}"
 
-    # ── Propagação ──
-
-    def propagate_status(self, user):
-        """Propaga status para o ArticleCollection pai."""
-        ArticleCollection.objects.get(
-            collection=self.collection,
-            article=self.article,
-        ).update_aggregate_status(user)
-
     # ── URL update ──
 
     def update_url_if_changed(self, new_url, user):
@@ -1467,7 +1498,8 @@ class ArticleWebPage(CommonControlField):
             "purpose": self.purpose,
             "status": self.status,
             "valid": self.status == choices.ARTICLE_WEBPAGE_STATUS_VALID_CONTENT,
-            "detail": self.detail,
+            "result": self.detail,
+            "updated": self.updated.isoformat(),
         }
 
     def check_page(
@@ -1486,43 +1518,44 @@ class ArticleWebPage(CommonControlField):
                 return detail
 
         try:
+            self.status = choices.ARTICLE_WEBPAGE_STATUS_UNAVAILABLE
+    
             response = check_url(self.url, timeout)
             content = response.get("content")
-            if not content:
-                raise ValueError("No content retrieved from URL")
-
             self.status = choices.ARTICLE_WEBPAGE_STATUS_AVAILABLE
 
-            if not article_metadata:
-                article = self.article
-                lang_code = self.lang.code2 if self.lang else None
-                article_metadata = article.get_metadata_items(lang_code)
-            if not article_metadata:
-                raise ValueError(
-                    "No article metadata available for content check"
-                )
+            if self.fmt in ("html", "xml"):
+                if not article_metadata:
+                    article = self.article
+                    lang_code = self.lang.code2 if self.lang else None
+                    article_metadata = article.get_metadata_items(lang_code)
 
-            response = check_content(article_metadata, content)
-            if response.get("error"):
-                raise ValueError(response["error"])
- 
-            detail.update(response)
-            rate = response.get("rate", 0)
-            if rate >= 0.5:
-                self.status = choices.ARTICLE_WEBPAGE_STATUS_VALID_CONTENT
-            else:
-                detail["content"] = content
-                detail["article_metadata"] = article_metadata
-                self.status = choices.ARTICLE_WEBPAGE_STATUS_CONTENT_MISMATCH
+                response = check_content(article_metadata, content, self.fmt) 
+                detail.update(response)
+                try:
+                    rate = response["rate"]
+                except KeyError:
+                    raise Exception("Unable to check content")
+
+                if rate >= 0.5:
+                    self.status = choices.ARTICLE_WEBPAGE_STATUS_VALID_CONTENT
+                else:
+                    # detail["content"] = content
+                    # detail["article_metadata"] = article_metadata
+                    self.status = choices.ARTICLE_WEBPAGE_STATUS_CONTENT_MISMATCH
         except Exception as e:
             detail["error"] = str(e)
-            self.status = choices.ARTICLE_WEBPAGE_STATUS_UNAVAILABLE
 
         self.detail = detail
         self.updated_by = user
-        self.save()
-        self.propagate_status(user)
-        logging.info(f"Checked page {self.url}: {detail}")
+
+        try:
+            self.save()
+        except Exception as e:
+            logging.info(f"Erro ao salvar ARticleWebPage")
+            logging.exception(e)
+
+        logging.info(f"data: {self.data}")
         return self.data
 
     # ── Factory ──

--- a/article/page_checker.py
+++ b/article/page_checker.py
@@ -1,7 +1,7 @@
 """
 Verifica a presença exata de metadados de artigo em um texto.
 """
-
+import logging
 import re
 import unicodedata
 from difflib import SequenceMatcher
@@ -38,37 +38,85 @@ def check_url(url, timeout):
         if not url:
             raise ValueError("check_page_url_and_content: URL is required for availability check.")
         content = fetch_data(url, timeout=timeout or 30)
-        if not content:
-            raise ValueError("check_page_url_and_content: No content fetched from URL.")
-        return {"content": content.decode("utf-8")}
+        return {"content": content}
     except Exception as e:
-        return {"error": str(e)}
+        return {"error": str(e), "function": "check_url"}
     
 
-def check_content(article_metadata, content):
+def clean_pdf_text(raw):
+    """
+    Limpa texto extraído de PDF para maximizar a chance de match
+    com metadados do artigo.
+    """
+    text = raw
+
+    # 1. Decodifica entidades HTML residuais (alguns extratores deixam)
+    text = unescape(text)
+
+    # 2. Remove hifenização de fim de linha: "publi-\ncação" → "publicação"
+    text = re.sub(r"(\w)-\s*\n\s*(\w)", r"\1\2", text)
+
+    # 3. Substitui quebras de linha por espaço
+    text = text.replace("\n", " ").replace("\r", " ")
+
+    # 4. Remove caracteres de controle (form feed, etc.)
+    text = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f]", " ", text)
+
+    # 5. Colapsa espaços múltiplos
+    text = re.sub(r"\s+", " ", text)
+
+    return text.strip()
+
+
+def check_content(article_metadata, content, format):
     try:
         if not article_metadata:
-            raise ValueError("check_page_url_and_content: Article metadata is required for availability check.")
+            raise ValueError("check_content: Article metadata is required for availability check.")
         if not content:
-            raise ValueError("check_page_url_and_content: Content is required for availability check.")
+            raise ValueError("check_content: Content is required for availability check.")
         try:
-            content = " ".join(content.split())
-            position = content.find("PID:")
-            if position:
-                content = content[:position+1000]
-        except (AttributeError, IndexError):
+            if format == "pdf":
+                # Decodifica bytes → str
+                if isinstance(content, bytes):
+                    content = content.decode("utf-8", errors="replace")
+                    if not content:
+                        raise ValueError("check_content: Unable to decode content for pdf")
+                logging.exception("check content 1111")
+
+                # Limpeza adequada para texto vindo de PDF
+                content = clean_pdf_text(content)
+                if not content:
+                    raise ValueError("check_content: Unable to clean pdf content")
+                logging.exception("check content 2222")
+            else:
+                content = content.decode("utf-8")
+                if not content:
+                    raise ValueError("check_content: Unable to decode content")
+                
+                logging.exception("check content 3333")
+                content = " ".join(content.split())
+                logging.exception("check content 4444")
+                if "PID:" in content:
+                    logging.exception("check content 5555")
+                    position = content.find("PID:")
+                    if position:
+                        logging.exception("check content 6666")
+                        content = content[:position+1000]
+                logging.exception("check content 7777") 
+        except (AttributeError, IndexError) as exc:
+            logging.exception(f"check content {exc}") 
             pass
         result = check_metadata(article_metadata, content)
-
         numbers = compute_rate(result)
-        rate = numbers.get("rate", 0)
-        return {
-            "result": result,
-            "numbers": numbers,
-            "rate": rate,
-        }
+        logging.info(f"check content: {result}")
+        logging.info(f"check content: {numbers}")
+        
+        response = {}
+        response["result"] = result
+        response.update(numbers)
+        return response
     except Exception as e:
-        return {"error": str(e)}
+        return {"error": str(e), "type": str(type(e))}
 
 
 def normalize(text):
@@ -148,6 +196,8 @@ def check_metadata(metadata, text):
     list[tuple]
         Lista de (label, valor, encontrado).
     """
+    if not text:
+        raise ValueError(f"check_metadata: Unable to check metadata because text is not provided")
     return [
         (label, value, is_found(value, text))
         for label, value in metadata
@@ -168,18 +218,18 @@ def compute_rate(items):
     -------
     dict
         {
-            "found_count": int,
-            "not_found_count": int,
+            "total_found": int,
+            "total_not_found": int,
             "total": int,
             "rate": float,
         }
     """
     total = len(items)
-    found_count = sum(1 for _, _, found in items if found)
+    total_found = sum(1 for _, _, found in items if found)
 
     return {
-        "found_count": found_count,
-        "not_found_count": total - found_count,
+        "total_found": total_found,
+        "total_not_found": total - total_found,
         "total": total,
-        "rate": found_count / total if total else 0.0,
+        "rate": total_found / total if total else 0.0,
     }

--- a/proc/models.py
+++ b/proc/models.py
@@ -144,32 +144,19 @@ class Operation(CommonControlField):
             Operação criada.
         """
         name = name[:64]
-        cls.exclude_events(user, proc, name)
         obj = cls()
         obj.proc = proc
         obj.name = name
         obj.creator = user
         obj.save()
         return obj
-        # try:
-        #     return cls.objects.get(proc=proc, name=name)
-        # except cls.MultipleObjectsReturned:
-        #     return cls.objects.filter(proc=proc, name=name).order_by("-created").first()
-        # except cls.DoesNotExist:
-        #     obj = cls()
-        #     obj.proc = proc
-        #     obj.name = name
-        #     obj.creator = user
-        #     obj.save()
-        #     return obj
 
     @classmethod
     def exclude_events(cls, user, proc, name):
         # apaga todas as ocorrências que foram armazenadas no arquivo
-        try:
-            cls.objects.filter(proc=proc, name=name).delete()
-        except Exception as e:
-            pass
+        item = cls.objects.filter(proc=proc, name=name).order_by("-created").first()
+        if item:
+            cls.objects.filter(proc=proc, created__gte=item.created).order_by("-created").delete()
 
     @classmethod
     def start(
@@ -178,6 +165,8 @@ class Operation(CommonControlField):
         proc,
         name=None,
     ):
+        name = name[:64]
+        cls.exclude_events(user, proc, name)
         return cls.create(user, proc, name)
 
     def finish(
@@ -2418,9 +2407,8 @@ class ArticleProc(BaseProc, ClusterableModel):
         exclude_list = (
             migration_choices.PID_STATUS_MISSING,
             migration_choices.PID_STATUS_EXCEEDING,
-            migration_choices.PID_STATUS_UNKNOWN,
         )
-        if force_update:
+        if not force_update:
             exclude_list = list(exclude_list)
             exclude_list.append(migration_choices.PID_STATUS_PUBLIC_VALID)
 
@@ -2553,20 +2541,21 @@ class ArticleProc(BaseProc, ClusterableModel):
     @classmethod
     def exclude_invalid_items(cls, user, issue):
         # obtém sps_pkg_ids cujo pid_v2 não corresponde ao ArticleProc.pid
-        sps_pkg_id_list = ArticleProc.get_sps_pkg_ids_which_pid_v2_is_incorrect(issue=issue)
+        sps_pkg_id_list = cls.get_sps_pkg_ids_which_pid_v2_is_incorrect(issue=issue)
 
         # completa sps_pkg.pid_v2 com os valores de sps_pkg.xml_with_pre.v2
         SPSPkg.complete_pid_v2(user, sps_pkg_id_list=sps_pkg_id_list)
 
-        # obtém novamente sps_pkg_ids cujo pid_v2 não corresponde ao ArticleProc.pid
-        sps_pkg_id_list = ArticleProc.get_sps_pkg_ids_which_pid_v2_is_incorrect(issue=issue)
+        # obtém novamente sps_pkg_ids cujo pid_v2 não corresponde ao cls.pid
+        sps_pkg_id_list = cls.get_sps_pkg_ids_which_pid_v2_is_incorrect(issue=issue)
 
         qs = cls.objects.filter(
-            Q(sps_pkg_id__in=sps_pkg_id_list)|Q(sps_pkg__isnull=True)
+            Q(sps_pkg_id__in=sps_pkg_id_list)|Q(sps_pkg__isnull=True),
+            issue_proc__issue=issue,
         )
         items = qs.values("pid", "sps_pkg__sps_pkg_name")
         qs.delete()
-        return {"sps_pkg_id_list": sps_pkg_id_list, "deleted": items}
+        return {"sps_pkg_id_list": list(sps_pkg_id_list), "deleted": list(items)}
 
     def update_sps_pkg_status(self):
         if self.sps_pkg:

--- a/proc/tasks.py
+++ b/proc/tasks.py
@@ -1361,28 +1361,37 @@ def task_sync_issue(
     Chamada de forma assíncrona após ``task_publish_issue_articles``
     para garantir que o fascículo apareça corretamente no TOC do site.
     """
-    task_params = {
-        "user_id": user_id,
-        "username": username,
-        "issue_proc_id": issue_proc_id,
-        "website_kind": website_kind,
-    }
-    task_exec = TaskExecution(
-        name="proc.tasks.task_sync_issue",
-        item=f"{issue_proc_id}",
-        params=task_params,
-    )
     try:
         user = _get_user(user_id, username)
         issue_proc = IssueProc.objects.get(id=issue_proc_id)
-        task_exec.item = f"{issue_proc}"
+        event = issue_proc.start(user, f"proc.tasks.task_sync_issue {website_kind}")
         if not api_data:
             api_data = get_api_data(issue_proc.collection, "issue", website_kind)
-        sync_issue(issue_proc, api_data)
-        task_exec.finish()
+        response = sync_issue(issue_proc, api_data)
+        event.finish(user=user, completed=True, detail=response)
     except Exception as e:
         exc_type, exc_value, exc_traceback = sys.exc_info()
-        task_exec.finish(exception=e, exc_traceback=exc_traceback)
+        try:
+            event.finish(
+                user=user,
+                completed=False,
+                exception=e,
+                exc_traceback=exc_traceback,
+            )
+        except Exception:
+            UnexpectedEvent.create(
+                item=f"{issue_proc_id}",
+                action="proc.tasks.task_sync_issue",
+                e=e,
+                exc_traceback=exc_traceback,
+                detail={
+                    "task": "proc.tasks.task_sync_issue",
+                    "user_id": user_id,
+                    "username": username,
+                    "website_kind": website_kind,
+                    "issue_proc_id": issue_proc_id,
+                },
+            )
 
 
 @celery_app.task(bind=True)
@@ -1601,45 +1610,38 @@ def task_exclude_invalid_issue_articles(
     Chamada automaticamente por ``task_migrate_and_publish_articles_by_issue``
     antes de iniciar a migração dos artigos.
     """
-    task_params = {"issue_proc_id": issue_proc_id}
-    issue_proc_str = str(issue_proc_id)
-    task_exec = TaskExecution(
-        name="task_exclude_invalid_issue_articles",
-        item=issue_proc_str,
-        params=task_params,
-    )
     try:
+        item = issue_proc_id
+        detail = None
+        event = None
         user = _get_user(user_id=user_id, username=username)
         issue_proc = IssueProc.objects.select_related("issue").get(
             id=issue_proc_id
         )
+        item = str(issue_proc)
+        event = issue_proc.start(user, "Exclude invalid articles")
+        detail = []
         issue = issue_proc.issue
-
-        task_exec.item = str(issue_proc)
-        issue_proc_str = str(issue_proc)
-
-        response = ArticleProc.exclude_invalid_items(user, issue_proc.issue)
-        # {"sps_pkg_id_list": sps_pkg_id_list, "deleted": items}
-        task_exec.add_event(response)
+        response = ArticleProc.exclude_invalid_items(user, issue)
+        detail.append({"Model": "ArticleProc", "response": response})
         response = Article.exclude_invalid_records(user, issue, response.get("sps_pkg_id_list"), timeout=timeout)
-        task_exec.add_event(response)
-        if response.get("sps_pkg_ids"):
-            response = ArticleProc.exclude_invalid_items(user, issue_proc.issue)
-            # {"sps_pkg_id_list": sps_pkg_id_list, "deleted": items}
-            task_exec.add_event(response)
-        task_exec.finish()
+        detail.append({"Model": "Article", "response": response})
+        if response.get("deleted_sps_pkg_ids"):
+            response = ArticleProc.exclude_invalid_items(user, issue)
+            detail.append({"Model": "ArticleProc", "response": response})
+        event.finish(user, completed=True, detail=detail)
     except Exception as e:
         exc_type, exc_value, exc_traceback = sys.exc_info()
-        try:
-            task_exec.finish(exception=e, exc_traceback=exc_traceback)
-        except Exception:
-            UnexpectedEvent.create(
-                item=issue_proc_str,
-                action="proc.tasks.task_exclude_invalid_issue_articles",
-                e=e,
-                exc_traceback=exc_traceback,
-                detail=task_params,
-            )
+        if event:
+            event.finish(user, exception=e, exc_traceback=exc_traceback)
+            return
+        UnexpectedEvent.create(
+            item=item,
+            action="proc.tasks.task_exclude_invalid_issue_articles",
+            e=e,
+            exc_traceback=exc_traceback,
+            detail=detail,
+        )
 
 
 @celery_app.task(bind=True)
@@ -1796,16 +1798,23 @@ def task_track_classic_website_article_pids_for_collection(
         result = tracker.update_pid_status()
         task_exec.add_event(result)
 
-        for item in ArticleProc.items_to_check_url_and_content(
+        for article_proc in ArticleProc.items_to_check_url_and_content(
             collection, force_update
         ):
-            task_check_migrated_article.delay(
-                user_id=user_id,
-                username=username,
-                article_proc_id=item.id,
-                timeout=timeout,
-                force_update=force_update,
-            )
+            for website in WebSiteConfiguration.objects.filter(
+                collection=collection, enabled=True
+            ):
+                website_kind = website.purpose
+                task_check_article_webpages.delay(
+                    user_id=user_id,
+                    username=username,
+                    collection_id=article_proc.collection.id,
+                    website_kind=website_kind,
+                    article_id=article_proc.article.id,
+                    timeout=timeout,
+                    force_update=force_update,
+                    article_proc_id=article_proc.id,
+                )
 
         task_exec.finish()
     except Exception as e:
@@ -1848,13 +1857,11 @@ def task_check_article_webpages(
             user, f"check availability {article_proc.collection} {website_kind}"
         )
 
-        article = Article.objects.select_related("journal").get(
-            id=article_id
-        )
+        article = article_proc.article
         article.create_or_update_article_collections(user)
         collection = article_proc.collection
         data = {}
-        article.check_availability(user, collection_id=collection_id, purpose=website_kind)
+        article.check_availability(user, collection_id=collection_id, purpose=website_kind, force_update=force_update)
         responses = [
             article.available_on_classic_website(collection),
             article.available_on_public_website(collection),
@@ -1862,9 +1869,12 @@ def task_check_article_webpages(
         response = responses[-1]
 
         data["responses"] = responses
-        data["detail"] = article.availability
+        data["availability"] = article.availability
+
+        for response in responses:
+            if response.get("valid"):
+                article_proc.set_pid_status(user, response.get("new_pid_status"))
     
-        article_proc.set_pid_status(user, response.get("new_pid_status"))
         event.finish(user, completed=True, detail=data)
     except Exception as e:
         exc_type, exc_value, exc_traceback = sys.exc_info()
@@ -1969,7 +1979,6 @@ def task_check_articles_availability(
     issue_folder=None,
     publication_year=None,
     article_pid_v3=None,
-    article_id=None,
     collection_acron=None,
     timeout=None,
     force_update=None,
@@ -2001,51 +2010,36 @@ def task_check_articles_availability(
     try:
         user = _get_user(user_id, username)
         article_params = {}
-        j_query = Q()
+        q = Q()
 
-        if article_id:
-            article_params["id"] = article_id
         if article_pid_v3:
-            article_params["pid_v3"] = article_pid_v3
+            article_params["sps_pkg__pid_v3"] = article_pid_v3
         if publication_year:
-            article_params["issue__publication_year"] = publication_year
+            article_params["issue_proc__issue__publication_year"] = publication_year
         if issue_folder:
-            article_params["issue__issue_folder"] = issue_folder
-
-        if collection_acron or issn_electronic or issn_print:
-            j_params = {}
-            if collection_acron:
-                j_params["collection__acron"] = collection_acron
-            if issn_print:
-                j_query |= Q(
-                    journal__official_journal__issn_print=issn_print
-                )
-            if issn_electronic:
-                j_query |= Q(
-                    journal__official_journal__issn_electronic=issn_electronic
-                )
-            article_params["journal__id__in"] = (
-                JournalProc.objects.filter(j_query, **j_params)
-                .values_list("journal__id", flat=True)
-                .distinct()
-            )
-        collection_id = None
+            article_params["issue_proc__issue__issue_folder"] = issue_folder
         if collection_acron:
-            collection_id = (
-                Collection.objects.filter(acron=collection_acron)
-                .values_list("id", flat=True)
-                .first()
+            article_params["collection__acron"] = collection_acron
+
+        q = Q()
+        if issn_print:
+            q |= Q(
+                issue_proc__journal_proc__journal__official_journal__issn_print=issn_print
+            )
+        if issn_electronic:
+            q |= Q(
+                issue_proc__journal_proc__journal__official_journal__issn_electronic=issn_electronic
             )
 
-        for article in Article.objects.filter(
-            journal__isnull=False, **article_params
+        for article_proc in ArticleProc.objects.filter(
+            q, **article_params
         ):
-            article.create_or_update_article_collections(user)
             task_check_article_webpages.delay(
                 user_id=user_id,
                 username=username,
-                article_id=article.id,
-                collection_id=collection_id,
+                article_proc_id=article_proc.id,
+                article_id=article_proc.article.id,
+                collection_id=article_proc.collection_id,
                 timeout=timeout,
                 force_update=force_update,
             )
@@ -2111,15 +2105,15 @@ def task_check_migrated_article(
 
         logging.info("pageslist(article.webpages): {}".format(list(article.webpages)))
         response = article.available_on_classic_website(article_proc.collection)
+        if response.get("valid"):
+            article_proc.set_pid_status(user, response.get("new_pid_status"))
         logging.info(
             f"Checked classic website for ArticleProc {article_proc_id}: {response}"
         )
-        article_proc.set_pid_status(user, response.get("new_pid_status"))
-        if not response.get("valid"):
-            return
-            
+
         response = article.available_on_public_website(article_proc.collection)
-        article_proc.set_pid_status(user, response.get("new_pid_status"))
+        if response.get("valid"):
+            article_proc.set_pid_status(user, response.get("new_pid_status"))
         logging.info(
             f"Checked public website for ArticleProc {article_proc_id}: {response}"
         )


### PR DESCRIPTION
## Refatora verificação de disponibilidade, exclusão de artigos e painel de edição

#### O que esse PR faz?

Refatora o fluxo de verificação de disponibilidade de artigos e a exclusão de registros inválidos, além de reorganizar o painel de edição do Article com TabbedInterface.

As principais mudanças são:

1. **article/page_checker.py** — Adiciona suporte a verificação de conteúdo PDF com `clean_pdf_text`, refatora `check_content` para tratar formatos html/xml e pdf separadamente, renomeia `found_count`/`not_found_count` para `total_found`/`total_not_found` e adiciona validação de texto em `check_metadata`.

2. **article/models.py** — Extrai `get_compiled_status` como função de módulo, substitui `panels` por `TabbedInterface` com abas (Article, Issue, Collections, Webpages), simplifica `_available_on_website` consultando `ArticleWebPage` diretamente sem passar por `ArticleCollection`, remove `propagate_status` e `get_compiled_status` de `ArticleCollection`/`ArticleWebPage`, e melhora a estrutura de retorno de `exclude_invalid_records` (renomeia chaves, adiciona limpeza final de artigos órfãos).

3. **proc/models.py** — Refatora `Operation.exclude_events` para manter apenas eventos a partir do último com mesmo nome, move `exclude_events` para o método `start`, corrige a lógica invertida de `force_update` em `items_to_check_url_and_content`, e adiciona filtro por `issue` no queryset de `exclude_invalid_items`.

4. **proc/tasks.py** — Migra `task_sync_issue` e `task_exclude_invalid_issue_articles` de `TaskExecution` para `Operation` (event), refatora `task_track_classic_website_article_pids_for_collection` para iterar por `WebSiteConfiguration`, refatora `task_check_articles_availability` para consultar via `ArticleProc` ao invés de `Article`, e corrige `task_check_article_webpages`/`task_check_migrated_article` para atualizar `pid_status` apenas quando `valid=True`.

#### Onde a revisão poderia começar?

Por `article/page_checker.py` (mudanças mais isoladas) e depois `article/models.py` (função `get_compiled_status` e `_available_on_website`), que são a base para as mudanças em `proc/`.

#### Como este poderia ser testado manualmente?

- Executar a task `task_check_articles_availability` para uma coleção e verificar que os status são atualizados corretamente no admin (aba Webpages do Article).
- Executar `task_exclude_invalid_issue_articles` para um fascículo com artigos órfãos (sem `sps_pkg` ou `pp_xml`) e verificar que são removidos.
- Verificar no admin que o Article agora exibe as abas Article, Issue, Collections e Webpages.
- Testar verificação de disponibilidade para artigos com páginas em formato PDF e HTML.

#### Algum cenário de contexto que queira dar?

A consulta de status passava por `ArticleCollection.get_compiled_status`, que era intermediária e desnecessária. Agora `_available_on_website` consulta `ArticleWebPage` diretamente. A função `get_compiled_status` foi extraída para o nível do módulo para ser reutilizada tanto em `Article._available_on_website` quanto em `ArticleCollection.update_aggregate_status`.

A migração de `TaskExecution` para `Operation` (event) nas tasks segue o padrão já adotado em outras tasks do projeto.

A correção de `force_update` em `items_to_check_url_and_content` (de `if force_update` para `if not force_update`) corrige um bug onde a condição estava invertida.

### Screenshots

### Quais são tickets relevantes?

### Referências