### PR TITLE
Corrige defeitos no pipeline de migração de artigos que não aparecia em nenhum relatório

### DIFF
--- a/article/models.py
+++ b/article/models.py
@@ -911,7 +911,7 @@ class Article(ClusterableModel, CommonControlField):
         try:
             return cls._exclude_invalid_records(user, issue, sps_pkg_id_list, timeout)
         except Exception as e:
-            return {"error": str(e), "error_type": str(type(e)), "traceback": traceback.format_exc(e)}
+            return {"error": str(e), "error_type": str(type(e)), "traceback": traceback.format_exc()}
 
     @classmethod
     def _exclude_invalid_records(cls, user, issue, sps_pkg_id_list, timeout=None):

--- a/article/models.py
+++ b/article/models.py
@@ -908,6 +908,13 @@ class Article(ClusterableModel, CommonControlField):
 
     @classmethod
     def exclude_invalid_records(cls, user, issue, sps_pkg_id_list, timeout=None):
+        try:
+            return cls._exclude_invalid_records(user, issue, sps_pkg_id_list, timeout)
+        except Exception as e:
+            return {"error": str(e), "error_type": str(type(e)), "traceback": traceback.format_exc(e)}
+
+    @classmethod
+    def _exclude_invalid_records(cls, user, issue, sps_pkg_id_list, timeout=None):
         total_deletado = 0
         
         # Estrutura exata solicitada por você
@@ -986,12 +993,13 @@ class Article(ClusterableModel, CommonControlField):
                     try:
                         item.create_or_update_article_collections(user)
                         item.check_availability(user, force_update=True, timeout=timeout)
-                        response = item.available_on_public_website()
-                        events.append(_("Checking {} is available. Result: {}").format(item, response))
-                        
-                        if response.get("valid"):
-                            keep = item
-                            break
+                        for coll in item.article_collections:
+                            response = item.available_on_public_website(coll.collection)
+                            events.append(_("Checking {} is available. Result: {}").format(item, response))
+                            
+                            if response.get("valid"):
+                                keep = item
+                                break
                     except Exception as e:
                         exceptions.append(_("Checking {} is available. Result: {}").format(item, e))
                 
@@ -1018,9 +1026,19 @@ class Article(ClusterableModel, CommonControlField):
         # pode adicioná-lo ao dicionário ou retornar uma tupla. 
         # Como o seu esqueleto final pedia apenas o retorno do dicionário, mantive assim:
         if ppxml_to_delete:
-            PidProviderXML.delete_queryset(PidProviderXML.objects.filter(id__in=ppxml_to_delete))
+            try:
+                PidProviderXML.objects.filter(id__in=ppxml_to_delete).delete()
+            except Exception as e:
+                exceptions.append(str(e))
+                PidProviderXML.objects.filter(
+                    id__in=ppxml_to_delete, 
+                ).update(proc_status=PPXML_STATUS_INVALID)
+
         if sps_pkg_to_delete:
-            SPSPkg.delete_queryset(SPSPkg.objects.filter(id__in=sps_pkg_to_delete))
+            try:
+                SPSPkg.objects.filter(id__in=sps_pkg_to_delete).delete()
+            except Exception as e:
+                exceptions.append(str(e))
         
         response["deleted_ppxml_ids"] = list(ppxml_to_delete)
         response["deleted_sps_pkg_ids"] = list(sps_pkg_to_delete)
@@ -1566,8 +1584,7 @@ class ArticleWebPage(CommonControlField):
                     article = self.article
                     lang_code = self.lang.code2 if self.lang else None
                     article_metadata = article.get_metadata_items(lang_code)
-
-                response = check_content(article_metadata, content, self.fmt) 
+                response = check_content(article_metadata, content, self.fmt)
                 detail.update(response)
                 try:
                     rate = response["rate"]

--- a/migration/controller.py
+++ b/migration/controller.py
@@ -731,9 +731,7 @@ def import_journal_acron_id_records(
             journal_acron,
             journal_acron + ".id",
         )
-        
-        datetime_now = datetime.now(timezone.utc).isoformat()
-        logging.info(f"Processing {source_path} at {datetime_now}")
+        detail["source_path"] = source_path
         journal_id_file = JournalAcronIdFile.create_or_update(
             user=user,
             collection=collection,
@@ -741,10 +739,12 @@ def import_journal_acron_id_records(
             source_path=source_path,
             force_update=force_update,
         )
+        journal_id_file_data = journal_id_file.data
+        detail.update(journal_id_file_data)
         
-        if not force_update and not id_file_record_need_to_be_updated(
-            journal_id_file, datetime_now, output, stats
-        ):
+        id_file_record_need_to_be_updated = journal_id_file_data.get("id_file_record_need_to_be_updated")
+        
+        if not force_update and not id_file_record_need_to_be_updated:
             raise IdFileRecordIsAlreadyUptodate(
                 _("IdFileRecord is already up-to-date with acron.id")
             )
@@ -762,13 +762,16 @@ def import_journal_acron_id_records(
                 **item,
             )
 
+        journal_id_file_data = journal_id_file.data
+        detail.update(journal_id_file_data)
+
         issue_pids = IdFileRecord.objects.filter(
             item_type="article", todo=True, parent=journal_id_file,
         ).annotate(
             pid_sliced=Substr("item_pid", 2, Length("item_pid") - 6)
         ).values_list("pid_sliced", flat=True).distinct()
 
-        journal_proc.issueproc_set.filter(
+        journal_proc.issueproc_set.all().filter(
             pid__in=issue_pids,
         ).exclude(
             docs_status__in=tracker_choices.PROGRESS_STATUS_REGULAR_TODO
@@ -776,6 +779,10 @@ def import_journal_acron_id_records(
             docs_status=tracker_choices.PROGRESS_STATUS_REPROC,
             updated_by=user,
         )
+        detail["stats"]["total_issueproc_docs_status_to_process"] = journal_proc.issueproc_set.all().filter(
+            docs_status__in=tracker_choices.PROGRESS_STATUS_REGULAR_TODO
+        ).count()
+
         article_proc_model.objects.filter(
             issue_proc__pid__in=issue_pids
         ).exclude(
@@ -784,53 +791,18 @@ def import_journal_acron_id_records(
             xml_status=tracker_choices.PROGRESS_STATUS_REPROC,
             updated_by=user,
         )
+        detail["stats"]["total_articleproc_xml_status_to_process"] = article_proc_model.objects.filter(
+            xml_status__in=tracker_choices.PROGRESS_STATUS_REGULAR_TODO
+        ).count()
 
-        qs = journal_id_file.id_file_records.filter(item_type="article")
-        total_id_file_records = qs.count()
-        total_id_file_records_to_migrate = qs.filter(todo=True).count()
-    
-        stats["total_id_file_records"] = total_id_file_records
-        stats["total_id_file_records_to_migrate"] = total_id_file_records_to_migrate
-        detail["stats"] = stats
-        detail["output"] = output
-        return detail
     except FileNotFoundError as e:
-        output["message"] = f"File not found: {source_path}"
-        detail["stats"] = stats
-        detail["output"] = output
-        return detail
+        detail["message"] = f"File not found: {source_path}"
     except IdFileRecordIsAlreadyUptodate as e:
-        output["message"] = str(e)
-        detail["stats"] = stats
-        detail["output"] = output
-        return detail
+        detail["message"] = str(e)
     except Exception as e:
-        output["traceback"] = traceback.format_exc()
-        detail["output"] = output
-        detail["stats"] = stats
-        return detail
-
-
-def id_file_record_need_to_be_updated(journal_id_file, datetime_now, output, stats):
-    output["datetime_now"] = datetime_now
-    
-    output["journal_id_file_last_updated"] = journal_id_file.updated.isoformat()
-    
-    qs = journal_id_file.id_file_records.filter(item_type="article")
-    total_id_file_records = qs.count()
-    stats["total_id_file_records"] = total_id_file_records
-    if total_id_file_records == 0:
-        return True
-
-    total_id_file_records = journal_id_file.id_file_records.count()
-    stats["total_id_file_records"] = total_id_file_records
-    
-    output["id_file_record_last_updated"] = qs.order_by("-updated").first().updated.isoformat()
-    logging.info(f"id_file_record_last_updated: {output['id_file_record_last_updated']}")
-    if output["journal_id_file_last_updated"] > output["id_file_record_last_updated"]:
-        return True
-
-    return False
+        detail["traceback"] = traceback.format_exc()
+        
+    return detail
 
 
 def get_bases_work_acron_id_file_records(

--- a/migration/controller.py
+++ b/migration/controller.py
@@ -787,13 +787,13 @@ def import_journal_acron_id_records(
         article_proc_model.objects.filter(
             issue_proc__pid__in=issue_pids
         ).exclude(
-            xml_status__in=tracker_choices.PROGRESS_STATUS_REGULAR_TODO
+            migration_status__in=tracker_choices.PROGRESS_STATUS_REGULAR_TODO
         ).update(
-            xml_status=tracker_choices.PROGRESS_STATUS_REPROC,
+            migration_status=tracker_choices.PROGRESS_STATUS_REPROC,
             updated_by=user,
         )
-        detail["stats"]["total_articleproc_xml_status_to_process"] = article_proc_model.objects.filter(
-            xml_status__in=tracker_choices.PROGRESS_STATUS_REGULAR_TODO
+        detail["stats"]["total_articleproc_migration_status_to_process"] = article_proc_model.objects.filter(
+            migration_status__in=tracker_choices.PROGRESS_STATUS_REGULAR_TODO
         ).count()
 
     except FileNotFoundError as e:

--- a/migration/controller.py
+++ b/migration/controller.py
@@ -768,7 +768,7 @@ def import_journal_acron_id_records(
             pid_sliced=Substr("item_pid", 2, Length("item_pid") - 6)
         ).values_list("pid_sliced", flat=True).distinct()
 
-        selected_issue_procs = journal_proc.issueproc_set.filter(
+        journal_proc.issueproc_set.filter(
             pid__in=issue_pids,
         ).exclude(
             docs_status__in=tracker_choices.PROGRESS_STATUS_REGULAR_TODO
@@ -777,7 +777,7 @@ def import_journal_acron_id_records(
             updated_by=user,
         )
         article_proc_model.objects.filter(
-            issue_proc__in=selected_issue_procs or []
+            issue_proc__pid__in=issue_pids
         ).exclude(
             xml_status__in=tracker_choices.PROGRESS_STATUS_REGULAR_TODO
         ).update(

--- a/migration/controller.py
+++ b/migration/controller.py
@@ -712,8 +712,7 @@ def import_journal_acron_id_records(
     Para um dado JournalAcronIdFile, criar itens em IdFileRecord
     """
     detail = {}
-    stats = {}
-    output = {}
+    exceptions = []
 
     try:
         detail["params"] = {
@@ -750,11 +749,13 @@ def import_journal_acron_id_records(
             )
 
         for item in get_bases_work_acron_id_file_records(
-            user,
             source_path,
             classic_website,
-            journal_proc,
         ):
+            if item.get("exception"):
+                exceptions.append(item.get("exception"))
+                continue
+
             item["force_update"] = force_update
             IdFileRecord.create_or_update(
                 user,
@@ -801,71 +802,54 @@ def import_journal_acron_id_records(
         detail["message"] = str(e)
     except Exception as e:
         detail["traceback"] = traceback.format_exc()
-        
+
+    detail["exceptions"] = exceptions
+
     return detail
 
 
 def get_bases_work_acron_id_file_records(
-    user, source_path, classic_website, journal_proc
+    source_path, classic_website,
 ):
-    try:
-        event = None
-        event = journal_proc.start(user, "get_bases_work_acron_id_file_records")
-        for item in get_doc_records(source_path):
-            try:
-                issue_id = item.get("issue_id")
-                doc_id = item.get("doc_id")
-                if doc_id:
-                    yield dict(
-                        item_type="article",
-                        item_pid=doc_id,
-                        data=item["doc_data"],
-                    )
+    for item in get_doc_records(source_path):
+        try:
+            issue_id = item.get("issue_id")
+            doc_id = item.get("doc_id")
 
-                elif issue_id:
-                    yield dict(
-                        item_type="issue",
-                        item_pid=issue_id,
-                        data=item["issue_data"],
-                    )
-
-                if not doc_id:
-                    continue
-
-                # se houver bases-work/p/<pid>, obtém os registros de parágrafo
-                ign_pid, p_records = classic_website.get_p_records(doc_id)
-                p_records = list(p_records)
-                if p_records:
-                    # adiciona registros p aos registros do artigo
-                    # info["external_p_records_count"] = len(p_records)
-                    yield dict(
-                        item_type="paragraph",
-                        item_pid=doc_id,
-                        data=p_records,
-                    )
-            except Exception as e:
-                exc_type, exc_value, exc_traceback = sys.exc_info()
-                subevent = journal_proc.start(
-                    user, "get_bases_work_acron_id_file_records item"
+            if doc_id:
+                yield dict(
+                    item_type="article",
+                    item_pid=doc_id,
+                    data=item["doc_data"],
                 )
-                subevent.finish(
-                    user,
-                    completed=False,
-                    detail=item,
-                    exception=e,
-                    exc_traceback=exc_traceback,
+                try:
+                    # se houver bases-work/p/<pid>, obtém os registros de parágrafo
+                    ign_pid, p_records = classic_website.get_p_records(doc_id)
+                    p_records = list(p_records)
+                    if p_records:
+                        # adiciona registros p aos registros do artigo
+                        # info["external_p_records_count"] = len(p_records)
+                        yield dict(
+                            item_type="paragraph",
+                            item_pid=doc_id,
+                            data=p_records,
+                        )
+                except FileNotFoundError:
+                    # é aceitável que bases-work/p/<pid>....id não exista
+                    pass
+
+            elif issue_id:
+                yield dict(
+                    item_type="issue",
+                    item_pid=issue_id,
+                    data=item["issue_data"],
                 )
 
-        event.finish(user, completed=True)
-    except Exception as e:
-        exc_type, exc_value, exc_traceback = sys.exc_info()
-        if event:
-            event.finish(
-                user,
-                completed=False,
-                detail=None,
-                exception=e,
-                exc_traceback=exc_traceback,
+        except Exception as e:
+            exc_type, exc_value, exc_traceback = sys.exc_info()
+            yield dict(
+                item_pid=doc_id or issue_id,
+                exception=str(e)
             )
 
 

--- a/migration/models.py
+++ b/migration/models.py
@@ -999,7 +999,7 @@ class IdFileRecord(CommonControlField, Orderable):
                 item_type,
                 item_pid,
                 data,
-                todo,
+                todo=True,
             )
 
     def get_record_data(self, journal_data=None, issue_data=None):

--- a/migration/models.py
+++ b/migration/models.py
@@ -869,6 +869,27 @@ class JournalAcronIdFile(CommonControlField, ClusterableModel):
             pass
         return obj
 
+    @property
+    def data(self):
+        output = {}
+        stats = {}
+        output["journal_id_file_last_updated"] = self.updated.isoformat()
+        output["id_file_record_last_updated"] = output["journal_id_file_last_updated"]
+        qs = self.id_file_records.filter(item_type="article")
+        total_id_file_records = qs.count()
+        stats["total_id_file_records"] = total_id_file_records
+        stats["total_id_file_records_to_migrate"] = qs.filter(todo=True).count()
+        if total_id_file_records:
+            output["id_file_record_last_updated"] = qs.order_by("-updated").first().updated.isoformat()
+
+        id_file_record_need_to_be_updated = (
+            total_id_file_records == 0 or
+            output["journal_id_file_last_updated"] > output["id_file_record_last_updated"]
+        )
+        output["stats"] = stats
+        output["id_file_record_need_to_be_updated"] = id_file_record_need_to_be_updated
+        return output
+
 
 class IdFileRecord(CommonControlField, Orderable):
     parent = ParentalKey(
@@ -1036,13 +1057,13 @@ class IdFileRecord(CommonControlField, Orderable):
         }
 
     @classmethod
-    def document_records_to_migrate(cls, collection, issue_pid, force_update):
+    def document_records_to_migrate(cls, collection, issue_pid, todo=None):
         params = {}
         if collection:
             params["parent__collection"] = collection
         if issue_pid:
             params["item_pid__startswith"] = f"S{issue_pid}"
-        if not force_update:
+        if todo:
             params["todo"] = True
         return cls.objects.filter(item_type="article", **params)
 

--- a/proc/controller.py
+++ b/proc/controller.py
@@ -2,6 +2,7 @@
 Facade para manter compatibilidade com o código existente.
 Este módulo importa todas as funções dos novos módulos especializados.
 """
+import logging
 
 from proc.models import JournalProc, IssueProc, ArticleProc
 
@@ -81,10 +82,10 @@ def ensure_issue_proc_exists(user, issue):
     return IssueDataChecker.ensure_proc_exists(user, issue)
 
 
-def get_total_status_data(journal_proc_id, total_status_data):
+def get_total_status_data(total_status_data, journal_proc_id, issue_proc_id=None):
     journal_total_status = JournalProc.get_total_status(journal_proc_id)
-    issue_total_status = IssueProc.get_total_status(journal_proc_id, "article")
-    article_total_status = ArticleProc.get_total_status(journal_proc_id)
+    issue_total_status = IssueProc.get_total_status(journal_proc_id, "article", issue_proc_id)
+    article_total_status = ArticleProc.get_total_status(journal_proc_id, issue_proc_id)
     
     total_status_data_updated = {}
     if journal_total_status != total_status_data.get("journal"):

--- a/proc/models.py
+++ b/proc/models.py
@@ -509,13 +509,34 @@ class BaseProc(CommonControlField):
 
     def __str__(self):
         return f"{self.collection} {self.pid}"
+    
+    def get_publication_status(self, purpose, new_status):
+        try:
+            enabled = self.collection.websiteconfiguration_set.filter(purpose=purpose).first().enabled
+        except AttributeError:
+            enabled = False
+        if not enabled:
+            return tracker_choices.PROGRESS_STATUS_IGNORED
+        return new_status
+
+    def set_qa_ws_status(self, new_status):
+        new_status = self.get_publication_status("QA", new_status)
+        if new_status == self.qa_ws_status:
+            return
+        self.qa_ws_status = new_status
+
+    def set_public_ws_status(self, new_status):
+        new_status = self.get_publication_status("PUBLIC", new_status)
+        if new_status == self.public_ws_status:
+            return
+        self.public_ws_status = new_status
 
     def propagate_reproc_or_todo_status(self):
         if self.migration_status == tracker_choices.PROGRESS_STATUS_REPROC:
-            self.qa_ws_status = tracker_choices.PROGRESS_STATUS_REPROC
+            self.set_qa_ws_status(tracker_choices.PROGRESS_STATUS_REPROC)
 
         if self.qa_ws_status == tracker_choices.PROGRESS_STATUS_REPROC:
-            self.public_ws_status = tracker_choices.PROGRESS_STATUS_REPROC
+            self.set_public_ws_status(tracker_choices.PROGRESS_STATUS_REPROC)
 
         self.save()
 
@@ -548,7 +569,7 @@ class BaseProc(CommonControlField):
             obj.creator = user
             obj.collection = collection
             obj.pid = pid
-            obj.public_ws_status = tracker_choices.PROGRESS_STATUS_TODO
+            obj.set_public_ws_status(tracker_choices.PROGRESS_STATUS_TODO)
             obj.save()
             return obj
         except IntegrityError:
@@ -820,6 +841,8 @@ class BaseProc(CommonControlField):
         params["migration_status"] = tracker_choices.PROGRESS_STATUS_DONE
         if content_type == "article":
             params["sps_pkg__pid_v3__isnull"] = False
+        params["collection__websiteconfiguration__purpose"] = "QA"
+        params["collection__websiteconfiguration__enabled"] = True
 
         q = Q(qa_ws_status=tracker_choices.PROGRESS_STATUS_REPROC)
         if force_update:
@@ -917,10 +940,10 @@ class BaseProc(CommonControlField):
                 return resp
 
             if website_kind == collection_choices.QA:
-                self.qa_ws_status = tracker_choices.PROGRESS_STATUS_DOING
-                self.public_ws_status = tracker_choices.PROGRESS_STATUS_TODO
+                self.set_qa_ws_status(tracker_choices.PROGRESS_STATUS_DOING)
+                self.set_public_ws_status(tracker_choices.PROGRESS_STATUS_TODO)
             else:
-                self.public_ws_status = tracker_choices.PROGRESS_STATUS_DOING
+                self.set_public_ws_status(tracker_choices.PROGRESS_STATUS_DOING)
             self.save()
 
             api_data = api_data or get_api_data(
@@ -941,9 +964,9 @@ class BaseProc(CommonControlField):
         except Exception as e:
             exc_type, exc_value, exc_traceback = sys.exc_info()
             if website_kind == collection_choices.QA:
-                self.qa_ws_status = tracker_choices.PROGRESS_STATUS_BLOCKED
+                self.set_qa_ws_status(tracker_choices.PROGRESS_STATUS_BLOCKED)
             else:
-                self.public_ws_status = tracker_choices.PROGRESS_STATUS_BLOCKED
+                self.set_public_ws_status(tracker_choices.PROGRESS_STATUS_BLOCKED)
             self.save()
             if operation:
                 operation.finish(
@@ -1009,6 +1032,8 @@ class BaseProc(CommonControlField):
             params["sps_pkg_status__isnull"] = False
             params["sps_pkg__pid_v3__isnull"] = False
             params["sps_pkg__registered_in_core"] = True
+        params["collection__websiteconfiguration__purpose"] = "PUBLIC"
+        params["collection__websiteconfiguration__enabled"] = True
 
         q = Q(public_ws_status=tracker_choices.PROGRESS_STATUS_REPROC)
 
@@ -1136,7 +1161,7 @@ class JournalProc(BaseProc, ClusterableModel):
             self.availability_status = availability_status or self.availability_status
 
             self.migration_status = migration_status or self.migration_status
-            self.qa_ws_status = tracker_choices.PROGRESS_STATUS_TODO
+            self.set_qa_ws_status(tracker_choices.PROGRESS_STATUS_TODO)
             self.save()
         except Exception as e:
             raise exceptions.JournalProcUpdateError(
@@ -1203,15 +1228,17 @@ class JournalProc(BaseProc, ClusterableModel):
 
     @classmethod
     def get_total_status(cls, journal_proc_id):
-        return list(
-            cls.objects.filter(id=journal_proc_id).values(
-                "migration_status",
-                "qa_ws_status",
-                "public_ws_status"
-            ).annotate(
-                total=Count("id"),
-            ).order_by("-total")
-        )
+        items = []
+        for item in cls.objects.filter(id=journal_proc_id).values(
+            "migration_status",
+            "qa_ws_status",
+            "public_ws_status"
+        ).annotate(
+            total=Count("id"),
+        ).order_by("-total"):
+            total = item.pop("total")
+            items.append({"total": total, "status": item})
+        return items
 
 
 ################################################
@@ -1351,29 +1378,33 @@ class IssueProc(BaseProc, ClusterableModel):
     def propagate_reproc_or_todo_status(self):
         # Propaga status para QA e Public WS
         if self.migration_status == tracker_choices.PROGRESS_STATUS_REPROC:
-            self.qa_ws_status = tracker_choices.PROGRESS_STATUS_REPROC
+            self.set_qa_ws_status(tracker_choices.PROGRESS_STATUS_REPROC)
 
         if self.qa_ws_status == tracker_choices.PROGRESS_STATUS_REPROC:
-            self.public_ws_status = tracker_choices.PROGRESS_STATUS_REPROC
+            self.set_public_ws_status(tracker_choices.PROGRESS_STATUS_REPROC)
 
         # Otimiza a atualização de ArticleProc para docs_status
-        if self.docs_status == tracker_choices.PROGRESS_STATUS_REPROC:
+        if self.docs_status == tracker_choices.PROGRESS_STATUS_REPROC or self.files_status == tracker_choices.PROGRESS_STATUS_REPROC:
             # Atualiza diretamente os artigos relacionados em massa
-            ArticleProc.objects.filter(issue_proc=self).update(
-                migration_status=tracker_choices.PROGRESS_STATUS_REPROC,
-                qa_ws_status=tracker_choices.PROGRESS_STATUS_REPROC,  # Propaga status de doc para migration e qa
-                public_ws_status=tracker_choices.PROGRESS_STATUS_REPROC,  # Propaga status de doc para public
-            )
 
-        # Otimiza a atualização de ArticleProc para files_status
-        if self.files_status == tracker_choices.PROGRESS_STATUS_REPROC:
-            # Atualiza diretamente os artigos relacionados em massa
-            ArticleProc.objects.filter(issue_proc=self).update(
+            valid_qa_publication_status = self.get_publication_status("QA", tracker_choices.PROGRESS_STATUS_REPROC)
+            valid_public_publication_status = self.get_publication_status("PUBLIC", tracker_choices.PROGRESS_STATUS_REPROC)
+
+            qs = ArticleProc.objects.filter(issue_proc=self)
+            qs.update(
                 xml_status=tracker_choices.PROGRESS_STATUS_REPROC,
                 sps_pkg_status=tracker_choices.PROGRESS_STATUS_REPROC,  # Propaga status de xml para sps_pkg
                 migration_status=tracker_choices.PROGRESS_STATUS_REPROC,  # Propaga status de sps_pkg para migration
-                qa_ws_status=tracker_choices.PROGRESS_STATUS_REPROC,  # Propaga status de migration para qa
-                public_ws_status=tracker_choices.PROGRESS_STATUS_REPROC,  # Propaga status de qa para public
+            )
+            qs.exclude(
+                qa_ws_status=valid_qa_publication_status,
+            ).update(
+                qa_ws_status=valid_qa_publication_status,
+            )
+            qs.exclude(
+                public_ws_status=valid_public_publication_status,
+            ).update(
+                public_ws_status=valid_public_publication_status,
             )
 
         self.save()
@@ -1564,10 +1595,10 @@ class IssueProc(BaseProc, ClusterableModel):
     ):
         """
         Migra os arquivos associados ao fascículo.
-        
+
         Processa e migra todos os arquivos (imagens, PDFs, etc) associados
         ao fascículo, organizando-os no repositório de destino.
-        
+
         Parameters
         ----------
         user : User
@@ -1576,28 +1607,38 @@ class IssueProc(BaseProc, ClusterableModel):
             Se True, reprocessa todos os arquivos.
         migrate_issue_files_function : callable
             Função que realiza a migração dos arquivos.
-            
+
         Returns
         -------
-        int
-            Número de arquivos migrados.
+        dict
+            Resultado da migração, no formato:
+            {
+                "completed": bool,
+                "message": str,
+                "migrated": int,
+                "failures": list,
+                "status": str,
+                "exception": str or None,
+            }
         """
+        failures = []
+        exception = None
+
         try:
-            operation = self.start(user, "migrate_document_files")
             if self.files_status == tracker_choices.PROGRESS_STATUS_DONE and not force_update:
-                operation.finish(
-                    user,
-                    completed=True,
-                    message="Files already migrated",
-                    detail={"migrated": self.issue_files.count()},
-                )
-                return
+                return {
+                    "completed": True,
+                    "message": "Files already migrated",
+                    "migrated": self.issue_files.count(),
+                    "failures": failures,
+                    "status": self.files_status,
+                    "exception": exception,
+                }
 
             self.files_status = tracker_choices.PROGRESS_STATUS_DOING
             self.save()
 
             ArticleProc.mark_for_reprocessing(self)
-            failures = []
             migration_result = migrate_issue_files_function(
                 user,
                 collection=self.collection,
@@ -1618,25 +1659,31 @@ class IssueProc(BaseProc, ClusterableModel):
                 self.files_status = tracker_choices.PROGRESS_STATUS_BLOCKED
             self.save()
 
-            operation.finish(
-                user,
-                completed=(self.files_status == tracker_choices.PROGRESS_STATUS_DONE),
-                message="Files",
-                detail={"migrated": self.issue_files.count(), "failures": failures},
-            )
-            return self.issue_files.count()
+            return {
+                "operation": "migrate_document_files",
+                "completed": self.files_status == tracker_choices.PROGRESS_STATUS_DONE,
+                "message": "Files",
+                "migrated": self.issue_files.count(),
+                "failures": failures,
+                "status": self.files_status,
+                "exception": exception,
+            }
 
         except Exception as e:
             logging.exception(f"Exception: migrate_document_files: {e}")
-            exc_type, exc_value, exc_traceback = sys.exc_info()
+            exception = traceback.format_exc()
             self.files_status = tracker_choices.PROGRESS_STATUS_BLOCKED
             self.save()
-            operation.finish(
-                user,
-                exc_traceback=exc_traceback,
-                exception=e,
-                detail={"failures": failures, "migrated": self.issue_files.count()},
-            )
+
+            return {
+                "operation": "migrate_document_files",
+                "completed": False,
+                "message": "Files",
+                "migrated": self.issue_files.count(),
+                "failures": failures,
+                "status": self.files_status,
+                "exception": exception,
+            }
 
     @classmethod
     def docs_to_migrate(cls, collection, journal_acron, publication_year, force_update):
@@ -1738,31 +1785,38 @@ class IssueProc(BaseProc, ClusterableModel):
     def migrate_document_records(self, user, force_update=None):
         """
         Migra os registros de documentos (artigos) do fascículo.
-        
+
         Processa os registros de documentos do arquivo acron.id, criando
         ou atualizando ArticleProc para cada artigo.
-        
+
         Parameters
         ----------
         user : User
             Usuário que executa a migração.
         force_update : bool, optional
             Se True, reprocessa todos os registros.
-            
+
         Returns
         -------
-        int
-            Número de artigos migrados.
+        dict
+            Resultado da migração, no formato:
+            {
+                "input": {...},
+                "output": {...},
+                "status": str,
+                "completed": bool,
+                "exception": str or None,
+                "total": int,
+            }
         """
+        total = 0
+        total_id_file_records = 0
+        exception = None
+        output_data = {}
+        input_data = {}
+        new_status = self.docs_status
+
         try:
-            total = 0
-            total_id_file_records = 0
-            exception = None
-            exc_traceback = None
-            output_data = {}
-            input_data = {}
-            operation = None
-            operation = self.start(user, "migrate_document_records")
             if not self.journal_proc:
                 raise ValueError(f"IssueProc ({self}) has no journal_proc")
 
@@ -1779,15 +1833,15 @@ class IssueProc(BaseProc, ClusterableModel):
             )
             total_articleprocs = article_procs.count()
             total_article_procs_to_process = article_procs.filter(
-                xml_status__in=tracker_choices.PROGRESS_STATUS_REGULAR_TODO
+                migration_status__in=tracker_choices.PROGRESS_STATUS_REGULAR_TODO,
             ).count()
             input_data["total_articleprocs"] = total_articleprocs
-            input_data["total_articleproc_xml_status_to_process"] = total_article_procs_to_process
+            input_data["total_articleproc_migration_status_to_process"] = total_article_procs_to_process
             input_data["force_update"] = force_update
             input_data["docs_status"] = self.docs_status
 
             force_update = (
-                force_update or 
+                force_update or
                 self.docs_status not in tracker_choices.PROGRESS_STATUS_REGULAR_TODO or
                 bool(total_article_procs_to_process) or
                 not total_articleprocs
@@ -1806,7 +1860,6 @@ class IssueProc(BaseProc, ClusterableModel):
             exceptions = {}
             for record in id_file_records:
                 try:
-                    data = None
                     data = record.get_record_data(
                         journal_data,
                         issue_data,
@@ -1821,34 +1874,39 @@ class IssueProc(BaseProc, ClusterableModel):
                     if not article_proc:
                         raise ValueError(f"Unable to create ArticleProc for PID {record.item_pid}")
                     total += 1
-                except Exception as e:
+                except Exception:
                     exceptions[record.item_pid] = traceback.format_exc()
 
             output_data["exceptions"] = exceptions
-            output_data["total failed"] = len(exceptions)
-            output_data["total done"] = input_data["total_id_file_records_to_migrate"] - output_data["total failed"]
+            output_data["total_failed"] = len(exceptions)
+            output_data["total_done"] = (
+                input_data["total_id_file_records_to_migrate"] - output_data["total_failed"]
+            )
+            output_data["total_migrated"] = total
             id_file_records.exclude(item_pid__in=list(exceptions.keys())).update(todo=False)
 
             new_status = self.get_new_docs_status(total_id_file_records)
-            
-        except NoDocumentRecordsToMigrateError as e:
-            new_status = self.get_new_docs_status(total_id_file_records)
 
-        except Exception as exception:
-            exc_type, exc_value, exc_traceback = sys.exc_info()
+        except NoDocumentRecordsToMigrateError:
+            new_status = self.get_new_docs_status(total_id_file_records)
+            exception = traceback.format_exc()
+
+        except Exception:
+            exception = traceback.format_exc()
             new_status = tracker_choices.PROGRESS_STATUS_BLOCKED
+
         if new_status != self.docs_status:
             self.docs_status = new_status
             self.save()
-        if operation:
-            operation.finish(
-                user,
-                completed=self.docs_status == tracker_choices.PROGRESS_STATUS_DONE,
-                exc_traceback=exc_traceback,
-                exception=exception,
-                detail={"input": input_data, "output": output_data}
-            )
-        return total
+
+        return {
+            "input": input_data,
+            "output": output_data,
+            "status": self.docs_status,
+            "completed": self.docs_status == tracker_choices.PROGRESS_STATUS_DONE,
+            "exception": exception,
+            "total": total,
+        }
 
     def get_new_docs_status(self, total_id_file_records=None, total_articleprocs=None):
         if total_id_file_records is None:
@@ -1882,25 +1940,33 @@ class IssueProc(BaseProc, ClusterableModel):
         return "-".join([self.journal_proc.pid, self.issue.bundle_id_suffix])
 
     @classmethod
-    def get_total_status(cls, journal_proc_id, item_type):
+    def get_total_status(cls, journal_proc_id, item_type, issue_proc_id=None):
+        params = {}
+        if issue_proc_id:
+            params["id"] = issue_proc_id
         if item_type == "article":
-            return list(
-                cls.objects.filter(journal_proc_id=journal_proc_id).values(
-                    "docs_status",
-                    "files_status",
-                ).annotate(
-                    total=Count("id"),
-                ).order_by("-total")
-            )
-        return list(
-            cls.objects.filter(journal_proc_id=journal_proc_id).values(
-                "migration_status",
-                "qa_ws_status",
-                "public_ws_status"
+            items = []
+            for item in cls.objects.filter(journal_proc_id=journal_proc_id, **params).values(
+                "docs_status",
+                "files_status",
             ).annotate(
                 total=Count("id"),
-            ).order_by("-total")
-        )
+            ).order_by("-total"):
+                total = item.pop("total")
+                items.append({"total": total, "status": item})
+            return items
+            
+        items = []
+        for item in cls.objects.filter(journal_proc_id=journal_proc_id, **params).values(
+            "migration_status",
+            "qa_ws_status",
+            "public_ws_status"
+        ).annotate(
+            total=Count("id"),
+        ).order_by("-total"):
+            total = item.pop("total")
+            items.append({"total": total, "status": item})
+        return items
 
 
 class ArticleEventCreateError(Exception): ...
@@ -2097,8 +2163,6 @@ class ArticleProc(BaseProc, ClusterableModel):
             xml_status=tracker_choices.PROGRESS_STATUS_REPROC,
             sps_pkg_status=tracker_choices.PROGRESS_STATUS_REPROC,
             migration_status=tracker_choices.PROGRESS_STATUS_REPROC,
-            qa_ws_status=tracker_choices.PROGRESS_STATUS_REPROC,
-            public_ws_status=tracker_choices.PROGRESS_STATUS_REPROC,
         )
 
     @classmethod
@@ -2114,9 +2178,9 @@ class ArticleProc(BaseProc, ClusterableModel):
         if self.sps_pkg_status == tracker_choices.PROGRESS_STATUS_REPROC:
             self.migration_status = tracker_choices.PROGRESS_STATUS_REPROC
         if self.migration_status == tracker_choices.PROGRESS_STATUS_REPROC:
-            self.qa_ws_status = tracker_choices.PROGRESS_STATUS_REPROC
+            self.set_qa_ws_status(tracker_choices.PROGRESS_STATUS_REPROC)
         if self.qa_ws_status == tracker_choices.PROGRESS_STATUS_REPROC:
-            self.public_ws_status = tracker_choices.PROGRESS_STATUS_REPROC
+            self.set_public_ws_status(tracker_choices.PROGRESS_STATUS_REPROC)
         self.save()
 
     # ── identification ──
@@ -2156,8 +2220,8 @@ class ArticleProc(BaseProc, ClusterableModel):
                 self.pid_status = migration_choices.PID_STATUS_MISSING
             self.xml_status = tracker_choices.PROGRESS_STATUS_TODO
             self.sps_pkg_status = tracker_choices.PROGRESS_STATUS_TODO
-            self.qa_ws_status = tracker_choices.PROGRESS_STATUS_TODO
-            self.public_ws_status = tracker_choices.PROGRESS_STATUS_TODO
+            self.set_qa_ws_status(tracker_choices.PROGRESS_STATUS_TODO)
+            self.set_public_ws_status(tracker_choices.PROGRESS_STATUS_TODO)
             self.save()
         except Exception as e:
             raise exceptions.ArticleProcUpdateError(
@@ -2472,12 +2536,11 @@ class ArticleProc(BaseProc, ClusterableModel):
 
     @classmethod
     def items_to_check_url_and_content(cls, collection=None, force_update=False):
-        exclude_list = (
+        exclude_list = [
             migration_choices.PID_STATUS_MISSING,
             migration_choices.PID_STATUS_EXCEEDING,
-        )
+        ]
         if not force_update:
-            exclude_list = list(exclude_list)
             exclude_list.append(migration_choices.PID_STATUS_PUBLIC_VALID)
 
         params = {}
@@ -2608,22 +2671,29 @@ class ArticleProc(BaseProc, ClusterableModel):
 
     @classmethod
     def exclude_invalid_items(cls, user, issue):
-        # obtém sps_pkg_ids cujo pid_v2 não corresponde ao ArticleProc.pid
-        sps_pkg_id_list = cls.get_sps_pkg_ids_which_pid_v2_is_incorrect(issue=issue)
+        try:
+            # obtém sps_pkg_ids cujo pid_v2 não corresponde ao ArticleProc.pid
+            sps_pkg_id_list = cls.get_sps_pkg_ids_which_pid_v2_is_incorrect(issue=issue)
 
-        # completa sps_pkg.pid_v2 com os valores de sps_pkg.xml_with_pre.v2
-        SPSPkg.complete_pid_v2(user, sps_pkg_id_list=sps_pkg_id_list)
+            # completa sps_pkg.pid_v2 com os valores de sps_pkg.xml_with_pre.v2
+            SPSPkg.complete_pid_v2(user, sps_pkg_id_list=sps_pkg_id_list)
 
-        # obtém novamente sps_pkg_ids cujo pid_v2 não corresponde ao cls.pid
-        sps_pkg_id_list = cls.get_sps_pkg_ids_which_pid_v2_is_incorrect(issue=issue)
+            # obtém novamente sps_pkg_ids cujo pid_v2 não corresponde ao cls.pid
+            sps_pkg_id_list = cls.get_sps_pkg_ids_which_pid_v2_is_incorrect(issue=issue)
 
-        qs = cls.objects.filter(
-            Q(sps_pkg_id__in=sps_pkg_id_list)|Q(sps_pkg__isnull=True),
-            issue_proc__issue=issue,
-        )
-        items = qs.values("pid", "sps_pkg__sps_pkg_name")
-        cls.delete_queryset(qs)
-        return {"sps_pkg_id_list": list(sps_pkg_id_list), "deleted": list(items)}
+            qs = cls.objects.filter(
+                Q(sps_pkg_id__in=sps_pkg_id_list)|Q(sps_pkg__isnull=True),
+                issue_proc__issue=issue,
+            )
+            items = qs.values("pid", "sps_pkg__sps_pkg_name")
+            qs.delete()
+            return {"sps_pkg_id_list": list(sps_pkg_id_list), "deleted": list(items)}
+        except Exception as e:
+            return {
+                "error": str(e),
+                "error_type": str(type(e)),
+                "traceback": traceback.format_exc()
+            }
 
     def update_sps_pkg_status(self):
         if self.sps_pkg:
@@ -2662,8 +2732,8 @@ class ArticleProc(BaseProc, ClusterableModel):
         )
         if not article:
             return None
-        self.qa_ws_status = tracker_choices.PROGRESS_STATUS_TODO
-        self.public_ws_status = tracker_choices.PROGRESS_STATUS_TODO
+        self.set_qa_ws_status(tracker_choices.PROGRESS_STATUS_TODO)
+        self.set_public_ws_status(tracker_choices.PROGRESS_STATUS_TODO)
         self.save()
         return article
 
@@ -2689,15 +2759,20 @@ class ArticleProc(BaseProc, ClusterableModel):
             self.save()
 
     @classmethod
-    def get_total_status(cls, journal_proc_id):
-        return list(
-            cls.objects.filter(issue_proc__journal_proc_id=journal_proc_id).values(
-                "xml_status",
-                "sps_pkg_status",
-                "migration_status",
-                "qa_ws_status",
-                "public_ws_status"
-            ).annotate(
-                total=Count("id"),
-            ).order_by("-total")
-        )
+    def get_total_status(cls, journal_proc_id, issue_proc_id=None):
+        params = {}
+        if issue_proc_id:
+            params["issue_proc_id"] = issue_proc_id
+        items = []
+        for item in cls.objects.filter(issue_proc__journal_proc_id=journal_proc_id, **params).values(
+            "xml_status",
+            "sps_pkg_status",
+            "migration_status",
+            "qa_ws_status",
+            "public_ws_status"
+        ).annotate(
+            total=Count("id"),
+        ).order_by("-total"):
+            total = item.pop("total")
+            items.append({"total": total, "status": item})
+        return items

--- a/proc/models.py
+++ b/proc/models.py
@@ -1756,10 +1756,11 @@ class IssueProc(BaseProc, ClusterableModel):
         """
         try:
             total = 0
-            total_document_records = 0
+            total_id_file_records = 0
             exception = None
             exc_traceback = None
-            detail = {}
+            output_data = {}
+            input_data = {}
             operation = None
             operation = self.start(user, "migrate_document_records")
             if not self.journal_proc:
@@ -1768,27 +1769,38 @@ class IssueProc(BaseProc, ClusterableModel):
             id_file_records = IdFileRecord.document_records_to_migrate(
                 collection=self.collection,
                 issue_pid=self.pid,
-                force_update=True,  # todos os registros encontrados em acron.id no momento
             )
-            total_document_records = id_file_records.count()
-            detail["total_document_records"] = total_document_records
+            total_id_file_records = id_file_records.count()
+            input_data["total_id_file_records"] = total_id_file_records
+            input_data["total_id_file_records_to_migrate"] = total_id_file_records
+
+            article_procs = ArticleProc.objects.filter(
+                issue_proc=self,
+            )
+            total_articleprocs = article_procs.count()
+            total_article_procs_to_process = article_procs.filter(
+                xml_status__in=tracker_choices.PROGRESS_STATUS_REGULAR_TODO
+            ).count()
+            input_data["total_articleprocs"] = total_articleprocs
+            input_data["total_articleproc_xml_status_to_process"] = total_article_procs_to_process
+            input_data["force_update"] = force_update
+            input_data["docs_status"] = self.docs_status
 
             force_update = (
                 force_update or 
-                self.docs_status != tracker_choices.PROGRESS_STATUS_DONE or
-                ArticleProc.objects.filter(issue_proc=self).count() < total_document_records
-            )    
+                self.docs_status not in tracker_choices.PROGRESS_STATUS_REGULAR_TODO or
+                bool(total_article_procs_to_process) or
+                not total_articleprocs
+            )
+
             if not force_update:
                 # obtém somente os registros por fazer (todo=True)
                 id_file_records = id_file_records.filter(todo=True)
+                input_data["total_id_file_records_to_migrate"] = id_file_records.count()
 
-            detail["total_document_records_to_migrate"] = id_file_records.count()
-            if detail["total_document_records_to_migrate"] == 0:
+            if input_data["total_id_file_records_to_migrate"] == 0:
                 raise NoDocumentRecordsToMigrateError("No document records to migrate")
 
-            detail["total_migrated_articles - initial"] = ArticleProc.objects.filter(
-                issue_proc=self
-            ).count()
             journal_data = self.journal_proc.migrated_data.data
             issue_data = self.migrated_data.data
             exceptions = {}
@@ -1806,26 +1818,24 @@ class IssueProc(BaseProc, ClusterableModel):
                         data=data["data"],
                         force_update=force_update,
                     )
-                    total += 1
                     if not article_proc:
                         raise ValueError(f"Unable to create ArticleProc for PID {record.item_pid}")
+                    total += 1
                 except Exception as e:
                     exceptions[record.item_pid] = traceback.format_exc()
 
-            detail["exceptions"] = exceptions
-            detail["total failed"] = len(exceptions)
-            detail["total done"] = detail["total_document_records_to_migrate"] - detail["total failed"]
+            output_data["exceptions"] = exceptions
+            output_data["total failed"] = len(exceptions)
+            output_data["total done"] = input_data["total_id_file_records_to_migrate"] - output_data["total failed"]
             id_file_records.exclude(item_pid__in=list(exceptions.keys())).update(todo=False)
 
-            new_status = self.get_new_docs_status(total_document_records)
+            new_status = self.get_new_docs_status(total_id_file_records)
             
         except NoDocumentRecordsToMigrateError as e:
-            exc_type, exc_value, exc_traceback = sys.exc_info()
-            new_status = self.get_new_docs_status(total_document_records)
+            new_status = self.get_new_docs_status(total_id_file_records)
 
-        except Exception as e:
+        except Exception as exception:
             exc_type, exc_value, exc_traceback = sys.exc_info()
-            exception = e
             new_status = tracker_choices.PROGRESS_STATUS_BLOCKED
         if new_status != self.docs_status:
             self.docs_status = new_status
@@ -1836,24 +1846,25 @@ class IssueProc(BaseProc, ClusterableModel):
                 completed=self.docs_status == tracker_choices.PROGRESS_STATUS_DONE,
                 exc_traceback=exc_traceback,
                 exception=exception,
-                detail=detail
+                detail={"input": input_data, "output": output_data}
             )
         return total
 
-    def get_new_docs_status(self, total_document_records=None, total_migrated_articles=None):
-        if total_document_records is None:
-            total_document_records = IdFileRecord.document_records_to_migrate(
+    def get_new_docs_status(self, total_id_file_records=None, total_articleprocs=None):
+        if total_id_file_records is None:
+            total_id_file_records = IdFileRecord.document_records_to_migrate(
                 collection=self.collection,
                 issue_pid=self.pid,
-                force_update=True,  # todos os registros encontrados em acron.id no momento
             ).count()
-        if total_migrated_articles is None:
-            total_migrated_articles = ArticleProc.objects.filter(issue_proc=self).count()
-        if total_document_records == 0:
+        if total_articleprocs is None:
+            total_articleprocs = ArticleProc.objects.filter(
+                issue_proc=self,
+            ).count()
+        if total_id_file_records == 0:
             return tracker_choices.PROGRESS_STATUS_BLOCKED
-        if total_migrated_articles == 0:
+        if total_articleprocs == 0:
             return tracker_choices.PROGRESS_STATUS_TODO
-        if total_migrated_articles == total_document_records:
+        if total_articleprocs == total_id_file_records:
             return tracker_choices.PROGRESS_STATUS_DONE
         return tracker_choices.PROGRESS_STATUS_PENDING
 

--- a/proc/tasks.py
+++ b/proc/tasks.py
@@ -1118,8 +1118,9 @@ def task_migrate_and_publish_articles_by_journal(
         total_processed = 0
         total_to_process = 0
 
+        issue_proc_and_related_article_proc_id_list = {}
         if issue_proc_id_list:
-            task_exec.add_number("total issues selected to process", len(issue_proc_id_list))
+            task_exec.add_number("total issue_proc_id_list", len(issue_proc_id_list))
             selected_article_proc_items = []
         else:
             selected_issue_procs = IssueProc.select_items(
@@ -1131,7 +1132,7 @@ def task_migrate_and_publish_articles_by_journal(
             issue_proc_id_list = list(
                 selected_issue_procs.values_list("id", flat=True)
             )
-            task_exec.add_number("total issues found to process", len(issue_proc_id_list))
+            task_exec.add_number("total issue_proc todo or reproc", len(issue_proc_id_list))
             selected_article_proc_items = (
                 ArticleProc.select_items(
                     journal_proc_id_list=[journal_proc_id],
@@ -1142,6 +1143,7 @@ def task_migrate_and_publish_articles_by_journal(
                 .values_list("issue_proc_id", "id")
                 .distinct()
             )
+            task_exec.add_number("total articles todo or reproc", selected_article_proc_items.count())
 
         issue_proc_and_related_article_proc_id_list = {
             issue_proc_id: []
@@ -1154,7 +1156,7 @@ def task_migrate_and_publish_articles_by_journal(
                 ).append(article_proc_id)
 
         total_to_process = len(issue_proc_and_related_article_proc_id_list)
-        task_exec.add_number("total issues to process", total_to_process)
+        task_exec.add_number("total issue_proc todo or reproc", total_to_process)
 
         for (
             issue_proc_id,

--- a/proc/tasks.py
+++ b/proc/tasks.py
@@ -82,7 +82,7 @@ from publication.api.issue import publish_issue, sync_issue
 from publication.api.journal import publish_journal
 from publication.api.publication import get_api_data
 from tracker import choices as tracker_choices
-from tracker.models import TaskTracker, UnexpectedEvent
+from tracker.models import TaskTracker, UnexpectedEvent, sanitize_for_json
 
 User = get_user_model()
 
@@ -106,6 +106,8 @@ class TaskExecution:
         self.events = []
         self.stats = {}
         self.exceptions = []
+        self.journal_proc_id = None
+        self.status_changes = {}
 
     @property
     def item(self):
@@ -146,40 +148,64 @@ class TaskExecution:
         self.stats[name] = number
 
     def finish(self, exception=None, exc_traceback=None):
-        """Persiste o TaskTracker com stats, eventos e exceções acumulados."""
-        if exception or exc_traceback or self.exceptions:
-            completed = False
-        else:
-            completed = True
-        self.params["item"] = self.item
-
-        self.stats["total_to_process"] = self.total_to_process
-        self.stats["total_processed"] = self.total_processed
-
-        detail = {
-            "params": self.params,
-            "stats": self.stats,
-            "events": self.events,
-            "exceptions": self.exceptions,
-        }
         try:
-            json.dumps(detail)
-        except Exception:
-            fixed_detail = {}
-            for key, value in detail.items():
-                try:
-                    json.dumps(value)
-                    fixed_detail[key] = value
-                except Exception:
-                    fixed_detail[key] = str(value)
-            detail = fixed_detail
+            if exception or exc_traceback or self.exceptions:
+                completed = False
+            else:
+                completed = True
+            self.stats["total_to_process"] = self.total_to_process
+            self.stats["total_processed"] = self.total_processed
 
-        self.task_tracker.finish(
-            completed=completed,
-            exception=exception,
-            exc_traceback=exc_traceback,
-            detail=detail,
-        )
+            detail = {
+                "params": self.params,
+                "stats": self.stats,
+                "events": self.events,
+                "exceptions": self.exceptions,
+                "status_changes": self.status_changes
+            }
+            try:
+                json.dumps(detail)
+            except Exception as x:
+                fixed_detail = {}
+                for key, value in detail.items():
+                    try:
+                        json.dumps(value)
+                        fixed_detail[key] = value
+                    except Exception as exxx:
+                        fixed_detail[key] = str(value)
+                detail = fixed_detail
+            self.task_tracker.finish(
+                completed=completed,
+                exception=exception,
+                exc_traceback=exc_traceback,
+                detail=detail,
+            )
+        except Exception as e:
+            exc_type, exc_value, exc_traceback = sys.exc_info()
+            UnexpectedEvent.create(
+                e=e,
+                exc_traceback=exc_traceback,
+                detail={
+                    "task": "proc.tasks.TaskExecution.finish",
+                    "item": self.item,
+                },
+            )
+
+    def update_total_status(self, label, issue_proc_id=None):
+        previous = {}
+        for key, items in self.status_changes.items():
+            try:
+                previous[key] = items[-1]["total_status"]
+            except (IndexError, KeyError):
+                previous[key] = []
+
+        result = get_total_status_data(previous, self.journal_proc_id, issue_proc_id)
+        for key, items in result.items():
+            data = {
+                "label": label,
+                "total_status": items
+            }
+            self.status_changes.setdefault(key, []).append(data)
 
 
 def _get_user(user_id, username):
@@ -1072,10 +1098,9 @@ def task_migrate_and_publish_articles_by_journal(
         "force_migrate_document_records": force_migrate_document_records,
         "force_migrate_document_files": force_migrate_document_files,
     }
-    title = f"{collection_acron}-{journal_acron}-{issue_folder}-{publication_year}"
     task_exec = TaskExecution(
         name="proc.tasks.task_migrate_and_publish_articles_by_journal",
-        item=title,
+        item=f"{collection_acron}-{journal_acron}",
         params=task_params,
     )
     try:
@@ -1086,15 +1111,11 @@ def task_migrate_and_publish_articles_by_journal(
         journal_proc = JournalProc.objects.get(id=journal_proc_id)
         user = _get_user(user_id, username)
 
-        task_exec.item = f"{collection_acron}-{journal_proc.acron}-{issue_folder}-{publication_year}"
-
-        total_status_data = get_total_status_data(journal_proc_id, {})
-        task_exec.add_event({"total_status_data initial": total_status_data})
+        task_exec.journal_proc_id = journal_proc_id
+        task_exec.update_total_status(("Start"))
 
         fix_publication_status(journal_proc.collection)
-
-        total_status_data_updated = get_total_status_data(journal_proc_id, total_status_data)             
-        task_exec.add_event({"total_status_data after updating websites status": total_status_data_updated})
+        task_exec.update_total_status(("Updated publication status"))
 
         response = controller.import_journal_acron_id_records(
             user,
@@ -1103,11 +1124,9 @@ def task_migrate_and_publish_articles_by_journal(
             force_update=force_import_acron_id_file,
         )
 
-        task_exec.add_event({"import_journal_acron_id_records_response": response})
+        task_exec.add_event({"operation": "import_journal_acron_id_records", "response": response})
 
-        total_status_data.update(total_status_data_updated)
-        total_status_data_updated = get_total_status_data(journal_proc_id, total_status_data)             
-        task_exec.add_event({"total_status_data after import_journal_acron_id_records": total_status_data_updated})
+        task_exec.update_total_status(label="Imported journal acron.id")
 
         qa_api_data = get_api_data(
             journal_proc.collection, "issue", "QA"
@@ -1164,7 +1183,7 @@ def task_migrate_and_publish_articles_by_journal(
         ) in issue_proc_and_related_article_proc_id_list.items():
             total_processed += 1
             # executa sincronamente a eliminação de registros ArticleProc e Article cujo conteúdo é defeituoso
-            task_exclude_invalid_issue_articles(
+            response = task_exclude_invalid_issue_articles(
                 issue_proc_id=issue_proc_id,
                 username=username,
                 user_id=user_id,
@@ -1182,6 +1201,7 @@ def task_migrate_and_publish_articles_by_journal(
                 force_migrate_document_files=force_migrate_document_files,
                 qa_api_data=qa_api_data,
                 public_api_data=public_api_data,
+                exclude_invalid_articles_response=response,
             )
         task_exec.total_processed = total_processed
         task_exec.total_to_process = total_to_process
@@ -1205,6 +1225,7 @@ def task_migrate_and_publish_articles_by_issue(
     force_migrate_document_files=False,
     qa_api_data=None,
     public_api_data=None,
+    exclude_invalid_articles_response=None,
 ):
     """
     Migra e publica artigos de um fascículo.
@@ -1236,12 +1257,12 @@ def task_migrate_and_publish_articles_by_issue(
         ).get(id=issue_proc_id)
         status = tracker_choices.get_valid_status(status, force_update)
 
-        journal_proc_id = issue_proc.journal_proc_id
-        total_status_data = {}
-        total_status_data_updated = get_total_status_data(journal_proc_id, total_status_data)             
-        task_exec.add_event({"total_status_data": total_status_data_updated})
+        task_exec.item = f"{issue_proc} {issue_proc.collection}"
 
-        task_exec.item = str(issue_proc)
+        task_exec.journal_proc_id = issue_proc.journal_proc_id
+        task_exec.update_total_status(("Start"), issue_proc_id)
+
+        task_exec.add_event(exclude_invalid_articles_response)
 
         total_articles_to_process = 0
         article_procs = None
@@ -1250,21 +1271,21 @@ def task_migrate_and_publish_articles_by_issue(
                 "issue_proc",
             ).filter(id__in=article_proc_id_list)
         else:
-            total_migrated_records = issue_proc.migrate_document_records(
+            # cria ou atualiza ArticleProc
+            response = issue_proc.migrate_document_records(
                 user, force_migrate_document_records
             )
-            task_exec.add_number(
-                "total_migrated_records", total_migrated_records
-            )
+            task_exec.add_event({"operation": "migrate_document_records", "response": response})
+            task_exec.update_total_status(("Created or updated Article Processing records"), issue_proc_id)
 
-            total_migrated_files = issue_proc.migrate_document_files(
+            # cria ou atualiza MigratedFile
+            response = issue_proc.migrate_document_files(
                 user,
                 force_migrate_document_files,
                 controller.migrate_issue_files,
             )
-            task_exec.add_number(
-                "total_migrated_files", total_migrated_files
-            )
+            task_exec.add_event({"operation": "migrate_document_files", "response": response})
+            task_exec.update_total_status(("Created or updated Migrated file records"), issue_proc_id)
 
             article_procs = ArticleProc.select_items(
                 issue_proc_id_list=[issue_proc_id],
@@ -1278,20 +1299,18 @@ def task_migrate_and_publish_articles_by_issue(
         exceptions = {}
         for article_proc in article_procs:
             try:
+                # faz o fluxo completo do artigo: get_xml e cria sps_pkg
                 article = article_proc.migrate_article(user, force_update)
                 total_processed += 1
             except Exception as e:
                 exc_type, exc_value, exc_traceback = sys.exc_info()
                 exceptions[article_proc.pid] = traceback.format_exc()
                 task_exec.add_exception(exceptions[article_proc.pid])
+        task_exec.update_total_status(("Created or updated SPS Package and Article records"), issue_proc_id)
 
         task_exec.total_processed = total_processed
         task_exec.add_number("total_processed", total_processed)
-        task_exec.add_number("total_articles", issue_proc.articleproc_set.count())
-
-        total_status_data.update(total_status_data_updated)
-        total_status_data_updated = get_total_status_data(journal_proc_id, total_status_data)
-        task_exec.add_event({"total_status_data after creating/updating ArticleProc": total_status_data_updated})
+        task_exec.add_number("total_articleprocs", issue_proc.articleproc_set.count())
 
         task_publish_issue_articles.delay(
             user_id=user_id,
@@ -1300,7 +1319,7 @@ def task_migrate_and_publish_articles_by_issue(
             status=status,
             force_update=force_update,
         )
-
+        task_exec.add_event({"operation": "Scheduled articles publication"})
         task_exec.finish()
     except Exception as e:
         exc_type, exc_value, exc_traceback = sys.exc_info()
@@ -1345,17 +1364,21 @@ def task_publish_issue_articles(
 
         status = tracker_choices.get_valid_status(status, force_update)
 
+        task_exec.journal_proc_id = issue_proc.journal_proc_id
+        task_exec.update_total_status(("Start"), issue_proc_id)
+
         articles = (
             ArticleProc.objects.select_related("issue_proc", "sps_pkg")
             .filter(
                 issue_proc=issue_proc,
                 sps_pkg__pid_v3__isnull=False,
             )
-            .values_list("id", flat=True)
         )
 
         collection = issue_proc.collection
         fix_publication_status(collection)
+        task_exec.update_total_status(("Updated publication status"), issue_proc_id)
+
         total_processed = 0
         total_to_process = 0
         for website in WebSiteConfiguration.objects.filter(
@@ -1370,9 +1393,11 @@ def task_publish_issue_articles(
             elif website_kind == PUBLIC:
                 query_by_status = Q(public_ws_status__in=status)
 
-            article_ids_to_publish = articles.filter(query_by_status)
-            total_to_process += article_ids_to_publish.count()
-
+            total_published = 0
+            total_to_publish = 0
+            article_ids_to_publish = articles.filter(query_by_status).values_list("id", flat=True)
+            total_to_publish = article_ids_to_publish.count()
+            total_to_process += total_to_publish
             for article_proc_id in article_ids_to_publish:
                 try:
                     task_publish_article(
@@ -1384,10 +1409,15 @@ def task_publish_issue_articles(
                         api_data=api_data,
                         force_update=force_update,
                     )
-                    total_processed += 1
+                    total_published += 1
                 except Exception as e:
                     exc_type, exc_value, exc_traceback = sys.exc_info()
                     task_exec.add_exception(traceback.format_exc())
+            total_processed += total_published
+            task_exec.update_total_status(
+                (f"Total article published on {website_kind}: {total_published}/{total_to_publish}"),
+                issue_proc_id
+            )
 
             task_sync_issue.delay(
                 user_id=user_id,
@@ -1396,8 +1426,10 @@ def task_publish_issue_articles(
                 issue_proc_id=issue_proc_id,
                 api_data=api_data,
             )
+            task_exec.add_event({"operation": "Scheduled issue synchronization"})
         task_exec.total_to_process = total_to_process
         task_exec.total_processed = total_processed
+        
         task_exec.finish()
     except Exception as e:
         exc_type, exc_value, exc_traceback = sys.exc_info()
@@ -1498,7 +1530,6 @@ def task_publish_articles(
             issue_proc_id=issue_proc_id,
         )
         total = issue_procs.count()
-        task_exec.add_event(f"Publishing articles of {total} issues")
 
         for issue_proc in issue_procs:
             task_publish_issue_articles.delay(
@@ -1508,6 +1539,7 @@ def task_publish_articles(
                 status=status,
                 force_update=force_update,
             )
+        task_exec.add_event({"operation": f"Scheduled article publication of {total} issues"})
         task_exec.finish()
     except Exception as e:
         exc_type, exc_value, exc_traceback = sys.exc_info()
@@ -1669,37 +1701,28 @@ def task_exclude_invalid_issue_articles(
     antes de iniciar a migração dos artigos.
     """
     try:
-        item = issue_proc_id
         detail = None
-        event = None
         user = _get_user(user_id=user_id, username=username)
         issue_proc = IssueProc.objects.select_related("issue").get(
             id=issue_proc_id
         )
-        item = str(issue_proc)
-        event = issue_proc.start(user, "Exclude invalid articles")
         detail = []
         issue = issue_proc.issue
         response = ArticleProc.exclude_invalid_items(user, issue)
-        detail.append({"Model": "ArticleProc", "response": response})
+        detail.append({"operation": "ArticleProc.exclude_invalid_items", "response": response})
         response = Article.exclude_invalid_records(user, issue, response.get("sps_pkg_id_list"), timeout=timeout)
-        detail.append({"Model": "Article", "response": response})
+        detail.append({"operation": "Article.exclude_invalid_records", "response": response})
         if response.get("deleted_sps_pkg_ids"):
             response = ArticleProc.exclude_invalid_items(user, issue)
-            detail.append({"Model": "ArticleProc", "response": response})
-        event.finish(user, completed=True, detail=detail)
+            detail.append({"operation": "ArticleProc.exclude_invalid_items", "response": response})
+        return detail
     except Exception as e:
         exc_type, exc_value, exc_traceback = sys.exc_info()
-        if event:
-            event.finish(user, exception=e, exc_traceback=exc_traceback)
-            return
-        UnexpectedEvent.create(
-            item=item,
-            action="proc.tasks.task_exclude_invalid_issue_articles",
-            e=e,
-            exc_traceback=exc_traceback,
-            detail=detail,
-        )
+        return {
+            "exc_type": str(exc_type),
+            "exc_value": str(exc_value),
+            "traceback": traceback.format_exc()
+        }
 
 
 @celery_app.task(bind=True)

--- a/publication/api/publication.py
+++ b/publication/api/publication.py
@@ -90,7 +90,7 @@ class PublicationAPI:
             exc_type, exc_value, exc_traceback = sys.exc_info()
             response = {
                 "post_data_url": self.post_data_url,
-                "payload": json.dumps(payload),
+                "payload": payload,
                 "traceback": traceback.format_tb(exc_traceback),
                 "error": str(e),
                 "error_type": str(type(e)),
@@ -102,7 +102,7 @@ class PublicationAPI:
             response["result"] = "OK"
         elif response.get("failed") is False:
             response["result"] = "OK"
-        response["payload"] = json.dumps(payload)
+        response["payload"] = payload
         return response or {}
 
     def get_token(self):


### PR DESCRIPTION
#### O que esse PR faz?

Corrige defeitos no pipeline de migração de artigos que não aparecia em nenhum relatório. Por este motivo, também neste PR foram feitas mudanças para que o relatório fosse mais informativo e menos fragmentado.

- **Corrige filtragem / atualização de status** na importação do arquivo `acron.id`.
- **Corrige tratamento de exceções** de`Article.exclude_invalid_records`, `ArticleProc.exclude_invalid_items`, `task_exclude_invalid_issue_articles`, retornando dicts com `error`/`traceback` — incluindo a correção de `traceback.format_exc()` (sem passar a exceção como argumento).
- **Corrige atribuição de valor de status para qa_ws_status e public_ws_status** (`WebSiteConfiguration.enabled`) antes de marcar `qa_ws_status`/`public_ws_status` para reprocessamento, via os novos métodos `BaseProc.get_publication_status`, `set_qa_ws_status` e `set_public_ws_status`.

Melhorias nos relatório de eventos / erros para ser mais informativo e menos fragmentado

- **Eliminar o acoplamento com o sistema de eventos (`operation.start/finish`, `journal_proc.start`)** em vários pontos, substituindo por retornos estruturados em `dict`/`list`, que passam a ser consumidos pela camada de tasks (`proc/tasks.py`) e registrados via `TaskExecution`.
- **Centralizar o rastreamento de status total** (`journal`/`issue`/`article`) em `TaskExecution.update_total_status`, que mantém histórico (`status_changes`) com rótulos por etapa, em vez de chamadas manuais e repetidas a `get_total_status_data` espalhadas pelas tasks.
- **Mover a lógica de "id_file_record precisa ser atualizado" e suas estatísticas** para a nova `property JournalAcronIdFile.data`, simplificando `import_journal_acron_id_records` e removendo a função auxiliar `id_file_record_need_to_be_updated`.
- **Tornar `get_bases_work_acron_id_file_records` mais resiliente**: passa a ignorar `FileNotFoundError` esperado ao buscar `bases-work/p/<pid>` e a sinalizar item com erro via `{"exception": ...}` no dict gerado, em vez de registrar evento próprio.
- **Ajustar `PublicationAPI`** para manter `payload` como `dict` nativo na resposta, em vez de string JSON (`json.dumps`).
- **Suportar filtragem por `issue_proc_id`** em `get_total_status_data`, `IssueProc.get_total_status` e `ArticleProc.get_total_status`, permitindo consultas de status mais granulares por fascículo.
- **Reestruturar o formato de retorno de `get_total_status`** (Journal/Issue/Article): cada item passa de dict plano `{"...": ..., "total": N}` para `{"total": N, "status": {...}}`, facilitando comparação de snapshots.

---

#### Onde a revisão poderia começar?

Sugiro esta ordem, da base para os módulos que dependem dela:

1. **`publication/api/publication.py`** — mudança pontual e isolada (payload como dict).
2. **`migration/models.py`** — nova `property JournalAcronIdFile.data` e ajuste de assinatura de `IdFileRecord.document_records_to_migrate` (`force_update` → `todo`). Entender esse ponto primeiro ajuda a entender o próximo item.
3. **`migration/controller.py`** — `import_journal_acron_id_records` e `get_bases_work_acron_id_file_records`, que consomem a `property` acima.
4. **`article/models.py`** — `exclude_invalid_records`/`_exclude_invalid_records` e o tratamento de falha ao deletar `PidProviderXML`/`SPSPkg`.
5. **`proc/models.py`** — foco em `get_publication_status`/`set_qa_ws_status`/`set_public_ws_status` (usados em cascata por todo o arquivo) e nos métodos `migrate_document_files`/`migrate_document_records`, que agora retornam dict em vez de int.
6. **`proc/controller.py`** — pequena mudança de assinatura de `get_total_status_data`.
7. **`proc/tasks.py`** — maior extensão de mudança: `TaskExecution.update_total_status`/`finish` e as tasks `task_migrate_and_publish_articles_by_journal/by_issue`, `task_publish_issue_articles`, `task_publish_articles`, `task_exclude_invalid_issue_articles`.

---

#### Como este poderia ser testado manualmente?

- **Importação de acron.id**:
  - Rodar `import_journal_acron_id_records` para um periódico com arquivo `.id` já processado (sem `force_update`) e confirmar que retorna `message` de "já atualizado" sem reprocessar.
  - Rodar novamente com `force_update=True` e verificar que `detail["stats"]` contém `total_id_file_records`, `total_id_file_records_to_migrate`, `total_issueproc_docs_status_to_process` e `total_articleproc_migration_status_to_process` corretos.
- **Publicação condicionada à coleção**:
  - Desabilitar `WebSiteConfiguration` de `QA` ou `PUBLIC` para uma coleção e confirmar que `set_qa_ws_status`/`set_public_ws_status` força `PROGRESS_STATUS_IGNORED`, e que `select_items_to_publish_on_qa_website`/`public_website` não retornam mais esses itens.
- **Migração de fascículo**:
  - Executar `IssueProc.migrate_document_records` e `migrate_document_files` diretamente e validar o novo formato de retorno (`dict` com `input`/`output`/`status`/`completed`/`exception`/`total` ou `completed`/`message`/`migrated`/`failures`/`status`/`exception`).
- **Task completa**:
  - Disparar `task_migrate_and_publish_articles_by_journal` para um periódico de teste e inspecionar o `TaskTracker` gerado: confirmar presença de `status_changes` com os rótulos ("Start", "Updated publication status", "Imported journal acron.id" etc.) e que `events` contém os dicts `{"operation": ..., "response": ...}`.
  - Verificar que `task_exclude_invalid_issue_articles`, ao ser chamada isoladamente (fora de uma task encadeada), retorna a `list`/`dict` esperada em vez de lançar exceção não tratada.
- **Falha ao deletar `PidProviderXML`/`SPSPkg`**:
  - Simular um `IntegrityError` (ex.: FK protegida) na exclusão e confirmar que `PidProviderXML` é marcado como `PPXML_STATUS_INVALID` via `update()` em vez de quebrar o fluxo, e que a exceção é registrada em `exceptions`.
- **`PublicationAPI`**:
  - Visualizar o payload no relatório em formato de json e não de string JSON

---

#### Algum cenário de contexto que queira dar?

Esse PR nasce da necessidade de:

- Corrigir um bug real em produção: o filtro/atualização de `ArticleProc`;
- Resultado mais centralizado no Event Tracker, ou seja, anteriormente eventos de artigos que eram relacionados Journal e Issue eram registrado nos seus eventos;
- Consolidar o histórico de status (`status_changes`) por task, o que deve ajudar bastante a depurar problemas de migração/publicação porque agora fica claro em qual etapa exata o status de um journal/issue/article mudou (antes era necessário reconstruir isso manualmente comparando eventos soltos).
- Resolver valor de status de publicação: sem checar `WebSiteConfiguration.enabled`, itens de coleções com QA ou PUBLIC desligados podiam ser marcados como `REPROC`/`TODO` e tentar publicar em um site desabilitado, gerando confusão.

---

### Screenshots

Exemplo de relatório 
```json
{
  "events": [
    {
      "operation": "ArticleProc.exclude_invalid_items",
      "response": {
        "deleted": [],
        "sps_pkg_id_list": []
      }
    },
    {
      "operation": "Article.exclude_invalid_records",
      "response": {
        "deleted_article_ids": [],
        "deleted_ppxml_ids": [],
        "deleted_sps_pkg_ids": [],
        "events": [],
        "exceptions": [],
        "ppxml_invalid": [],
        "repeated_pid_v2": [],
        "repeated_sps_pkg__sps_pkg_name": [],
        "sps_pkg_with_invalid_pid_v2": [],
        "total_deleted_items": 0
      }
    },
    {
      "operation": "migrate_document_records",
      "response": {
        "completed": true,
        "exception": null,
        "input": {
          "docs_status": "REPROC",
          "force_update": false,
          "total_articleproc_migration_status_to_process": 30,
          "total_articleprocs": 30,
          "total_id_file_records": 30,
          "total_id_file_records_to_migrate": 30
        },
        "output": {
          "exceptions": {},
          "total_done": 30,
          "total_failed": 0,
          "total_migrated": 30
        },
        "status": "DONE",
        "total": 30
      }
    },
    {
      "operation": "migrate_document_files",
      "response": {
        "completed": true,
        "exception": null,
        "failures": [],
        "message": "Files already migrated",
        "migrated": 356,
        "status": "DONE"
      }
    },
    {
      "operation": "Scheduled articles publication"
    }
  ],
  "exceptions": [],
  "params": {
    "article_proc_id_list": [],
    "force_migrate_document_files": false,
    "force_migrate_document_records": false,
    "force_update": false,
    "issue_proc_id": 16199,
    "status": [
      "REPROC",
      "TODO"
    ],
    "user_id": 1,
    "username": null
  },
  "stats": {
    "total_articleprocs": 30,
    "total_processed": 30,
    "total_to_process": 30
  },
  "status_changes": {
    "article": [
      {
        "label": "Start",
        "total_status": [
          {
            "status": {
              "migration_status": "REPROC",
              "public_ws_status": "IGNORED",
              "qa_ws_status": "DONE",
              "sps_pkg_status": "DONE",
              "xml_status": "DONE"
            },
            "total": 30
          }
        ]
      },
      {
        "label": "Created or updated Article Processing records",
        "total_status": [
          {
            "status": {
              "migration_status": "TODO",
              "public_ws_status": "IGNORED",
              "qa_ws_status": "TODO",
              "sps_pkg_status": "TODO",
              "xml_status": "TODO"
            },
            "total": 30
          }
        ]
      },
      {
        "label": "Created or updated SPS Package and Article records",
        "total_status": [
          {
            "status": {
              "migration_status": "DONE",
              "public_ws_status": "IGNORED",
              "qa_ws_status": "TODO",
              "sps_pkg_status": "DONE",
              "xml_status": "DONE"
            },
            "total": 30
          }
        ]
      }
    ],
    "issue": [
      {
        "label": "Start",
        "total_status": [
          {
            "status": {
              "docs_status": "REPROC",
              "files_status": "DONE"
            },
            "total": 1
          }
        ]
      },
      {
        "label": "Created or updated Article Processing records",
        "total_status": [
          {
            "status": {
              "docs_status": "DONE",
              "files_status": "DONE"
            },
            "total": 1
          }
        ]
      }
    ],
    "journal": [
      {
        "label": "Start",
        "total_status": [
          {
            "status": {
              "migration_status": "DONE",
              "public_ws_status": "DONE",
              "qa_ws_status": "DONE"
            },
            "total": 1
          }
        ]
      }
    ]
  }
}
```

#### Quais são tickets relevantes?
#1016

### Referências

- `tracker/choices.py` — valores de `PROGRESS_STATUS_*` usados em `get_publication_status` e nas comparações de status.
- `tracker/models.py` (`TaskTracker`, `UnexpectedEvent`, `sanitize_for_json`) — consumidos por `TaskExecution`.
- Documentação interna do fluxo de migração `scms-upload` (Classic → Upload → Core → OPAC).
