### PR TITLE
Remove ambiguidade no resultados de article data query

### DIFF
--- a/pid_provider/models.py
+++ b/pid_provider/models.py
@@ -36,7 +36,7 @@ from pid_provider.query_params import (
     compare,
     QueryBuilderPidProviderXML,
 )
-from tracker.models import UnexpectedEvent
+from tracker.models import BaseEvent, UnexpectedEvent
 
 PARTIAL_BODY_MAX = 300
 
@@ -615,6 +615,7 @@ class PidProviderXML(BasePidProviderXML, CommonControlField, ClusterableModel):
             "record_status": "updated" if self.updated else "created",
             "registered_in_core": self.registered_in_core,
         }
+        _data.update(self.get_readable_data())
         return _data
 
     @classmethod
@@ -649,9 +650,16 @@ class PidProviderXML(BasePidProviderXML, CommonControlField, ClusterableModel):
             return False
         return True
 
+    def get_readable_data(self):
+        if self.readable_data:
+            return self.readable_data
+        if self.xml_with_pre:
+            return self.xml_with_pre.get_article_data()
+        return {}
+
     @property
     def data_to_compare(self):
-        readable = self.readable_data or {}
+        readable = self.get_readable_data()
         titles = readable.get("article_titles")
         body_fragment = readable.get("body_fragment")
         return {
@@ -1034,13 +1042,15 @@ class PidProviderXML(BasePidProviderXML, CommonControlField, ClusterableModel):
             "journal-issue-article",
             list(
                 selected_journal.filter(
-                    Q(**qbuilder.issue_params) & qbuilder.article_data_query
+                    qbuilder.get_article_data_query(issue=True)
                 )
             ),
         )
 
         # 3) journal + dados do artigo
-        yield "journal-article", list(selected_journal.filter(qbuilder.article_data_query))
+        yield "journal-article", list(
+            selected_journal.filter(qbuilder.get_article_data_query(issue=False))
+        )
 
     @staticmethod
     def select_record(xml_adapter, selection_results):

--- a/pid_provider/models.py
+++ b/pid_provider/models.py
@@ -412,6 +412,12 @@ class PidProviderXML(BasePidProviderXML, CommonControlField, ClusterableModel):
     z_surnames = models.CharField(_("surnames"), max_length=64, null=True, blank=True)
     z_collab = models.CharField(_("collab"), max_length=64, null=True, blank=True)
     z_links = models.CharField(_("links"), max_length=64, null=True, blank=True)
+
+    # NOTA: a partir de então body_fragment_fingerprint (hash 300 chars), não mais 
+    # z_partial_body (hash do primeiro parágrafo que apresentou muita ambiguidade).
+    # Registros antigos mantêm o valor legado;
+    # a query de match (article_data_query) compara com ambos os
+    # candidatos para cobrir os dois formatos sem exigir backfill.
     z_partial_body = models.CharField(
         _("partial_body"), max_length=64, null=True, blank=True
     )
@@ -1194,7 +1200,7 @@ class PidProviderXML(BasePidProviderXML, CommonControlField, ClusterableModel):
         self.z_surnames = xml_adapter.z_surnames
         self.z_collab = xml_adapter.z_collab
         self.z_links = xml_adapter.z_links
-        self.z_partial_body = xml_adapter.z_partial_body
+        self.z_partial_body = xml_adapter.xml_with_pre.body_fragment_fingerprint
 
         self.readable_data = xml_adapter.xml_with_pre.get_article_data()
 

--- a/pid_provider/query_params.py
+++ b/pid_provider/query_params.py
@@ -89,6 +89,14 @@ class QueryBuilderPidProviderXML:
         """
         self.xml_adapter = xml_adapter
         # Centraliza o acesso aos dados brutos e normalizados (hashes de 64 chars)
+        # z_body_fragment: fingerprint sha256 do corpo INTEIRO do artigo
+        # (XMLWithPre.body_fragment_fingerprint), acessado direto do
+        # xml_with_pre — não requer nenhuma mudança no packtools nem no
+        # PidProviderXMLAdapter. É mais robusto que z_partial_body (que
+        # é só o primeiro parágrafo não vazio e pode colidir entre
+        # artigos diferentes, ex.: rótulos de seção genéricos como
+        # "ARTIGO DE REVISÃO").
+        self.z_body_fragment = xml_adapter.xml_with_pre.body_fragment_fingerprint
         self.adapter_data = xml_adapter.data
         self.compare_data = xml_adapter.get_data_to_compare()
         self.xml_with_pre_data = xml_adapter.xml_with_pre.get_article_data(300)
@@ -219,7 +227,39 @@ class QueryBuilderPidProviderXML:
         if order:
             data["v2__endswith"] = order
         return data
-    
+
+    @property
+    def partial_body_query(self):
+        """
+        Constrói a query para o campo z_partial_body, que hoje armazena
+        dois formatos possíveis de hash, dependendo de quando o registro
+        foi salvo:
+
+        - legado: hash de z_partial_body (primeiro parágrafo não vazio
+          do corpo, via xml_adapter.z_partial_body);
+        - atual: fingerprint do corpo INTEIRO do artigo
+          (xml_with_pre.body_fragment_fingerprint), gravado no mesmo
+          campo z_partial_body a partir desta correção (sem necessidade
+          de migração/backfill).
+
+        Usa IN com os hashes disponíveis do XML de entrada para casar
+        com candidatos em qualquer um dos dois formatos.
+
+        Quando o XML de entrada não tem NENHUM dos dois hashes
+        calculados (ambos None), não é seguro usar
+        `z_partial_body__in=(None, None)`: em SQL, `IN` é uma cadeia de
+        igualdades e `NULL = NULL` é UNKNOWN (nunca True), então essa
+        forma jamais encontraria candidatos com z_partial_body nulo.
+        Nesse caso, usamos `z_partial_body__isnull=True` explicitamente,
+        preservando o comportamento equivalente ao antigo
+        `Q(z_partial_body=None)` (que o Django traduz para IS NULL).
+        """
+        z_partial_body = self.adapter_data.get("z_partial_body")
+        candidates = set(v for v in (z_partial_body, self.z_body_fragment) if v)
+        if candidates:
+            return Q(z_partial_body__in=candidates)
+        return Q(z_partial_body__isnull=True)
+
     @property
     def article_data_query(self):
         """
@@ -228,15 +268,12 @@ class QueryBuilderPidProviderXML:
         z_surnames = self.adapter_data.get("z_surnames")
         z_collab = self.adapter_data.get("z_collab")
         z_links = self.adapter_data.get("z_links")
-        z_partial_body = self.adapter_data.get("z_partial_body")
 
-        # Caso contrário, retorna os campos (geralmente None neste ponto) com AND
         return Q(
             z_surnames=z_surnames,
             z_collab=z_collab,
             z_links=z_links,
-            z_partial_body=z_partial_body,
-        )
+        ) & self.partial_body_query
 
     def get_article_data_query(self, issue):
         if issue:

--- a/pid_provider/query_params.py
+++ b/pid_provider/query_params.py
@@ -45,7 +45,7 @@ def compare_items(label, registered, input_data):
     elif (input_data or None) == (registered or None):
         score = 1
     else:
-        score = how_similar(input_data, registered)
+        score = how_similar(input_data or "", registered or "")
     response = {"label": label, "score": score}
     if score != 1:
         response["registered"] = registered
@@ -230,23 +230,29 @@ class QueryBuilderPidProviderXML:
         z_links = self.adapter_data.get("z_links")
         z_partial_body = self.adapter_data.get("z_partial_body")
 
-        # Se houver qualquer dado textual disponível, constrói query com OR (|)
-        if z_surnames or z_partial_body or z_collab or z_links:
-            q = Q()
-            if z_surnames:
-                q |= Q(z_surnames=z_surnames)
-            if z_collab:
-                q |= Q(z_collab=z_collab)
-            if z_links:
-                q |= Q(z_links=z_links)
-            if z_partial_body:
-                q |= Q(z_partial_body=z_partial_body)
-            return q
-        
         # Caso contrário, retorna os campos (geralmente None neste ponto) com AND
         return Q(
             z_surnames=z_surnames,
             z_collab=z_collab,
             z_links=z_links,
             z_partial_body=z_partial_body,
-        ) & Q(**self.article_location_params)
+        )
+
+    def get_article_data_query(self, issue):
+        if issue:
+            return (
+                self.article_data_query & 
+                Q(**self.issue_params) & 
+                Q(**self.article_location_params)
+            )
+        return (
+            self.article_data_query & 
+            Q(
+                volume__isnull=True,
+                number__isnull=True,
+                suppl__isnull=True,
+                elocation_id__isnull=True,
+                fpage__isnull=True,
+                lpage__isnull=True,
+            )
+        )

--- a/pid_provider/tests/test_query_params.py
+++ b/pid_provider/tests/test_query_params.py
@@ -2,6 +2,18 @@
 Testes para QueryBuilderPidProviderXML e as funções de comparação
 (compare, compare_lists, compare_items, get_score, zero_to_none).
 
+Atualizado para cobrir a correção do falso-match na branch journal-article:
+- QueryBuilderPidProviderXML agora também lê
+  `xml_adapter.xml_with_pre.body_fragment_fingerprint` (fingerprint do
+  corpo INTEIRO do artigo) diretamente do xml_with_pre — sem depender de
+  mudança no PidProviderXMLAdapter/packtools.
+- `article_data_query` não usa mais z_partial_body isolado: delega ao
+  novo `partial_body_query`, que monta `z_partial_body__in=[...]` com os
+  hashes disponíveis (legado + novo fingerprint) ou, quando nenhum dos
+  dois existe no XML de entrada, `z_partial_body__isnull=True` — nunca
+  `z_partial_body__in=(None, None)`, que em SQL jamais casaria com
+  candidatos NULL (NULL = NULL é UNKNOWN, não True).
+
 ATENÇÃO: ajuste o caminho de import abaixo (`pid_provider.query_params`)
 para o módulo real onde essas classes/funções estão definidas no projeto,
 caso seja diferente.
@@ -36,8 +48,16 @@ def make_xml_adapter(
     collab=None,
     links=None,
     partial_body=None,
+    body_fragment_fingerprint=None,
 ):
-    """Monta um mock de xml_adapter com a forma esperada por QueryBuilderPidProviderXML."""
+    """
+    Monta um mock de xml_adapter com a forma esperada por
+    QueryBuilderPidProviderXML.
+
+    body_fragment_fingerprint: valor de
+    xml_adapter.xml_with_pre.body_fragment_fingerprint, o novo sinal
+    (hash do corpo inteiro do artigo) usado em partial_body_query.
+    """
     adapter = MagicMock()
     adapter.data = data or {}
     adapter.get_data_to_compare.return_value = {}
@@ -48,6 +68,7 @@ def make_xml_adapter(
     adapter.sps_pkg_name = sps_pkg_name
     adapter.order = order
     adapter.xml_with_pre.deprecated_sps_pkg_name_list = deprecated_sps_pkg_name_list or []
+    adapter.xml_with_pre.body_fragment_fingerprint = body_fragment_fingerprint
     adapter.xml_with_pre.get_article_data.return_value = {
         "article_titles": article_titles or [],
         "surnames": surnames,
@@ -244,77 +265,128 @@ class ArticleLocationParamsTests(SimpleTestCase):
         self.assertEqual(params["v2__endswith"], "00003")
 
 
-class ArticleDataQueryTests(SimpleTestCase):
+class PartialBodyQueryTests(SimpleTestCase):
     """
-    Atualizado: `article_data_query` não tem mais o branch OR nem faz o
-    merge com `article_location_params` internamente. Agora ela sempre
-    retorna a query AND com os valores reais (truthy ou não) dos 4 campos
-    textuais. A junção com localização/fascículo passou para
-    `get_article_data_query`.
+    Cobre especificamente o fix do incidente: z_partial_body agora aceita
+    dois formatos de hash (legado e fingerprint do corpo inteiro), e o
+    caso "nenhum dos dois presente" precisa cair em isnull=True, nunca em
+    __in=(None, None).
     """
 
-    def test_returns_and_query_with_available_textual_fields(self):
+    def test_uses_in_with_only_legacy_partial_body(self):
         adapter = make_xml_adapter(
-            data={"z_surnames": "Silva", "z_partial_body": "corpo"}
+            data={"z_partial_body": "hash-legado"},
+            body_fragment_fingerprint=None,
         )
         qbuilder = QueryBuilderPidProviderXML(adapter)
-        expected = Q(
-            z_surnames="Silva", z_collab=None, z_links=None, z_partial_body="corpo"
+        self.assertEqual(
+            qbuilder.partial_body_query, Q(z_partial_body__in=["hash-legado"])
         )
-        self.assertEqual(qbuilder.article_data_query, expected)
 
-    def test_does_not_use_or_even_when_multiple_fields_present(self):
-        """Antes do diff, múltiplos campos truthy geravam OR; agora é sempre AND."""
+    def test_uses_in_with_only_body_fragment_fingerprint(self):
+        adapter = make_xml_adapter(
+            data={},
+            body_fragment_fingerprint="hash-corpo-inteiro",
+        )
+        qbuilder = QueryBuilderPidProviderXML(adapter)
+        self.assertEqual(
+            qbuilder.partial_body_query,
+            Q(z_partial_body__in=["hash-corpo-inteiro"]),
+        )
+
+    def test_uses_in_with_both_hashes_when_both_present_and_different(self):
+        adapter = make_xml_adapter(
+            data={"z_partial_body": "hash-legado"},
+            body_fragment_fingerprint="hash-corpo-inteiro",
+        )
+        qbuilder = QueryBuilderPidProviderXML(adapter)
+        self.assertEqual(
+            qbuilder.partial_body_query,
+            Q(z_partial_body__in=["hash-legado", "hash-corpo-inteiro"]),
+        )
+
+    def test_deduplicates_when_both_hashes_are_equal(self):
+        adapter = make_xml_adapter(
+            data={"z_partial_body": "hash-igual"},
+            body_fragment_fingerprint="hash-igual",
+        )
+        qbuilder = QueryBuilderPidProviderXML(adapter)
+        self.assertEqual(
+            qbuilder.partial_body_query, Q(z_partial_body__in=["hash-igual"])
+        )
+
+    def test_uses_isnull_when_neither_hash_is_present(self):
+        """
+        Regressão do incidente: quando o XML de entrada não tem nenhum
+        hash de corpo, a query deve usar isnull=True (equivalente ao
+        antigo Q(z_partial_body=None)), e JAMAIS __in=(None, None), que
+        em SQL nunca casaria com candidatos cujo z_partial_body é NULL
+        (NULL = NULL é UNKNOWN, não True).
+        """
+        adapter = make_xml_adapter(data={}, body_fragment_fingerprint=None)
+        qbuilder = QueryBuilderPidProviderXML(adapter)
+        self.assertEqual(qbuilder.partial_body_query, Q(z_partial_body__isnull=True))
+        self.assertNotEqual(
+            qbuilder.partial_body_query, Q(z_partial_body__in=(None, None))
+        )
+
+
+class ArticleDataQueryTests(SimpleTestCase):
+    """
+    article_data_query agora delega o campo z_partial_body inteiramente a
+    partial_body_query (ver PartialBodyQueryTests) e mantém AND puro para
+    z_surnames/z_collab/z_links.
+    """
+
+    def test_combines_textual_fields_with_partial_body_query_both_hashes(self):
         adapter = make_xml_adapter(
             data={
                 "z_surnames": "Silva",
-                "z_collab": "Grupo X",
-                "z_links": "link1",
-                "z_partial_body": "corpo",
-            }
+                "z_collab": None,
+                "z_links": None,
+                "z_partial_body": "hash-legado",
+            },
+            body_fragment_fingerprint="hash-corpo-inteiro",
         )
         qbuilder = QueryBuilderPidProviderXML(adapter)
-        expected = Q(
-            z_surnames="Silva",
-            z_collab="Grupo X",
-            z_links="link1",
-            z_partial_body="corpo",
+        expected = Q(z_surnames="Silva", z_collab=None, z_links=None) & Q(
+            z_partial_body__in=["hash-legado", "hash-corpo-inteiro"]
         )
         self.assertEqual(qbuilder.article_data_query, expected)
-        # Garante que não é a versão OR (equivalente mas com | em vez de AND
-        # implícito do Q com múltiplos kwargs)
-        or_version = (
-            Q(z_surnames="Silva")
-            | Q(z_collab="Grupo X")
-            | Q(z_links="link1")
-            | Q(z_partial_body="corpo")
-        )
-        self.assertNotEqual(qbuilder.article_data_query, or_version)
 
-    def test_returns_and_query_when_no_textual_data(self):
-        adapter = make_xml_adapter(data={})
+    def test_falls_back_to_isnull_when_no_body_hash_available(self):
+        adapter = make_xml_adapter(data={}, body_fragment_fingerprint=None)
         qbuilder = QueryBuilderPidProviderXML(adapter)
-        expected = Q(z_surnames=None, z_collab=None, z_links=None, z_partial_body=None)
+        expected = Q(z_surnames=None, z_collab=None, z_links=None) & Q(
+            z_partial_body__isnull=True
+        )
         self.assertEqual(qbuilder.article_data_query, expected)
 
-    def test_no_longer_merges_with_article_location_params(self):
+    def test_two_different_articles_produce_different_queries(self):
         """
-        Regressão: antes do diff, quando não havia dado textual,
-        `article_data_query` retornava `Q(...) & Q(**article_location_params)`.
-        Agora essa junção não ocorre mais aqui.
+        Regressão conceitual do incidente: dois artigos com hashes de
+        corpo diferentes (mesmo que ambos tenham, no passado, colidido
+        via z_partial_body legado genérico) agora produzem queries IN
+        distintas, pois o fingerprint do corpo inteiro entra na
+        composição.
         """
-        adapter = make_xml_adapter(
-            data={"elocation_id": "e123", "fpage": "10", "lpage": "20"}
+        adapter_a = make_xml_adapter(
+            data={"z_partial_body": "rotulo-generico-artigo-revisao"},
+            body_fragment_fingerprint="hash-corpo-artigo-a",
         )
-        qbuilder = QueryBuilderPidProviderXML(adapter)
-        old_style_expected = Q(
-            z_surnames=None, z_collab=None, z_links=None, z_partial_body=None
-        ) & Q(**qbuilder.article_location_params)
-        self.assertNotEqual(qbuilder.article_data_query, old_style_expected)
+        adapter_b = make_xml_adapter(
+            data={"z_partial_body": "rotulo-generico-artigo-revisao"},
+            body_fragment_fingerprint="hash-corpo-artigo-b",
+        )
+        qbuilder_a = QueryBuilderPidProviderXML(adapter_a)
+        qbuilder_b = QueryBuilderPidProviderXML(adapter_b)
+        self.assertNotEqual(
+            qbuilder_a.article_data_query, qbuilder_b.article_data_query
+        )
 
 
 class GetArticleDataQueryTests(SimpleTestCase):
-    """Novo método introduzido pelo diff, usado em select_records (models.py)."""
+    """Método usado em select_records (models.py)."""
 
     def test_issue_true_combines_article_data_issue_and_location_params(self):
         adapter = make_xml_adapter(
@@ -327,7 +399,8 @@ class GetArticleDataQueryTests(SimpleTestCase):
                 "elocation_id": "e1",
                 "fpage": "10",
                 "lpage": "20",
-            }
+            },
+            body_fragment_fingerprint=None,
         )
         qbuilder = QueryBuilderPidProviderXML(adapter)
         result = qbuilder.get_article_data_query(issue=True)
@@ -339,7 +412,9 @@ class GetArticleDataQueryTests(SimpleTestCase):
         self.assertEqual(result, expected)
 
     def test_issue_false_requires_issue_and_location_fields_null(self):
-        adapter = make_xml_adapter(data={"z_surnames": "Silva"})
+        adapter = make_xml_adapter(
+            data={"z_surnames": "Silva"}, body_fragment_fingerprint=None
+        )
         qbuilder = QueryBuilderPidProviderXML(adapter)
         result = qbuilder.get_article_data_query(issue=False)
         expected = qbuilder.article_data_query & Q(
@@ -353,7 +428,10 @@ class GetArticleDataQueryTests(SimpleTestCase):
         self.assertEqual(result, expected)
 
     def test_issue_true_and_false_produce_different_queries(self):
-        adapter = make_xml_adapter(data={"z_surnames": "Silva", "pub_year": "2026"})
+        adapter = make_xml_adapter(
+            data={"z_surnames": "Silva", "pub_year": "2026"},
+            body_fragment_fingerprint=None,
+        )
         qbuilder = QueryBuilderPidProviderXML(adapter)
         self.assertNotEqual(
             qbuilder.get_article_data_query(issue=True),
@@ -437,11 +515,6 @@ class CompareItemsTests(SimpleTestCase):
     def test_none_input_data_falls_back_to_empty_string_for_how_similar(
         self, mock_how_similar
     ):
-        """
-        Regressão do diff: antes, `how_similar(input_data, registered)` com
-        input_data=None estourava TypeError dentro de how_similar. Agora
-        `input_data or ""` evita isso.
-        """
         mock_how_similar.return_value = 0.2
         result = compare_items("z_links", "algum-link", None)
         self.assertEqual(

--- a/pid_provider/tests/test_query_params.py
+++ b/pid_provider/tests/test_query_params.py
@@ -245,22 +245,120 @@ class ArticleLocationParamsTests(SimpleTestCase):
 
 
 class ArticleDataQueryTests(SimpleTestCase):
+    """
+    Atualizado: `article_data_query` não tem mais o branch OR nem faz o
+    merge com `article_location_params` internamente. Agora ela sempre
+    retorna a query AND com os valores reais (truthy ou não) dos 4 campos
+    textuais. A junção com localização/fascículo passou para
+    `get_article_data_query`.
+    """
 
-    def test_builds_or_query_with_available_textual_fields(self):
+    def test_returns_and_query_with_available_textual_fields(self):
         adapter = make_xml_adapter(
             data={"z_surnames": "Silva", "z_partial_body": "corpo"}
         )
         qbuilder = QueryBuilderPidProviderXML(adapter)
-        expected = Q(z_surnames="Silva") | Q(z_partial_body="corpo")
+        expected = Q(
+            z_surnames="Silva", z_collab=None, z_links=None, z_partial_body="corpo"
+        )
         self.assertEqual(qbuilder.article_data_query, expected)
 
-    def test_falls_back_to_and_query_when_no_textual_data(self):
-        adapter = make_xml_adapter(data={})
+    def test_does_not_use_or_even_when_multiple_fields_present(self):
+        """Antes do diff, múltiplos campos truthy geravam OR; agora é sempre AND."""
+        adapter = make_xml_adapter(
+            data={
+                "z_surnames": "Silva",
+                "z_collab": "Grupo X",
+                "z_links": "link1",
+                "z_partial_body": "corpo",
+            }
+        )
         qbuilder = QueryBuilderPidProviderXML(adapter)
         expected = Q(
+            z_surnames="Silva",
+            z_collab="Grupo X",
+            z_links="link1",
+            z_partial_body="corpo",
+        )
+        self.assertEqual(qbuilder.article_data_query, expected)
+        # Garante que não é a versão OR (equivalente mas com | em vez de AND
+        # implícito do Q com múltiplos kwargs)
+        or_version = (
+            Q(z_surnames="Silva")
+            | Q(z_collab="Grupo X")
+            | Q(z_links="link1")
+            | Q(z_partial_body="corpo")
+        )
+        self.assertNotEqual(qbuilder.article_data_query, or_version)
+
+    def test_returns_and_query_when_no_textual_data(self):
+        adapter = make_xml_adapter(data={})
+        qbuilder = QueryBuilderPidProviderXML(adapter)
+        expected = Q(z_surnames=None, z_collab=None, z_links=None, z_partial_body=None)
+        self.assertEqual(qbuilder.article_data_query, expected)
+
+    def test_no_longer_merges_with_article_location_params(self):
+        """
+        Regressão: antes do diff, quando não havia dado textual,
+        `article_data_query` retornava `Q(...) & Q(**article_location_params)`.
+        Agora essa junção não ocorre mais aqui.
+        """
+        adapter = make_xml_adapter(
+            data={"elocation_id": "e123", "fpage": "10", "lpage": "20"}
+        )
+        qbuilder = QueryBuilderPidProviderXML(adapter)
+        old_style_expected = Q(
             z_surnames=None, z_collab=None, z_links=None, z_partial_body=None
         ) & Q(**qbuilder.article_location_params)
-        self.assertEqual(qbuilder.article_data_query, expected)
+        self.assertNotEqual(qbuilder.article_data_query, old_style_expected)
+
+
+class GetArticleDataQueryTests(SimpleTestCase):
+    """Novo método introduzido pelo diff, usado em select_records (models.py)."""
+
+    def test_issue_true_combines_article_data_issue_and_location_params(self):
+        adapter = make_xml_adapter(
+            data={
+                "z_surnames": "Silva",
+                "pub_year": "2026",
+                "volume": "10",
+                "number": "2",
+                "suppl": None,
+                "elocation_id": "e1",
+                "fpage": "10",
+                "lpage": "20",
+            }
+        )
+        qbuilder = QueryBuilderPidProviderXML(adapter)
+        result = qbuilder.get_article_data_query(issue=True)
+        expected = (
+            qbuilder.article_data_query
+            & Q(**qbuilder.issue_params)
+            & Q(**qbuilder.article_location_params)
+        )
+        self.assertEqual(result, expected)
+
+    def test_issue_false_requires_issue_and_location_fields_null(self):
+        adapter = make_xml_adapter(data={"z_surnames": "Silva"})
+        qbuilder = QueryBuilderPidProviderXML(adapter)
+        result = qbuilder.get_article_data_query(issue=False)
+        expected = qbuilder.article_data_query & Q(
+            volume__isnull=True,
+            number__isnull=True,
+            suppl__isnull=True,
+            elocation_id__isnull=True,
+            fpage__isnull=True,
+            lpage__isnull=True,
+        )
+        self.assertEqual(result, expected)
+
+    def test_issue_true_and_false_produce_different_queries(self):
+        adapter = make_xml_adapter(data={"z_surnames": "Silva", "pub_year": "2026"})
+        qbuilder = QueryBuilderPidProviderXML(adapter)
+        self.assertNotEqual(
+            qbuilder.get_article_data_query(issue=True),
+            qbuilder.get_article_data_query(issue=False),
+        )
 
 
 class ZeroToNoneTests(SimpleTestCase):
@@ -334,6 +432,31 @@ class CompareItemsTests(SimpleTestCase):
             result, {"label": "z_surnames", "score": 0.4, "registered": "Silva"}
         )
         mock_how_similar.assert_called_once_with("Souza", "Silva")
+
+    @patch("pid_provider.query_params.how_similar")
+    def test_none_input_data_falls_back_to_empty_string_for_how_similar(
+        self, mock_how_similar
+    ):
+        """
+        Regressão do diff: antes, `how_similar(input_data, registered)` com
+        input_data=None estourava TypeError dentro de how_similar. Agora
+        `input_data or ""` evita isso.
+        """
+        mock_how_similar.return_value = 0.2
+        result = compare_items("z_links", "algum-link", None)
+        self.assertEqual(
+            result, {"label": "z_links", "score": 0.2, "registered": "algum-link"}
+        )
+        mock_how_similar.assert_called_once_with("", "algum-link")
+
+    @patch("pid_provider.query_params.how_similar")
+    def test_none_registered_falls_back_to_empty_string_for_how_similar(
+        self, mock_how_similar
+    ):
+        mock_how_similar.return_value = 0.3
+        result = compare_items("z_links", None, "algum-link")
+        self.assertEqual(result, {"label": "z_links", "score": 0.3, "registered": None})
+        mock_how_similar.assert_called_once_with("algum-link", "")
 
 
 class CompareTests(SimpleTestCase):

--- a/pid_provider/tests/test_select_records.py
+++ b/pid_provider/tests/test_select_records.py
@@ -10,6 +10,17 @@ from pid_provider.models import PidProviderXML
 User = get_user_model()
 
 
+def build_get_article_data_query_side_effect(issue_true_query, issue_false_query):
+    """
+    Constrói o side_effect para `qbuilder.get_article_data_query(issue)`,
+    já que agora é ele quem decide a query final (antes, select_records
+    montava `Q(**issue_params) & article_data_query` diretamente).
+    """
+    def _side_effect(issue):
+        return issue_true_query if issue else issue_false_query
+    return _side_effect
+
+
 class PidProviderXMLSelectRecordsTests(TestCase):
     """
     select_records agora é um generator: apenas yield-a tuplas
@@ -20,6 +31,14 @@ class PidProviderXMLSelectRecordsTests(TestCase):
     não expõe métodos como .count() ou .filter().
     Ele NÃO chama mais best_matches nem levanta DoesNotExist —
     essa orquestração ficou fora deste método.
+
+    IMPORTANTE (pós-diff): as branches 2 e 3 não usam mais
+    `qbuilder.issue_params` e `qbuilder.article_data_query` diretamente —
+    passaram a usar `qbuilder.get_article_data_query(issue=True)` (branch
+    "journal-issue-article") e `qbuilder.get_article_data_query(issue=False)`
+    (branch "journal-article"). Por isso o mock precisa configurar
+    `get_article_data_query` (não mais `issue_params`/`article_data_query`
+    isolados).
     """
 
     def setUp(self):
@@ -39,8 +58,16 @@ class PidProviderXMLSelectRecordsTests(TestCase):
         mock_qbuilder = mock_qbuilder_cls.return_value
         mock_qbuilder.identifier_queries = Q(v3="12345")
         mock_qbuilder.issn_query = Q(issn_print="1234-5678")
-        mock_qbuilder.issue_params = {"pub_year": 2026}
-        mock_qbuilder.article_data_query = Q(z_surnames="Silva")
+
+        # issue=True -> exige pub_year=2026 (equivalente ao antigo issue_params)
+        # issue=False -> ignora pub_year, só olha z_surnames (equivalente ao
+        # antigo article_data_query "puro")
+        mock_qbuilder.get_article_data_query.side_effect = (
+            build_get_article_data_query_side_effect(
+                issue_true_query=Q(pub_year=2026) & Q(z_surnames="Silva"),
+                issue_false_query=Q(z_surnames="Silva"),
+            )
+        )
 
         record_by_id = PidProviderXML.objects.create(
             creator=self.user, v3="12345", registered_in_core=True
@@ -71,6 +98,11 @@ class PidProviderXMLSelectRecordsTests(TestCase):
         for _label, candidates in results:
             self.assertIsInstance(candidates, list)
 
+        # get_article_data_query deve ter sido chamado com issue=True e
+        # depois issue=False, nesta ordem
+        calls = [c.args[0] if c.args else c.kwargs.get("issue") for c in mock_qbuilder.get_article_data_query.call_args_list]
+        self.assertEqual(calls, [True, False])
+
         # 1) ids: só o registro com v3 correspondente
         ids_list = results[0][1]
         self.assertIn(record_by_id, ids_list)
@@ -93,8 +125,12 @@ class PidProviderXMLSelectRecordsTests(TestCase):
         mock_qbuilder = mock_qbuilder_cls.return_value
         mock_qbuilder.identifier_queries = Q(v3="nao_existe")
         mock_qbuilder.issn_query = Q(issn_print="0000-0000")
-        mock_qbuilder.issue_params = {"pub_year": 1900}
-        mock_qbuilder.article_data_query = Q(z_surnames="Ninguem")
+        mock_qbuilder.get_article_data_query.side_effect = (
+            build_get_article_data_query_side_effect(
+                issue_true_query=Q(pub_year=1900) & Q(z_surnames="Ninguem"),
+                issue_false_query=Q(z_surnames="Ninguem"),
+            )
+        )
 
         results = list(PidProviderXML.select_records(self.xml_adapter_mock))
 
@@ -110,12 +146,18 @@ class PidProviderXMLSelectRecordsTests(TestCase):
         Por ser generator, nada é executado na chamada da função:
         QueryBuilderPidProviderXML(...) e validate_input_data() só
         rodam quando o generator é de fato consumido (primeiro next()).
+        get_article_data_query só é chamado a partir do 2º/3º next(),
+        já que a 1ª branch ("ids") não depende dele.
         """
         mock_qbuilder = mock_qbuilder_cls.return_value
         mock_qbuilder.identifier_queries = Q(v3="qualquer")
         mock_qbuilder.issn_query = Q(issn_print="0000-0000")
-        mock_qbuilder.issue_params = {}
-        mock_qbuilder.article_data_query = Q()
+        mock_qbuilder.get_article_data_query.side_effect = (
+            build_get_article_data_query_side_effect(
+                issue_true_query=Q(),
+                issue_false_query=Q(),
+            )
+        )
 
         gen = PidProviderXML.select_records(self.xml_adapter_mock)
 
@@ -123,7 +165,16 @@ class PidProviderXMLSelectRecordsTests(TestCase):
         mock_qbuilder_cls.assert_not_called()
         mock_qbuilder.validate_input_data.assert_not_called()
 
-        next(gen)
+        next(gen)  # yield "ids"
 
         mock_qbuilder_cls.assert_called_once_with(self.xml_adapter_mock)
         mock_qbuilder.validate_input_data.assert_called_once()
+        # "ids" não usa get_article_data_query
+        mock_qbuilder.get_article_data_query.assert_not_called()
+
+        next(gen)  # yield "journal-issue-article"
+        mock_qbuilder.get_article_data_query.assert_called_once_with(issue=True)
+
+        next(gen)  # yield "journal-article"
+        self.assertEqual(mock_qbuilder.get_article_data_query.call_count, 2)
+        mock_qbuilder.get_article_data_query.assert_called_with(issue=False)


### PR DESCRIPTION
## O que esse PR faz?
Corrige o falso-positivo de correspondência (`unmatched` indevido, causando `QueryDocumentMultipleObjectsReturnedError`) na busca de documentos já registrados em `PidProviderXML`, junto com dois ajustes correlatos que saíram na mesma revisão do fluxo de matching (`select_records`/`data_to_compare`/`compare_items`).

**Correção principal — falso match por `z_partial_body` genérico:**
- `QueryBuilderPidProviderXML` passa a ler `xml_adapter.xml_with_pre.body_fragment_fingerprint` (fingerprint sha256 do corpo **inteiro** do artigo, já existente em `XMLWithPre`) diretamente do `xml_with_pre`, sem nenhuma alteração no packtools ou no `PidProviderXMLAdapter`.
- Novo método `partial_body_query`, que monta `z_partial_body__in={...}` combinando os dois formatos possíveis do campo — hash legado (primeiro parágrafo, `z_partial_body`) e o novo fingerprint (corpo inteiro) — reaproveitando a coluna `z_partial_body` já existente, sem migração.
- Quando o XML de entrada não tem nenhum dos dois hashes, `partial_body_query` usa `z_partial_body__isnull=True` — nunca `__in=(None, None)`, que em SQL nunca casaria com candidatos `NULL` (`NULL = NULL` é `UNKNOWN`, não `TRUE`).
- `article_data_query` simplificada: perde o branch OR condicional antigo e passa a ser AND puro em `z_surnames`/`z_collab`/`z_links`, delegando o campo de corpo inteiramente a `partial_body_query`.
- `_add_data` (`models.py`) passa a gravar `xml_adapter.xml_with_pre.body_fragment_fingerprint` em `z_partial_body` (antes gravava `xml_adapter.z_partial_body`, baseado só no primeiro parágrafo). Campo documentado com comentário explicando a dualidade de formato entre registros antigos e novos.
- Novo método `get_article_data_query(issue)`, usado em `select_records`: compõe explicitamente a busca "com fascículo" (`issue=True`: dados textuais + `issue_params` + `article_location_params`) e "sem fascículo" (`issue=False`: dados textuais + exigência de `volume`/`number`/`suppl`/`elocation_id`/`fpage`/`lpage` nulos) — antes, a branch `journal-article` não impunha nenhuma restrição de fascículo/localização, permitindo candidatos de fascículos completamente diferentes entrarem na comparação.

**Ajustes correlatos:**
- `PidProviderXML.get_readable_data()`: recalcula os dados legíveis via `xml_with_pre.get_article_data()` quando `readable_data` está vazio/nulo (registros antigos), usado tanto em `data_to_compare` quanto em `data`. Antes, `data_to_compare` usava `self.readable_data or {}` direto, ficando sem `article_titles`/`body_fragment` para registros sem `readable_data` preenchido.
- `compare_items`: `how_similar(input_data or "", registered or "")` evita `TypeError` quando um dos lados é `None`.
- Import corrigido em `models.py`: `from tracker.models import BaseEvent, UnexpectedEvent` (`BaseEvent` estava faltando).

## Onde a revisão poderia começar?
- `pid_provider/query_params.py::QueryBuilderPidProviderXML.partial_body_query` (peça central do fix) e `article_data_query`.
- `pid_provider/models.py::PidProviderXML._add_data` (novo valor gravado em `z_partial_body`) e `select_records` (uso de `get_article_data_query`).
- `pid_provider/models.py::PidProviderXML.get_readable_data`/`data_to_compare`/`data`.

## Como este poderia ser testado manualmente?
1. Reproduzir o incidente original: registrar um XML de artigo já existente no banco (com `z_partial_body` = hash de um rótulo genérico como "ARTIGO DE REVISÃO"); em seguida registrar um XML **novo**, mesma revista, mesmo rótulo genérico de seção, mas conteúdo de corpo e fascículo diferentes. Antes desta correção: `QueryDocumentMultipleObjectsReturnedError`. Depois: `event_status: created`, pois o fingerprint do corpo inteiro diverge (entra no `IN` junto com o hash legado) e a branch sem fascículo passa a exigir ausência de dados de fascículo/localização.
2. Rodar a suíte de testes:

```console
python manage.py test  pid_provider.tests --keepdb
```

Resultado
```
System check identified 10 issues (0 silenced).
.......................................................................................
----------------------------------------------------------------------
Ran 87 tests in 0.481s

OK
Preserving test database for alias 'default'...
```

3. Conferir que um registro antigo sem `readable_data` preenchido ainda é corretamente comparado (usa `get_readable_data()` como fallback).

## Algum cenário de contexto que queira dar?
Resolve o incidente de produção relatado (traceback com `QueryDocumentMultipleObjectsReturnedError` no registro de `2317-6326-abcd-22-01-41_44_00009.xml`, revista ABCD), causado por um candidato de outro fascículo/artigo colidir apenas por compartilhar um `z_partial_body` genérico. A solução evita rota mais custosa (campo novo + migração): reaproveita a coluna `z_partial_body` já existente, comparando via `IN` os dois formatos possíveis de hash. Fica registrado como dívida técnica: como o fingerprint do corpo inteiro não foi exposto em `get_data_to_compare()`, ele hoje só atua no **pré-filtro** dos candidatos (`partial_body_query`) — não influencia o *score* de similaridade (`get_best_match`/`compare_items`). Se um dia isso for necessário, será preciso expor esse fingerprint também nesse ponto.

## Screenshots
N/A (mudança de lógica de backend, sem interface).

## Quais são os tickets relevantes?
Fixes #1029 
Fixes #1006 

## Referências
- Issue: "Bug: falso unmatched na estratégia journal-article por colisão de z_partial_body genérico — reforço com fingerprint do corpo inteiro"
- `pid_provider/models.py`, `pid_provider/query_params.py`
- Log do incidente: `PidProviderXMLRegistration` — `event_status: unmatched`, `error_type: QueryDocumentMultipleObjectsReturnedError`, pkg_name `2317-6326-abcd-22-01-41_44_00009`

---
## Segurança da informação (NSI.04)
Seção obrigatória, referência NSI.04 - Norma de Desenvolvimento Seguro.

- **Manipula dados sensíveis/pessoais (LGPD)?** Não. Hashes sha256 de metadados bibliográficos já existentes (corpo do artigo, autores, etc.), sem introdução de novo dado pessoal.
- **Altera autenticação, autorização, controle de acesso ou sessão?** Não.
- **Introduz/atualiza/remove dependências de terceiros?** Não.
- **Validado pelo pipeline de segurança (SonarQube/Trivy)?** Sim — sem nova dependência; conferir job de qualidade/testes no CI desta PR.
- **Concatena/monta/executa comandos SQL, HTML ou JS a partir de entrada externa?** Não. Queries construídas exclusivamente via Django ORM (`Q`, `__in`, `__isnull`).
- **Expõe novos endpoints, telas ou serviços?** Não.
- **Algum segredo/senha/chave/token adicionado ao código-fonte?** Não.