### PR TITLE
proc: corrige mapeamento incorreto de subject_descriptor para áreas de estudo de Journal

### DIFF
--- a/proc/source_core_api.py
+++ b/proc/source_core_api.py
@@ -434,10 +434,6 @@ def process_journal_result(
         )
         journal.sponsor.add(Sponsor.create_or_update(user, journal, institution))
 
-    # Processa subject descriptors (novo campo da API)
-    for item in result.get("subject_descriptor") or []:
-        journal.subject.add(Subject.create_or_update(user, item["value"]))
-
     no_lang = []
     for item in result.get("mission"):
         if not item["language"]:


### PR DESCRIPTION
#### O que esse PR faz?

Remove o processamento incorreto do campo `subject_descriptor` da API do core na função `process_journal_result` (`proc/source_core_api.py`).

O campo `subject_descriptor` estava sendo mapeado para o M2M `journal.subject` (áreas de estudo), mas ele contém palavras-chave livres (ex: "Virologia", "Entomologia") que não correspondem aos 9 códigos padronizados de `choices.STUDY_AREA`. Isso causava a criação de objetos `Subject` inválidos no banco, corrompendo os dados de áreas de estudo do periódico.

#### Onde a revisão poderia começar?

`proc/source_core_api.py`, função `process_journal_result` — bloco removido estava nas linhas 437-439 (antes da correção).

#### Como este poderia ser testado manualmente?

1. Com o ambiente local rodando, acesse a administração Wagtail
2. Execute a sincronização de um Journal via `create_or_update_journal` apontando para a API do core (`https://core.scielo.org/api/v1/journal/`)
3. Verifique no admin que o campo "Study Areas" do periódico contém apenas valores válidos de `choices.STUDY_AREA` (Agricultural Sciences, Health Sciences, etc.)
4. Confirme que não há objetos `Subject` com códigos livres (ex: "Virologia") na tabela `journal_subject`

#### Algum cenário de contexto que queira dar?

Na API do core, `subject` e `subject_descriptor` são dois modelos distintos:
- `subject` → modelo `Subject` (code + value) com as áreas de estudo padronizadas do SciELO
- `subject_descriptor` → modelo `SubjectDescriptor` (somente value) com palavras-chave livres cadastradas pelos editores

Ambos os serializers retornam `{"value": "..."}`, o que levou ao tratamento idêntico indevido no upload. O campo `subject` da API já é processado corretamente e é suficiente para preencher as áreas de estudo.

#### Quais são tickets relevantes?

Closes #1010

### Referências

- [Modelo Journal no core](https://github.com/scieloorg/core/blob/8e7b1fadcaa8103ad55dc5260435d6d170843eaf/journal/models.py#L389)
- [Serializers da API do core](https://github.com/scieloorg/core/blob/main/journal/api/v1/serializers.py)
- [Códigos de study-area](https://scielo.readthedocs.io/projects/scielo-pc-programs/en/latest/code_database.html#study-area)