### PR TITLE
Evita reprocessamento de artigos DONE e melhora rastreabilidade do pipeline de migração

### DIFF
--- a/article/models.py
+++ b/article/models.py
@@ -2,7 +2,6 @@ import logging
 import traceback
 from datetime import datetime, timezone
 
-from django.db import transaction
 from django.contrib.auth import get_user_model
 from django.db import IntegrityError, models
 from django.db.models import Count, Q
@@ -15,8 +14,9 @@ from wagtail.admin.panels import FieldPanel, InlinePanel, MultiFieldPanel, Tabbe
 from wagtail.models import Orderable
 from wagtailautocomplete.edit_handlers import AutocompletePanel
 
+from core.widgets import ReadOnlyPrettyJSONWidget
 from migration import choices as migration_choices
-from migration.models import MigratedArticle, ClassicWebsiteConfiguration
+from migration.models import ClassicWebsiteConfiguration
 from article.page_checker import check_url, check_content, format_url, format_classic_url
 from article.forms import ArticleForm, RelatedItemForm, RequestArticleChangeForm
 from collection.choices import PUBLIC
@@ -1495,7 +1495,7 @@ class ArticleWebPage(CommonControlField):
         FieldPanel("fmt", read_only=True),
         FieldPanel("lang", read_only=True),
         FieldPanel("status", read_only=True),
-        FieldPanel("detail", read_only=True),
+        FieldPanel("detail", widget=ReadOnlyPrettyJSONWidget()),
     ]
 
     class Meta:

--- a/core/widgets.py
+++ b/core/widgets.py
@@ -1,0 +1,28 @@
+import json
+from django import forms
+
+class ReadOnlyPrettyJSONWidget(forms.Textarea):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.attrs.update({
+            'readonly': True,
+            'rows': 20,
+            'style': (
+                'font-family: monospace;'
+            ),
+        })
+
+    def format_value(self, value):
+        if not value:
+            return ''
+        try:
+            parsed = json.loads(value) if isinstance(value, str) else value
+            return json.dumps(
+                parsed,
+                indent=2,
+                ensure_ascii=False,
+                sort_keys=True,
+                default=str,   # fallback: converte qualquer coisa para str
+            )
+        except (json.JSONDecodeError, TypeError):
+            return value

--- a/migration/controller.py
+++ b/migration/controller.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from zipfile import ZIP_DEFLATED, ZipFile
 
 from django.db.models import Q
+from django.db.models.functions import Substr, Length
 from django.utils.translation import gettext_lazy as _
 from packtools.sps.models.article_and_subarticles import ArticleAndSubArticles
 from packtools.sps.models.v2.article_assets import ArticleAssets
@@ -719,7 +720,7 @@ def import_journal_acron_id_records(
             "journal_acron": journal_proc.acron,
             "force_update": force_update,
         }
-        
+        source_path = None
         collection = journal_proc.collection
         journal_acron = journal_proc.acron
         collection_acron = collection.acron
@@ -748,10 +749,6 @@ def import_journal_acron_id_records(
                 _("IdFileRecord is already up-to-date with acron.id")
             )
 
-        logging.info(f"Updating IdFileRecord from {source_path}")
-
-        issue_pids = set()
-
         for item in get_bases_work_acron_id_file_records(
             user,
             source_path,
@@ -759,26 +756,28 @@ def import_journal_acron_id_records(
             journal_proc,
         ):
             item["force_update"] = force_update
-            item["todo"] = True
             IdFileRecord.create_or_update(
                 user,
                 journal_id_file,
                 **item,
             )
-            if item["item_type"] == "article":
-                issue_pids.add(item["item_pid"][1:-5])
+
+        issue_pids = IdFileRecord.objects.filter(
+            item_type="article", todo=True, parent=journal_id_file,
+        ).annotate(
+            pid_sliced=Substr("item_pid", 2, Length("item_pid") - 6)
+        ).values_list("pid_sliced", flat=True).distinct()
 
         selected_issue_procs = journal_proc.issueproc_set.filter(
             pid__in=issue_pids,
-        )
-        selected_issue_procs.exclude(
+        ).exclude(
             docs_status__in=tracker_choices.PROGRESS_STATUS_REGULAR_TODO
         ).update(
             docs_status=tracker_choices.PROGRESS_STATUS_REPROC,
             updated_by=user,
         )
         article_proc_model.objects.filter(
-            issue_proc__in=selected_issue_procs
+            issue_proc__in=selected_issue_procs or []
         ).exclude(
             xml_status__in=tracker_choices.PROGRESS_STATUS_REGULAR_TODO
         ).update(
@@ -796,7 +795,10 @@ def import_journal_acron_id_records(
         detail["output"] = output
         return detail
     except FileNotFoundError as e:
-        raise FileNotFoundError(f"File not found: {source_path}")
+        output["message"] = f"File not found: {source_path}"
+        detail["stats"] = stats
+        detail["output"] = output
+        return detail
     except IdFileRecordIsAlreadyUptodate as e:
         output["message"] = str(e)
         detail["stats"] = stats
@@ -805,6 +807,7 @@ def import_journal_acron_id_records(
     except Exception as e:
         output["traceback"] = traceback.format_exc()
         detail["output"] = output
+        detail["stats"] = stats
         return detail
 
 

--- a/migration/models.py
+++ b/migration/models.py
@@ -2,7 +2,6 @@ import logging
 import os
 import sys
 from datetime import datetime, timezone
-from pathlib import Path
 
 from django.core.files.base import ContentFile
 from django.db import DataError, IntegrityError, models
@@ -12,11 +11,12 @@ from modelcluster.fields import ParentalKey
 from modelcluster.models import ClusterableModel
 from wagtail.admin.panels import FieldPanel
 from wagtail.models import Orderable
+from scielo_classic_website import classic_ws
 
 from collection.models import Collection
+from core.widgets import ReadOnlyPrettyJSONWidget
 from core.forms import CoreAdminModelForm
 from core.models import CommonControlField
-from scielo_classic_website import classic_ws
 from tracker import choices as tracker_choices
 from tracker.models import UnexpectedEvent
 
@@ -235,7 +235,7 @@ class MigratedData(CommonControlField):
         FieldPanel("migration_status"),
         FieldPanel("isis_updated_date"),
         FieldPanel("isis_created_date"),
-        FieldPanel("data"),
+        FieldPanel("data", widget=ReadOnlyPrettyJSONWidget()),
     ]
 
     class Meta:
@@ -628,7 +628,7 @@ class MigratedJournal(MigratedData):
     panels = [
         FieldPanel("isis_updated_date"),
         FieldPanel("isis_created_date"),
-        FieldPanel("data"),
+        FieldPanel("data", widget=ReadOnlyPrettyJSONWidget()),
     ]
 
     @classmethod
@@ -645,7 +645,7 @@ class MigratedIssue(MigratedData):
     panels = [
         FieldPanel("isis_updated_date"),
         FieldPanel("isis_created_date"),
-        FieldPanel("data"),
+        FieldPanel("data", widget=ReadOnlyPrettyJSONWidget()),
     ]
 
     @classmethod
@@ -671,7 +671,7 @@ class MigratedArticle(MigratedData):
         FieldPanel("file_type"),
         FieldPanel("isis_updated_date"),
         FieldPanel("isis_created_date"),
-        FieldPanel("data"),
+        FieldPanel("data", widget=ReadOnlyPrettyJSONWidget()),
     ]
 
     def __str__(self):
@@ -882,7 +882,7 @@ class IdFileRecord(CommonControlField, Orderable):
     panels = [
         FieldPanel("item_pid", read_only=True),
         FieldPanel("item_type", read_only=True),
-        FieldPanel("data", read_only=True),
+        FieldPanel("data", widget=ReadOnlyPrettyJSONWidget()),
     ]
 
     class Meta:
@@ -989,7 +989,7 @@ class IdFileRecord(CommonControlField, Orderable):
             obj.updated_by = user
             obj.updated = datetime.now(timezone.utc)
             obj.data = data
-            obj.todo = todo
+            obj.todo = True
             obj.save()
             return obj
         except cls.DoesNotExist:

--- a/package/models.py
+++ b/package/models.py
@@ -11,7 +11,6 @@ from zipfile import ZIP_DEFLATED, ZipFile
 
 from django.core.files.base import ContentFile
 from django.db import models
-from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 from modelcluster.fields import ParentalKey
 from modelcluster.models import ClusterableModel
@@ -21,22 +20,19 @@ from packtools.sps.models.v2.article_assets import ArticleAssets
 from packtools.sps.pid_provider.xml_sps_lib import (
     XMLWithPre,
     get_xml_with_pre,
-    get_xml_with_pre_from_uri,
 )
 from packtools.utils import SPPackage
 from wagtail.admin.panels import FieldPanel, InlinePanel, ObjectList, TabbedInterface
 from wagtail.models import Orderable
-from wagtailautocomplete.edit_handlers import AutocompletePanel
 
-from collection import choices as collection_choices
 from collection.models import Language
+from core.widgets import ReadOnlyPrettyJSONWidget
 from core.models import CommonControlField
 from core.utils.requester import fetch_data
 from core.utils.file_utils import delete_files
 from files_storage.models import FileLocation, MinioConfiguration
 from package import choices
 from pid_provider.requester import PidRequester
-from tracker.models import UnexpectedEvent
 
 
 pid_provider_app = PidRequester()
@@ -335,7 +331,7 @@ class SPSPkg(CommonControlField, ClusterableModel):
         FieldPanel("registered_in_core", read_only=True),
         FieldPanel("valid_texts", read_only=True),
         FieldPanel("valid_components", read_only=True),
-        FieldPanel("texts", read_only=True),
+        FieldPanel("texts", widget=ReadOnlyPrettyJSONWidget()),
     ]
 
     edit_handler = TabbedInterface(

--- a/pid_provider/models.py
+++ b/pid_provider/models.py
@@ -1,28 +1,26 @@
 import io
-import json
 import logging
 import os
 import sys
 import traceback
 import zipfile
 from datetime import datetime
-from functools import lru_cache, cached_property
+from functools import cached_property
 from zlib import crc32
 
 from django.core.files.base import ContentFile
 from django.db import IntegrityError, models
-from django.db.models import Q, Count, Min
+from django.db.models import Q, Count
 from django.utils.translation import gettext_lazy as _
 from modelcluster.fields import ParentalKey
 from modelcluster.models import ClusterableModel
 from packtools.sps.pid_provider import v3_gen, xml_sps_adapter
 from packtools.sps.pid_provider.xml_sps_lib import XMLWithPre
 from wagtail.admin.panels import FieldPanel, InlinePanel, ObjectList, TabbedInterface
-from wagtail.fields import RichTextField
-from wagtail.models import Orderable
 from wagtailautocomplete.edit_handlers import AutocompletePanel
 
 from collection.models import Collection
+from core.widgets import ReadOnlyPrettyJSONWidget
 from core.forms import CoreAdminModelForm
 from core.models import CommonControlField
 from core.utils.profiling_tools import (  # ajuste o import conforme sua estrutura
@@ -1650,7 +1648,7 @@ class XMLURL(CommonControlField):
         FieldPanel("status"),
         FieldPanel("pid"),
         FieldPanel("zipfile"),
-        FieldPanel("detail"),
+        FieldPanel("detail", widget=ReadOnlyPrettyJSONWidget()),
         FieldPanel("exceptions"),
         FieldPanel("is_public"),
     ]

--- a/proc/controller.py
+++ b/proc/controller.py
@@ -3,6 +3,8 @@ Facade para manter compatibilidade com o código existente.
 Este módulo importa todas as funções dos novos módulos especializados.
 """
 
+from proc.models import JournalProc, IssueProc, ArticleProc
+
 # Imports de Exceptions
 from proc.exceptions import (
     ProcBaseException,
@@ -77,3 +79,19 @@ def ensure_journal_proc_exists(user, journal):
 def ensure_issue_proc_exists(user, issue):
     """Delega para IssueDataChecker.ensure_proc_exists."""
     return IssueDataChecker.ensure_proc_exists(user, issue)
+
+
+def get_total_status_data(journal_proc_id, total_status_data):
+    journal_total_status = JournalProc.get_total_status(journal_proc_id)
+    issue_total_status = IssueProc.get_total_status(journal_proc_id, "article")
+    article_total_status = ArticleProc.get_total_status(journal_proc_id)
+    
+    total_status_data_updated = {}
+    if journal_total_status != total_status_data.get("journal"):
+        total_status_data_updated["journal"] = journal_total_status
+    if issue_total_status != total_status_data.get("issue"):
+        total_status_data_updated["issue"] = issue_total_status
+    if article_total_status != total_status_data.get("article"):
+        total_status_data_updated["article"] = article_total_status
+
+    return total_status_data_updated

--- a/proc/models.py
+++ b/proc/models.py
@@ -22,10 +22,11 @@ from wagtail.admin.panels import (
 )
 from wagtail.models import Orderable
 from wagtailautocomplete.edit_handlers import AutocompletePanel
+from scielo_classic_website.htmlbody.html_body import HTMLContent
 
-from article.models import Article
 from collection import choices as collection_choices
 from collection.models import Collection
+from core.widgets import ReadOnlyPrettyJSONWidget
 from core.models import CommonControlField
 from core.utils.file_utils import delete_files
 from core.utils.sanitize import sanitize_for_json
@@ -52,7 +53,6 @@ from package.models import SPSPkg
 from proc import exceptions
 from proc.forms import IssueProcAdminModelForm, ProcAdminModelForm
 from publication.api.publication import get_api_data
-from scielo_classic_website.htmlbody.html_body import HTMLContent
 from tracker import choices as tracker_choices
 from tracker.models import UnexpectedEvent, format_traceback
 
@@ -94,7 +94,7 @@ class Operation(CommonControlField):
         FieldPanel("created", read_only=True),
         FieldPanel("updated", read_only=True),
         FieldPanel("completed", read_only=True),
-        FieldPanel("detail", read_only=True),
+        FieldPanel("detail", widget=ReadOnlyPrettyJSONWidget()),
     ]
 
     class Meta:
@@ -1170,6 +1170,7 @@ class JournalProc(BaseProc, ClusterableModel):
         cls,
         collection_acron_list=None,
         journal_acron_list=None,
+        has_issue_proc=None,
     ):  
         collection_acron_list = collection_acron_list or []
         journal_acron_list = journal_acron_list or []
@@ -1179,6 +1180,8 @@ class JournalProc(BaseProc, ClusterableModel):
             params["collection__acron__in"] = collection_acron_list
         if journal_acron_list:
             params["acron__in"] = journal_acron_list
+        if has_issue_proc:
+            params["issueproc__isnull"] = False
         return cls.objects.filter(
             **params,
         )
@@ -1197,6 +1200,19 @@ class JournalProc(BaseProc, ClusterableModel):
     @property
     def issn_electronic(self):
         return self.journal and self.journal.issn_electronic
+
+    @classmethod
+    def get_total_status(cls, journal_proc_id):
+        return list(
+            cls.objects.filter(id=journal_proc_id).values(
+                "migration_status",
+                "qa_ws_status",
+                "public_ws_status"
+            ).annotate(
+                total=Count("id"),
+            ).order_by("-total")
+        )
+
 
 ################################################
 class IssueGetOrCreateError(Exception): ...
@@ -1429,7 +1445,6 @@ class IssueProc(BaseProc, ClusterableModel):
         journal_acron=None,
         issue_proc_id=None,
     ):  
-        status_list = tracker_choices.get_valid_status(status_list, force_update)
         collection_acron_list = collection_acron_list or []
         if collection_acron:
             collection_acron_list.append(collection_acron)
@@ -1845,6 +1860,26 @@ class IssueProc(BaseProc, ClusterableModel):
             return ""
         return "-".join([self.journal_proc.pid, self.issue.bundle_id_suffix])
 
+    @classmethod
+    def get_total_status(cls, journal_proc_id, item_type):
+        if item_type == "article":
+            return list(
+                cls.objects.filter(journal_proc_id=journal_proc_id).values(
+                    "docs_status",
+                    "files_status",
+                ).annotate(
+                    total=Count("id"),
+                ).order_by("-total")
+            )
+        return list(
+            cls.objects.filter(journal_proc_id=journal_proc_id).values(
+                "migration_status",
+                "qa_ws_status",
+                "public_ws_status"
+            ).annotate(
+                total=Count("id"),
+            ).order_by("-total")
+        )
 
 
 class ArticleEventCreateError(Exception): ...
@@ -2631,3 +2666,17 @@ class ArticleProc(BaseProc, ClusterableModel):
             self.pid_status = pid_status
             self.updated_by = user
             self.save()
+
+    @classmethod
+    def get_total_status(cls, journal_proc_id):
+        return list(
+            cls.objects.filter(issue_proc__journal_proc_id=journal_proc_id).values(
+                "xml_status",
+                "sps_pkg_status",
+                "migration_status",
+                "qa_ws_status",
+                "public_ws_status"
+            ).annotate(
+                total=Count("id"),
+            ).order_by("-total")
+        )

--- a/proc/tasks.py
+++ b/proc/tasks.py
@@ -60,8 +60,7 @@ from django.contrib.auth import get_user_model
 from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 
-from article.models import Article, ArticleCollection, ArticleWebPage, get_pid_status_from_webpage_status
-from article import choices as article_choices
+from article.models import Article, ArticleCollection, ArticleWebPage
 from journal.models import Journal
 from issue.models import Issue
 from collection.choices import PUBLIC, QA
@@ -69,12 +68,12 @@ from collection.models import Collection, WebSiteConfiguration
 from config import celery_app
 from migration import controller
 from migration import choices as migration_choices
-from package.models import SPSPkg
 from proc.controller import (
     create_or_update_migrated_issue,
     create_or_update_migrated_journal,
     fetch_and_create_journal,
     migrate_issue,
+    get_total_status_data,
 )
 from proc.article_controller import ClassicWebsiteArticlePidTracker
 from proc.models import ArticleProc, IssueProc, JournalProc
@@ -963,6 +962,8 @@ def task_migrate_and_publish_articles(
             collection_acron_list += [collection_acron]
 
         items_to_process = {}
+        status = tracker_choices.get_valid_status(status, force_update)
+
         if publication_year or issue_folder:
             selected_issue_procs = IssueProc.select_items(
                 collection_acron_list=collection_acron_list,
@@ -975,20 +976,21 @@ def task_migrate_and_publish_articles(
                 to_migrate_articles=True,
             )
             issue_proc_ids = selected_issue_procs.values_list(
-                "journal_proc_id", "id"
+                "journal_proc_id", "journal_proc__acron", "id"
             ).distinct()
-            for journal_proc_id, issue_proc_id in issue_proc_ids:
-                items_to_process.setdefault(journal_proc_id, []).append(
+            for journal_proc_id, journal_acron, issue_proc_id in issue_proc_ids:
+                items_to_process.setdefault((journal_proc_id, journal_acron), []).append(
                     issue_proc_id
                 )
         else:
             journal_proc_ids = JournalProc.select_items(
                 collection_acron_list=collection_acron_list,
                 journal_acron_list=journal_acron_list,
-            ).values_list("id", flat=True)
+                has_issue_proc=True,
+            ).values_list("id", "acron")
             items_to_process = {
-                journal_proc_id: None
-                for journal_proc_id in journal_proc_ids
+                (journal_proc_id, journal_acron): None
+                for journal_proc_id, journal_acron in journal_proc_ids
             }
 
         total_journals_to_process = len(items_to_process)
@@ -1001,16 +1003,26 @@ def task_migrate_and_publish_articles(
         kwargs_.pop("collection_acron_list", None)
         kwargs_.pop("journal_acron_list", None)
 
+        skipped_journals = 0
         task_exec.total_to_process = total_journals_to_process
         total_processed = 0
-        for journal_proc_id, issue_proc_id_list in items_to_process.items():
+        for key in items_to_process.keys():
             kwargs = {}
             kwargs.update(kwargs_)
+            journal_proc_id, journal_acron = key
             kwargs["journal_proc_id"] = journal_proc_id
-            kwargs["issue_proc_id_list"] = issue_proc_id_list
+            kwargs["journal_acron"] = journal_acron
+            kwargs["issue_proc_id_list"] = items_to_process[key]
+            kwargs["status"] = status
+            
+            if not items_to_process[key]:
+                if not IssueProc.objects.filter(journal_proc_id=journal_proc_id).exists():
+                    skipped_journals.append(journal_acron)
+                    continue
             total_processed += 1
             task_migrate_and_publish_articles_by_journal.delay(**kwargs)
 
+        task_exec.add_event({"skipped_journals": skipped_journals})
         task_exec.total_processed = total_processed
         task_exec.finish()
 
@@ -1080,13 +1092,28 @@ def task_migrate_and_publish_articles_by_journal(
         journal_proc = JournalProc.objects.get(id=journal_proc_id)
         user = _get_user(user_id, username)
 
+        task_exec.item = f"{collection_acron}-{journal_proc.acron}-{issue_folder}-{publication_year}"
+
+        total_status_data = get_total_status_data(journal_proc_id, {})
+        task_exec.add_event({"total_status_data initial": total_status_data})
+
         fix_publication_status(journal_proc.collection)
+
+        total_status_data_updated = get_total_status_data(journal_proc_id, total_status_data)             
+        task_exec.add_event({"total_status_data after updating websites status": total_status_data_updated})
+
         response = controller.import_journal_acron_id_records(
             user,
             ArticleProc,
             journal_proc,
             force_update=force_import_acron_id_file,
         )
+
+        task_exec.add_event({"import_journal_acron_id_records_response": response})
+
+        total_status_data.update(total_status_data_updated)
+        total_status_data_updated = get_total_status_data(journal_proc_id, total_status_data)             
+        task_exec.add_event({"total_status_data after import_journal_acron_id_records": total_status_data_updated})
 
         qa_api_data = get_api_data(
             journal_proc.collection, "issue", "QA"
@@ -1098,10 +1125,8 @@ def task_migrate_and_publish_articles_by_journal(
         total_to_process = 0
 
         if issue_proc_id_list:
-            issue_proc_and_related_article_proc_id_list = {
-                issue_proc_id: []
-                for issue_proc_id in issue_proc_id_list
-            }
+            task_exec.add_number("total issues selected to process", len(issue_proc_id_list))
+            selected_article_proc_items = []
         else:
             selected_issue_procs = IssueProc.select_items(
                 journal_proc_id_list=[journal_proc_id],
@@ -1113,15 +1138,11 @@ def task_migrate_and_publish_articles_by_journal(
             issue_proc_id_list = list(
                 selected_issue_procs.values_list("id", flat=True)
             )
-            issue_proc_and_related_article_proc_id_list = {
-                issue_proc_id: []
-                for issue_proc_id in (issue_proc_id_list or [])
-            }
-
+            task_exec.add_number("total issues found to process", len(issue_proc_id_list))
             selected_article_proc_items = (
                 ArticleProc.select_items(
                     journal_proc_id_list=[journal_proc_id],
-                    exclude_issue_proc_id_list=list(issue_proc_id_list),
+                    exclude_issue_proc_id_list=issue_proc_id_list,
                     status_list=status,
                     force_update=force_update,
                 )
@@ -1129,16 +1150,19 @@ def task_migrate_and_publish_articles_by_journal(
                 .distinct()
             )
 
-            for issue_proc_id, article_proc_id in (
-                selected_article_proc_items
-            ):
+        issue_proc_and_related_article_proc_id_list = {
+            issue_proc_id: []
+            for issue_proc_id in (issue_proc_id_list or [])
+        }
+        if selected_article_proc_items:
+            for issue_proc_id, article_proc_id in selected_article_proc_items:
                 issue_proc_and_related_article_proc_id_list.setdefault(
                     issue_proc_id, []
                 ).append(article_proc_id)
 
-        total_to_process = len(
-            issue_proc_and_related_article_proc_id_list
-        )
+        total_to_process = len(issue_proc_and_related_article_proc_id_list)
+        task_exec.add_number("total issues to process", total_to_process)
+
         for (
             issue_proc_id,
             article_proc_id_list,
@@ -1217,14 +1241,19 @@ def task_migrate_and_publish_articles_by_issue(
         ).get(id=issue_proc_id)
         status = tracker_choices.get_valid_status(status, force_update)
 
+        journal_proc_id = issue_proc.journal_proc_id
+        total_status_data = {}
+        total_status_data_updated = get_total_status_data(journal_proc_id, total_status_data)             
+        task_exec.add_event({"total_status_data": total_status_data_updated})
+
         task_exec.item = str(issue_proc)
 
         total_articles_to_process = 0
+        article_procs = None
         if article_proc_id_list:
             article_procs = ArticleProc.objects.select_related(
                 "issue_proc",
             ).filter(id__in=article_proc_id_list)
-            total_articles_to_process = article_procs.count()
         else:
             total_migrated_records = issue_proc.migrate_document_records(
                 user, force_migrate_document_records
@@ -1247,7 +1276,7 @@ def task_migrate_and_publish_articles_by_issue(
                 status_list=status,
                 force_update=force_update,
             )
-            total_articles_to_process = article_procs.count()
+        total_articles_to_process = article_procs.count()
         task_exec.total_to_process = total_articles_to_process
 
         total_processed = 0
@@ -1263,6 +1292,11 @@ def task_migrate_and_publish_articles_by_issue(
 
         task_exec.total_processed = total_processed
         task_exec.add_number("total_processed", total_processed)
+        task_exec.add_number("total_articles", issue_proc.articleproc_set.count())
+
+        total_status_data.update(total_status_data_updated)
+        total_status_data_updated = get_total_status_data(journal_proc_id, total_status_data)
+        task_exec.add_event({"total_status_data after creating/updating ArticleProc": total_status_data_updated})
 
         task_publish_issue_articles.delay(
             user_id=user_id,
@@ -2086,7 +2120,6 @@ def task_check_articles_availability(
             "issue_folder": issue_folder,
             "publication_year": publication_year,
             "article_pid_v3": article_pid_v3,
-            "article_id": article_id,
             "collection_acron": collection_acron,
             "timeout": timeout,
             "force_update": force_update,

--- a/tracker/models.py
+++ b/tracker/models.py
@@ -2,19 +2,12 @@ import json
 import logging
 import traceback
 import uuid
-from datetime import datetime
 
-from django.core.files.base import ContentFile
 from django.db import models
 from django.utils.translation import gettext_lazy as _
-from modelcluster.fields import ParentalKey
-from modelcluster.models import ClusterableModel
-from wagtail.admin.panels import FieldPanel, InlinePanel, ObjectList, TabbedInterface
-from wagtail.models import Orderable
-from wagtailautocomplete.edit_handlers import AutocompletePanel
+from wagtail.admin.panels import FieldPanel
 
-from core.forms import CoreAdminModelForm
-from core.models import CommonControlField
+from core.widgets import ReadOnlyPrettyJSONWidget
 from core.utils.sanitize import sanitize_for_json
 from tracker import choices
 
@@ -26,9 +19,6 @@ class UnexpectedEventCreateError(Exception): ...
 
 
 class EventCreateError(Exception): ...
-
-
-class EventReportCreateError(Exception): ...
 
 
 class EventReportSaveFileError(Exception): ...
@@ -114,6 +104,14 @@ class UnexpectedEvent(models.Model):
         blank=True,
     )
 
+    panels = [
+        FieldPanel("item", read_only=True),
+        FieldPanel("action", read_only=True),
+        FieldPanel("exception_type", read_only=True),
+        FieldPanel("exception_msg", read_only=True),
+        FieldPanel("traceback", widget=ReadOnlyPrettyJSONWidget()),
+        FieldPanel("detail", widget=ReadOnlyPrettyJSONWidget()),
+    ]
     class Meta:
         indexes = [
             models.Index(fields=["exception_type"]),
@@ -207,7 +205,7 @@ class TaskTracker(BaseEvent):
         FieldPanel("total_to_process", read_only=True),
         FieldPanel("total_processed", read_only=True),
         FieldPanel("status", read_only=True),
-        FieldPanel("detail", read_only=True),
+        FieldPanel("detail", widget=ReadOnlyPrettyJSONWidget()),
     ]
 
     @classmethod

--- a/upload/models.py
+++ b/upload/models.py
@@ -1,5 +1,4 @@
 import json
-import traceback
 import sys
 import csv
 import logging
@@ -8,7 +7,7 @@ import zlib
 from datetime import date, datetime, timedelta
 from random import randint
 from tempfile import TemporaryDirectory
-from zipfile import ZipFile, ZIP_DEFLATED
+from zipfile import ZipFile
 
 from django.contrib.auth import get_user_model
 from django.core.files.base import ContentFile
@@ -19,14 +18,10 @@ from modelcluster.fields import ParentalKey
 from modelcluster.models import ClusterableModel
 from packtools.sps.pid_provider.xml_sps_lib import (
     XMLWithPre,
-    XMLWithPreArticlePublicationDateError,
-    update_zip_file_xml,
-    get_zips,
 )
 from wagtail.admin.panels import (
     FieldPanel,
     InlinePanel,
-    MultiFieldPanel,
     ObjectList,
     TabbedInterface,
 )
@@ -35,15 +30,15 @@ from wagtailautocomplete.edit_handlers import AutocompletePanel
 
 from article import choices as article_choices
 from article.models import Article
-
 from collection.models import Collection
 from collection import choices as collection_choices
+from core.widgets import ReadOnlyPrettyJSONWidget
 from core.models import CommonControlField
 from issue.models import Issue
 from package import choices as package_choices
 from package.models import SPSPkg
 from pid_provider.models import PidProviderXML
-from proc.models import IssueProc, JournalProc, Operation
+from proc.models import IssueProc, Operation
 from proc.source_core_api import create_or_update_issue
 from team.models import CollectionTeamMember
 from upload import choices
@@ -301,7 +296,7 @@ class Package(CommonControlField, ClusterableModel):
     panels = [
         # FieldPanel("file"),
         FieldPanel("status", read_only=True),
-        FieldPanel("numbers", read_only=True),
+        FieldPanel("numbers", widget=ReadOnlyPrettyJSONWidget()),
         FieldPanel("qa_ws_status", read_only=True),
         FieldPanel("public_ws_status", read_only=True),
     ]
@@ -1455,7 +1450,7 @@ class BaseValidationResult(CommonControlField):
         FieldPanel("subject", read_only=True),
         FieldPanel("status", read_only=True),
         FieldPanel("message", read_only=True),
-        FieldPanel("data", read_only=True),
+        FieldPanel("data", widget=ReadOnlyPrettyJSONWidget()),
     ]
 
     cols = ("status", "subject", "message", "data")
@@ -1670,7 +1665,9 @@ class XMLError(BaseXMLValidationResult, ClusterableModel):
     panels = [
         FieldPanel("status", read_only=True),
         FieldPanel("advice", read_only=True),
-        FieldPanel("data", read_only=True),
+        FieldPanel("got_value", widget=ReadOnlyPrettyJSONWidget()),
+        FieldPanel("expected_value", widget=ReadOnlyPrettyJSONWidget()),
+        FieldPanel("data", widget=ReadOnlyPrettyJSONWidget()),
         FieldPanel("reaction"),
     ]
 
@@ -2063,7 +2060,7 @@ class UploadValidator(CommonControlField):
         FieldPanel("max_impossible_to_fix_percentage"),
         FieldPanel("decision_for_critical_errors"),
         FieldPanel("publication_rule"),
-        FieldPanel("validation_params"),
+        FieldPanel("validation_params", widget=ReadOnlyPrettyJSONWidget()),
     ]
     base_form_class = UploadValidatorForm
 


### PR DESCRIPTION
**O que esse PR faz?**

Dois problemas independentes resolvidos juntos:

1. **Reprocessamento desnecessário e pipeline opaco** — dois problemas com a mesma raiz: o pipeline não sabia com precisão o que precisava ser feito nem o que havia mudado entre uma fase e outra.

   - **Seleção de issues incorreta:** a extração de `issue_pids` era feita incrementalmente dentro do loop de criação dos `IdFileRecord`, antes de todos os registros estarem gravados. Isso fazia com que artigos com status `DONE` fossem marcados para reprocessamento sem necessidade. A correção substitui a coleta por uma query ORM com `Substr`/`Length` annotation executada após a gravação completa dos registros, garantindo que apenas o que realmente mudou no arquivo `.id` dispara reprocessamento.

   - **Pipeline sem registro de progresso:** não havia forma de saber, ao analisar os logs, o que havia mudado entre as fases de importação, publicação e criação de `ArticleProc`. A adição de `get_total_status` em `JournalProc`, `IssueProc` e `ArticleProc` permite agregar contagens de status por journal a qualquer momento. O `get_total_status_data` em `proc/controller.py` usa esses métodos para comparar snapshots antes e depois de cada etapa, registrando apenas o que efetivamente mudou — tornando o histórico de execução das tasks muito mais legível e útil para diagnóstico.
 
2. **Melhora na apresentação dos campos do tipo JSON** — campos `data`, `detail`, `numbers`, `texts`, `traceback` e similares eram exibidos como string crua (uma linha só, sem indentação). O novo `ReadOnlyPrettyJSONWidget` reserializa o valor com `indent=2`, `sort_keys=True` e `ensure_ascii=False` antes de renderizar, usando fonte monospace e `readonly=True`. Aplicado em `tracker`, `migration`, `package`, `pid_provider`, `proc`, `article` e `upload`.



---

**Onde a revisão poderia começar?**

- `core/widgets.py` — o widget novo, ponto central do item 1
- `migration/controller.py` — refatoração de `issue_pids` e tratamento de `FileNotFoundError`
- `proc/models.py` — os três `get_total_status` e o filtro `has_issue_proc`
- `proc/controller.py` — `get_total_status_data`
- `proc/tasks.py` — uso de `get_total_status_data` e reorganização do pipeline

---

**Como este poderia ser testado manualmente?**

- Abrir qualquer registro de `UnexpectedEvent`, `TaskTracker`, `MigratedArticle`, `IdFileRecord`, `XMLURL`, `SPSPkg`, `ArticleWebPage`, `Package`, `XMLError` ou `UploadValidator` no admin e verificar que campos JSON aparecem indentados e legíveis
- Disparar `task_migrate_and_publish_articles` para um journal que já teve uma execução anterior com artigos `DONE` e confirmar que esses artigos não entram em reprocessamento
- Conferir nos eventos do `TaskExecution` os snapshots `total_status_data` em cada fase e verificar que apenas os campos que mudaram aparecem registrados
- Disparar para um journal sem issues e confirmar que ele aparece em `skipped_journals` sem erro

---

**Algum cenário de contexto que queira dar?**

O reprocessamento indevido de artigos `DONE` era silencioso — não gerava erro, apenas trabalho desnecessário. Em coleções grandes, isso se traduzia em centenas de tasks disparadas sem necessidade a cada execução do pipeline. A correção é pontual mas o impacto é proporcional ao volume da coleção.

A instrumentação com snapshots não altera nenhum dado; serve exclusivamente para tornar visível o que antes era implícito — quantos artigos estavam em cada status antes e depois de cada fase, e o que o pipeline efetivamente moveu.

---

**Screenshots**

_(adicionar capturas do campo JSON antes/depois no admin)_

---

**Quais são os tickets relevantes?**

---

**Referências**

- [`[django.db.models.functions.Substr](https://docs.djangoproject.com/en/4.2/ref/models/database-functions/#substr)`](https://docs.djangoproject.com/en/4.2/ref/models/database-functions/#substr)
- [`[django.db.models.functions.Length](https://docs.djangoproject.com/en/4.2/ref/models/database-functions/#length)`](https://docs.djangoproject.com/en/4.2/ref/models/database-functions/#length)