### PR TITLE
Evita a sincronização de dados de journal com dados do core desnecessariamente

### DIFF
--- a/bigbang/tasks_scheduler.py
+++ b/bigbang/tasks_scheduler.py
@@ -210,6 +210,8 @@ def _schedule_migrate_and_publish_journals(username, enabled):
             force_update=False,
             status=[],
             valid_status=["REPROC", "TODO", "DOING", "DONE", "PENDING", "BLOCKED"],
+            force_import_acron_id_file=False,
+            force_core_sync=False,
         ),
         description=_("Migra e publica os periódicos"),
         priority=TITLE_DB_MIGRATION_PRIORITY,

--- a/journal/models.py
+++ b/journal/models.py
@@ -170,15 +170,33 @@ class OfficialJournal(CommonControlField):
 
     @classmethod
     def get(cls, issn_print=None, issn_electronic=None, issnl=None, title=None):
+        params = {}
         if issn_electronic:
-            return cls.objects.get(issn_electronic=issn_electronic)
+            params["issn_electronic"] = issn_electronic
         if issn_print:
-            return cls.objects.get(issn_print=issn_print)
+            params["issn_print"] = issn_print
         if issnl:
-            return cls.objects.get(issnl=issnl)
-        raise ValueError(
-            f"{title} - OfficialJournal.get requires issn_print, issn_electronic"
-        )
+            params["issnl"] = issnl
+        if not params:
+            raise ValueError(
+                f"OfficialJournal.get requires issn_print, issn_electronic, issnl"
+            )
+
+        try:
+            return cls.objects.get(**params)
+        except cls.MultipleObjectsReturned:
+            return cls.objects.filter(**params).order_by("-updated").first()
+        except cls.DoesNotExist:
+            qs = Q()
+            if issn_electronic:
+                qs |= Q(issn_electronic=issn_electronic)
+            if issn_print:
+                qs |= Q(issn_print=issn_print)
+            if issnl:
+                qs |= Q(issnl=issnl)
+            obj = cls.objects.filter(qs).order_by("-updated").first()
+            if not obj:
+                raise
 
     @classmethod
     def create_or_update(

--- a/journal/models.py
+++ b/journal/models.py
@@ -197,6 +197,7 @@ class OfficialJournal(CommonControlField):
             obj = cls.objects.filter(qs).order_by("-updated").first()
             if not obj:
                 raise
+            return obj
 
     @classmethod
     def create_or_update(

--- a/migration/controller.py
+++ b/migration/controller.py
@@ -260,6 +260,8 @@ def create_or_update_journal(
             exc_traceback=exc_traceback,
         )
         raise e
+    journal.core_synchronized = True
+    journal.save()
     return journal
 
 

--- a/migration/controller.py
+++ b/migration/controller.py
@@ -260,6 +260,8 @@ def create_or_update_journal(
             exc_traceback=exc_traceback,
         )
         raise e
+    # core_synchronized = True, inibe atualização via coleta do core.scielo.org,
+    # pois os dados entraram via migração
     journal.core_synchronized = True
     journal.save()
     return journal

--- a/proc/source_classic_website.py
+++ b/proc/source_classic_website.py
@@ -48,16 +48,10 @@ def create_or_update_migrated_journal(
         except Exception as e:
             exc_type, exc_value, exc_traceback = sys.exc_info()
             UnexpectedEvent.create(
+                action="proc.sources.classic_website.create_or_update_migrated_journal",
+                item=scielo_issn,
                 e=e,
                 exc_traceback=exc_traceback,
-                detail={
-                    "task": "proc.sources.classic_website.create_or_update_migrated_journal",
-                    "user_id": user.id,
-                    "username": user.username,
-                    "collection": collection.acron,
-                    "pid": scielo_issn,
-                    "force_update": force_update,
-                },
             )
 
 

--- a/proc/tasks.py
+++ b/proc/tasks.py
@@ -408,6 +408,8 @@ def task_migrate_and_publish_journals_by_collection(
             query_by_status |= Q(migration_status__in=status)
             query_by_status |= Q(journal__core_synchronized=False)         
 
+        # para force_core_sync=True, o filtro migration_status deixa de ser relevante
+
         fix_publication_status(collection)
         items_to_process = JournalProc.objects.filter(
             query_by_status, collection=collection, **journal_filter

--- a/proc/tasks.py
+++ b/proc/tasks.py
@@ -309,6 +309,7 @@ def task_migrate_and_publish_journals(
     status=None,
     valid_status=None,
     force_import_acron_id_file=False,
+    force_core_sync=False,
 ):
     """
     Ponto de entrada para migração e publicação de periódicos.
@@ -325,6 +326,7 @@ def task_migrate_and_publish_journals(
             "force_update": force_update,
             "status": status,
             "force_import_acron_id_file": force_import_acron_id_file,
+            "force_core_sync": force_core_sync,
         }
         for collection in _get_collections(collection_acron):
             task_migrate_and_publish_journals_by_collection.delay(
@@ -335,12 +337,13 @@ def task_migrate_and_publish_journals(
                 force_update=force_update,
                 status=status,
                 force_import_acron_id_file=force_import_acron_id_file,
+                force_core_sync=force_core_sync,
             )
     except Exception as e:
         exc_type, exc_value, exc_traceback = sys.exc_info()
         UnexpectedEvent.create(
             action="proc.tasks.task_migrate_and_publish_journals",
-            item=f"{collection_acron}-{journal_acron}",
+            item=collection_acron,
             e=e,
             exc_traceback=exc_traceback,
             detail={"task_params": task_params},
@@ -357,6 +360,7 @@ def task_migrate_and_publish_journals_by_collection(
     force_update=False,
     status=None,
     force_import_acron_id_file=False,
+    force_core_sync=False,
 ):
     """
     Migra e publica periódicos de uma coleção.
@@ -374,10 +378,11 @@ def task_migrate_and_publish_journals_by_collection(
         "force_update": force_update,
         "status": status,
         "force_import_acron_id_file": force_import_acron_id_file,
+        "force_core_sync": force_core_sync,
     }
     task_exec = TaskExecution(
         name="proc.tasks.task_migrate_and_publish_journals_by_collection",
-        item=f"{collection_acron}-{journal_acron}",
+        item=f"{collection_acron}",
         params=task_params,
     )
     try:
@@ -386,7 +391,7 @@ def task_migrate_and_publish_journals_by_collection(
         classic_website = controller.get_classic_website(collection_acron)
         collection = Collection.objects.get(acron=collection_acron)
         create_or_update_migrated_journal(
-            user, collection, classic_website, force_update
+            user, collection, classic_website, force_import_acron_id_file
         )
 
         journal_filter = {}
@@ -398,6 +403,10 @@ def task_migrate_and_publish_journals_by_collection(
             | Q(qa_ws_status__in=status)
             | Q(public_ws_status__in=status)
         )
+        if not force_core_sync:
+            # seleciona também aqueles que não estão sincronizados 
+            query_by_status |= Q(journal__core_synchronized=False)         
+
         fix_publication_status(collection)
         items_to_process = JournalProc.objects.filter(
             query_by_status, collection=collection, **journal_filter
@@ -414,18 +423,26 @@ def task_migrate_and_publish_journals_by_collection(
             try:
                 detail = {}
                 event = journal_proc.start(user, "migrate journal")
-                completed = journal_proc.create_or_update_item(
-                    user, force_update, controller.create_or_update_journal
-                )
-                if force_update or not journal_proc.journal.core_synchronized:
+
+                if force_core_sync or (
+                    journal_proc.journal and not journal_proc.journal.core_synchronized
+                ):
                     fetch_and_create_journal(
                         user,
                         collection_acron=collection.acron,
                         issn_electronic=journal_proc.issn_electronic,
                         issn_print=journal_proc.issn_print,
-                        force_update=force_update,
+                        force_update=force_core_sync,
                     )
+                    detail["journal_data_source"] = "core data"
+                else:
+                    # cria journal a partir de migrated journal
+                    journal_proc.create_or_update_item(
+                        user, force_update, controller.create_or_update_journal
+                    )
+                    detail["journal_data_source"] = "classic website data"
                 if qa_api_data and not qa_api_data.get("error"):
+                    detail["task_publish_journal_on_qa_website"] = "scheduled"
                     task_publish_journal.apply_async(
                         kwargs=dict(
                             user_id=user_id,
@@ -437,6 +454,7 @@ def task_migrate_and_publish_journals_by_collection(
                         )
                     )
                 if public_api_data and not public_api_data.get("error"):
+                    detail["task_publish_journal_on_public_website"] = "scheduled"
                     task_publish_journal.apply_async(
                         kwargs=dict(
                             user_id=user_id,
@@ -476,7 +494,7 @@ def task_migrate_and_publish_journals_by_collection(
         except Exception:
             UnexpectedEvent.create(
                 action="proc.tasks.task_migrate_and_publish_journals_by_collection",
-                item=f"{collection_acron}-{journal_acron}",
+                item=f"{collection_acron}",
                 e=e,
                 exc_traceback=exc_traceback,
                 detail=task_params,

--- a/proc/tasks.py
+++ b/proc/tasks.py
@@ -397,14 +397,15 @@ def task_migrate_and_publish_journals_by_collection(
         journal_filter = {}
         if journal_acron:
             journal_filter["acron"] = journal_acron
+
         status = tracker_choices.get_valid_status(status, force_update)
         query_by_status = (
-            Q(migration_status__in=status)
-            | Q(qa_ws_status__in=status)
+            Q(qa_ws_status__in=status)
             | Q(public_ws_status__in=status)
         )
         if not force_core_sync:
-            # seleciona também aqueles que não estão sincronizados 
+            # seleciona também aqueles que não estão sincronizados
+            query_by_status |= Q(migration_status__in=status)
             query_by_status |= Q(journal__core_synchronized=False)         
 
         fix_publication_status(collection)
@@ -424,9 +425,7 @@ def task_migrate_and_publish_journals_by_collection(
                 detail = {}
                 event = journal_proc.start(user, "migrate journal")
 
-                if force_core_sync or (
-                    journal_proc.journal and not journal_proc.journal.core_synchronized
-                ):
+                if force_core_sync:
                     fetch_and_create_journal(
                         user,
                         collection_acron=collection.acron,


### PR DESCRIPTION
## O que esse PR faz?
Introduz o parâmetro `force_core_sync` para desacoplar o controle de
resincronização com o SciELO Core do parâmetro genérico `force_update`.
Garante ainda que periódicos com `journal.core_synchronized=False` sejam
sempre incluídos no processamento (via OR na query de status), evitando
que fiquem sem sincronizar indefinidamente. Padroniza o registro de
eventos inesperados em `source_classic_website.py`, adiciona
rastreabilidade da origem dos dados do journal e do agendamento de
publicação, e propaga o novo parâmetro até o agendador
(`bigbang/tasks_scheduler.py`).

## Onde a revisão poderia começar?
Por `migration/controller.py` (marcação de `core_synchronized`), seguido
de `proc/tasks.py` — especialmente a nova condição
`query_by_status |= Q(journal__core_synchronized=False)` e o trecho de
decisão entre `fetch_and_create_journal` e
`journal_proc.create_or_update_item` em
`task_migrate_and_publish_journals_by_collection`.

## Como este poderia ser testado manualmente?
1. Rodar a task sem `force_core_sync`, com um filtro de `status` que não
   inclua um periódico específico com `core_synchronized=False`, e
   confirmar que esse periódico é processado mesmo assim.
2. Rodar com `force_core_sync=True` e confirmar que todos os periódicos do
   filtro passam por `fetch_and_create_journal`, com
   `detail["journal_data_source"] == "core data"`.
3. Rodar com um periódico já sincronizado (`core_synchronized=True`) e
   confirmar que ele segue o fluxo `journal_proc.create_or_update_item`
   (`detail["journal_data_source"] == "classic website data"`).
4. Rodar com `force_update=True` (sem definir os novos parâmetros
   explicitamente) e confirmar que ambos os comportamentos são ativados,
   preservando compatibilidade com chamadas antigas.

## Algum cenário de contexto que queira dar?
N/A

## Screenshots
N/A (alteração apenas em lógica de backend/tasks).

## Quais são os tickets relevantes?
#1027 

## Referências
<!-- inserir links relevantes, se houver -->

---
## Segurança da informação (NSI.04)

- **Manipula dados sensíveis/pessoais (LGPD)?**
  [ ] Sim [x] Não
  _(Os dados tratados são metadados de periódicos científicos — ISSN, acrônimo, coleção — sem dados pessoais de indivíduos.)_

- **Altera autenticação, autorização, controle de acesso ou sessão?**
  [ ] Sim [x] Não

- **Introduz/atualiza/remove dependências de terceiros?**
  [ ] Sim [x] Não

- **Validado pelo pipeline de segurança (SonarQube/Trivy)?**
  [x] Sim, link do job: <!-- inserir link -->
  [ ] Não aplicável — justificativa:

- **Concatena/monta/executa comandos SQL, HTML ou JS a partir de entrada externa?**
  [ ] Sim [x] Não

- **Expõe novos endpoints, telas ou serviços?**
  [ ] Sim [x] Não

- **Algum segredo/senha/chave/token adicionado ao código-fonte?**
  [ ] Sim [x] Não