### PR TITLE
resolve o problema de rastreabilidade e inconsistência de dados na sincronização de registros com o OPAC

### DIFF
--- a/core/utils/harvesters.py
+++ b/core/utils/harvesters.py
@@ -110,7 +110,7 @@ class OPACHarvester:
             "item": item,
             # o nome do é status (o ideal é que fosse is_public) mas o OPAC retorna "false" ou "true" na chave status
             # e o valor deve ser True se explicitamente é o contrário de "false"
-            "is_public": item.get("status") != "false",
+            "is_public": item.get("status"),
         }
 
     def format_normalized(self, pid_v3, item):

--- a/pid_provider/base_pid_provider.py
+++ b/pid_provider/base_pid_provider.py
@@ -172,7 +172,11 @@ class BasePidProvider:
         """
         # a) Try to obtain XML from URI
         try:
+            xml_url_record = None
+            xml_with_pre = None
+            resp = None
             xml_with_pre = list(XMLWithPre.create(uri=xml_uri))[0]
+            xml_url_record = XMLURL.record(user, xml_uri, None, document_item, xml_with_pre=xml_with_pre)
         except Exception as e:
             return XMLURL.record(user, xml_uri, "xml_fetch_failed", document_item, exception=e)
 
@@ -197,11 +201,17 @@ class BasePidProvider:
                 pass  # If xml_with_pre is not present or cannot be removed, ignore and log rest of response
 
             if response.get("error_type") or response.get("error_msg") or response.get("error_message"):
-                XMLURL.record(user, xml_uri, "pid_provider_xml_failed", document_item, response=resp, xml_with_pre=xml_with_pre, name=name)
+                status = "pid_provider_xml_failed"
             else:
-                XMLURL.record(user, xml_uri, "success", document_item, response=resp, xml_with_pre=xml_with_pre, name=name)
+                status = "success"
+
+            xml_url_record.update_record(user, status, exception=None, response=resp, xml_with_pre=xml_with_pre)
             return response
         except Exception as e:
+            if xml_url_record:
+                xml_url_record.update_record(user, status=None, exception=e, response=resp, xml_with_pre=xml_with_pre)
+                return resp
+
             return self._handle_unexpected_error(e, xml_uri, name, user, origin_date, force_update, is_published, document_item)
 
     def _handle_unexpected_error(self, exception, xml_uri, name, user, origin_date, force_update, is_published, document_item):

--- a/pid_provider/models.py
+++ b/pid_provider/models.py
@@ -1764,24 +1764,48 @@ class XMLURL(CommonControlField):
         
     @classmethod
     def record(cls, user, url, status, document_item, *, exception=None, response=None, xml_with_pre=None, name=None):
+        pid = None
+        is_public = None
         detail = {"document_item": document_item}
+
+        if document_item:
+            pid = pid or document_item.get("pid_v3")
+            is_public = document_item.get("status")
+        if xml_with_pre:
+            pid = xml_with_pre.v3 or pid
+
+        if exception is not None:
+            detail["exceptions"] = traceback.format_exc()
+        if response is not None:
+            detail["response"] = response
+            pid = response.get("v3") or pid
+
+        xmlurl_obj = cls.create_or_update(user=user, url=url, status=status, pid=pid, detail=detail, is_public=is_public)
+
+        if xml_with_pre is not None:
+            name = xml_with_pre.sps_pkg_name
+            filename = f"{name}.xml"
+            xmlurl_obj.save_file(xml_with_pre.tostring(), filename=filename)
+
+        return xmlurl_obj
+    
+    def update_record(self, user, status, exception=None, response=None, xml_with_pre=None):
+        detail = self.detail
+
         if exception is not None:
             detail["exceptions"] = traceback.format_exc()
         if response is not None:
             detail["response"] = response
 
-        pid = response.get("v3") if response else None
-
-        is_public = None
-        if document_item:
-            doc_status = document_item.get("status")
-            if doc_status is not None:
-                is_public = doc_status != "false"
-
-        xmlurl_obj = cls.create_or_update(user=user, url=url, status=status, pid=pid, detail=detail, is_public=is_public)
+        self.status = status
+        self.detail = detail
+        self.updated_by = user
 
         if xml_with_pre is not None:
-            filename = name or pid or "content.xml"
-            xmlurl_obj.save_file(xml_with_pre.tostring(), filename=filename)
+            self.pid = xml_with_pre.v3
+            name = xml_with_pre.sps_pkg_name
+            filename = f"{name}.xml"
+            self.save_file(xml_with_pre.tostring(), filename=filename)
 
-        return xmlurl_obj
+        self.save()
+        return self

--- a/pid_provider/tasks.py
+++ b/pid_provider/tasks.py
@@ -142,9 +142,6 @@ def task_load_records_from_counter_dict(
 
                 url = document.get("url")
                 origin_date = document.get("origin_date")
-                if not document.get("is_public"):
-                    continue
-
                 document_item = document.get("item") or {}
 
                 task_load_record_from_xml_url.delay(


### PR DESCRIPTION
## 📝 Descrição

Este PR resolve o problema de rastreabilidade e inconsistência de dados na sincronização de registros com o OPAC. Anteriormente, itens que possuíam `"status": false` eram interpretados incorretamente como públicos (`is_public = True`), o que forçava tentativas de requisição inválidas, gerando logs de erro confusos (`xml_fetch_failed`) e poluindo a listagem de `XMLURLs`.

Além disso, o fluxo de persistência de log foi refatorado para garantir o registro antecipado das tentativas de coleta, otimizando o diagnóstico de falhas.


---

## 🛠️ Alterações

### 1. `core/utils/harvesters.py`
* **Correção no mapeamento:** Removida a validação antiga que tratava o status como string (`!= "false"`). Agora o sistema aceita diretamente o booleano retornado pelo OPAC, garantindo que o dicionário de dados reflita o estado real do item.

### 2. `pid_provider/models.py` & `tasks.py`
* **Tratamento de `is_public`:** Ajustado o método `XMLURL.record` para ler e salvar corretamente o booleano vindo de `document_item.get("status")`.
* **Novo método:** Adicionado o método helper `update_record` para atualizar instâncias já existentes de `XMLURL` sem duplicar registros ou perder o contexto inicial do payload.
* **Remoção de trava:** Removido o `continue` precoce na task de carga, permitindo que itens não públicos também cheguem ao provider para serem registrados com o status correto de auditoria.

### 3. `pid_provider/base_pid_provider.py`
* **Persistência Antecipada:** O objeto `xml_url_record` agora é criado **antes** de tentar obter o XML via URI (`try/except`). Caso ocorra uma falha de rede ou comportamento inesperado, o registro base já existe no banco e é atualizado com o erro correspondente no bloco `except`, evitando estados inconsistentes.

---

## 🐛 Problema Reportado (Issue)

Corrige #1005 

* **Comportamento Incorreto:** Itens indisponíveis (`status: false`) estavam tentando ser coletados e salvos com `is_public = Yes` (True), resultando no erro genérico `xml_fetch_failed`.
* **Impacto Secundário:** Lentidão e poluição na listagem do menu *Pid Provider > XML URLs*.

##  Comportamento Esperado (Após este PR)

* Se o item possui `"status": false`, o sistema infere `is_public = No`.
* O log registrará com precisão o estado do item, evitando tentativas desnecessárias de fetch ou rotulando o erro de forma errônea.
* Fluxo de log mais limpo e seguro contra falhas silenciosas de rede.

---

## 🧪 Como testar?

1. Execute a task de carga para o PID `zXmHVPm3TWVd8pdVmgXw4jN` (ou um payload similar com `"status": false`).
2. Acesse o admin em **Pid Provider > XML URLs** e busque pelo PID em questão.
3. Valide se:
   - O campo `is_public` está marcado como **No** (False).
   - O fluxo tratou o status adequadamente sem mascarar o erro como uma falha de requisição comum.