### PR TITLE
fix: limit bulk_update batch size to avoid OOM on PostgreSQL

### DIFF
--- a/package/models.py
+++ b/package/models.py
@@ -940,4 +940,4 @@ class SPSPkg(CommonControlField, ClusterableModel):
 
         # 4. Salvamos tudo em uma única consulta ao banco
         if items_to_update:
-            cls.objects.bulk_update(items_to_update, ["pid_v2", "updated_by"])
+            cls.objects.bulk_update(items_to_update, ["pid_v2", "updated_by"], batch_size=100)


### PR DESCRIPTION
#### O que esse PR faz?
Define `batch_size=100` no `bulk_update` de `pid_v2` em `SPSPkg`, evitando que o PostgreSQL seja morto pelo OOM Killer ao executar um único `UPDATE ... CASE WHEN` com centenas de registros.

#### Onde a revisão poderia começar?
Em `package/models.py`, no método que chama `cls.objects.bulk_update(items_to_update, ["pid_v2", "updated_by"])` — alteração de uma linha.

#### Como este poderia ser testado manualmente?
Executar o processo de atualização de `pid_v2` para um periódico com grande volume de pacotes (ex: fascículo com 50+ artigos) e verificar que a operação é concluída sem erros de OOM no log do PostgreSQL.

#### Algum cenário de contexto que queira dar?
O processo estava sendo interrompido com `signal 9: Killed` no PostgreSQL durante a geração de um `CASE WHEN` muito grande. O log registrava:
```
server process (PID 45759) was terminated by signal 9: Killed
Failed process was running: UPDATE "package_spspkg" SET "pid_v2" = (CASE WHEN ...)
```
O `bulk_update` do Django sem `batch_size` gera um único statement com todos os registros, consumindo memória excessiva no worker do PostgreSQL. Com `batch_size=100`, o Django divide em múltiplos statements menores.

### Screenshots
_N/A — alteração de comportamento interno, sem impacto visual._

#### Quais são tickets relevantes?
_—_

### Referências
- [Django docs — bulk_update](https://docs.djangoproject.com/en/4.2/ref/models/querysets/#bulk-update)
- Log de erro: `2026-06-09 22:30:30 UTC` — OOM Kill durante UPDATE em `package_spspkg`