### PR TITLE
Corrige exceção na obtenção de dados de journal (email) e exceção de MultipleObjectReturned de Article usando sps_pkg

### DIFF
--- a/proc/models.py
+++ b/proc/models.py
@@ -2580,12 +2580,9 @@ class ArticleProc(BaseProc, ClusterableModel):
 
     @property
     def article(self):
-        try:
-            sps_pkg = self.sps_pkg
-            if sps_pkg:
-                return Article.objects.get(sps_pkg=sps_pkg)
-        except (AttributeError, Article.DoesNotExist) as e:
-            logging.info(f"Not found ArticleProc.article: {sps_pkg} {e}")
+        if not self.sps_pkg:
+            return None
+        return self.sps_pkg.article_set.all().order_by("-updated").first()
 
     # ── migration flow ──
 

--- a/proc/source_core_api.py
+++ b/proc/source_core_api.py
@@ -389,7 +389,7 @@ def process_journal_result(
     journal.save()
 
     journal.journal_email.all().delete()
-    for item in result.get("email"):
+    for item in result.get("email") or []:
         journal.add_email(item)
 
     # Processa subjects


### PR DESCRIPTION

## 📝 Descrição

Este PR introduz melhorias na robustez e legibilidade do módulo `proc`. Foram aplicadas correções para evitar erros de execução em tempo de execução (runtime) e uma refatoração na busca de modelos relacionados.

## 🛠 Alterações

### 1. Refatoração em `ArticleProc.article` (`proc/models.py`)

* **O que mudou:** Substituímos o bloco `try/except` por uma verificação direta de existência do `sps_pkg`.
* **Motivo:** A lógica anterior era redundante. Agora, utilizamos o relacionamento reverso (`article_set`) ordenado pela data de atualização (`-updated`), garantindo que o método retorne o artigo mais recente de forma mais performática e idiomática do Django.

### 2. Prevenção de erro em `process_journal_result` (`proc/source_core_api.py`)

* **O que mudou:** Adicionada uma proteção de fallback (`or []`) ao iterar sobre os e-mails retornados pela API.
* **Motivo:** Evita que o sistema lance uma exceção `TypeError: 'NoneType' object is not iterable` caso a chave `email` no dicionário de resultados esteja nula ou ausente.

---

## 🧪 Como testar

1. **Verificação de Artigos:** Certifique-se de que instâncias de `ArticleProc` continuam acessando seus respectivos artigos corretamente através da propriedade `.article`.
2. **Teste de API:** Execute o processamento de periódicos com uma resposta de API onde o campo `email` seja `null` e verifique se o processo termina sem erros.

## 🔗 Tarefas relacionadas

* *Insira aqui o link para a Issue ou card do Jira, se houver.*

---

### ⚠️ Check-list

* [x] O código segue os padrões de estilo do projeto.
* [x] Testes manuais realizados.
* [x] Commits atômicos e bem descritos.