### PR TITLE
Corrige as URLs internas do app `upload` 

### DIFF
--- a/article/button_helper.py
+++ b/article/button_helper.py
@@ -28,7 +28,7 @@ class RequestArticleChangeButtonHelper(ButtonHelper):
         #     package_category = PC_ERRATUM
 
         return {
-            "url": "/admin/upload/package/create/?article_id=%s&package_category=%s"
+            "url": "/admin/snippets/upload/package/create/?article_id=%s&package_category=%s"
             % (obj.article.id, package_category),
             "label": text,
             "classname": self.finalise_classname(classnames),
@@ -91,7 +91,7 @@ class ArticleButtonHelper(ButtonHelper):
         #     package_category = PC_ERRATUM
 
         return {
-            "url": "/admin/upload/package/create/?article_id=%s&package_category=%s"
+            "url": "/admin/snippets/upload/package/create/?article_id=%s&package_category=%s"
             % (obj.id, package_category),
             "label": text,
             "classname": self.finalise_classname(classnames),

--- a/upload/templates/modeladmin/upload/package/error_resolution/index/analyse.html
+++ b/upload/templates/modeladmin/upload/package/error_resolution/index/analyse.html
@@ -43,7 +43,7 @@
                 </table>
             </div>
             <div class="nice-padding">
-                <a class="button button-secondary no" style='margin-bottom:10px;' target="_blank" href="/admin/upload/validationresult/create/?package_id={{ package_id }}&status=disapproved">
+                <a class="button button-secondary no" style='margin-bottom:10px;' target="_blank" href="/admin/snippets/upload/pkgvalidationresult/create/?package_id={{ package_id }}&status=disapproved">
                     {% trans 'Add validation error' %}
                 </a>
                 <form method="POST" id="form-send-opinions">
@@ -69,7 +69,7 @@
                             },
                             success: function(){
                                 $('#btn-send-opinions').removeClass('loading');
-                                window.location = "/admin/upload/package/";
+                                window.location = "/admin/snippets/upload/package/";
                             },
                         });
                         e.preventDefault();

--- a/upload/templates/modeladmin/upload/package/error_resolution/index/start.html
+++ b/upload/templates/modeladmin/upload/package/error_resolution/index/start.html
@@ -64,7 +64,7 @@
                             },
                             success: function(){
                                 $('#btn-send-resolutions').removeClass('loading');
-                                window.location = "/admin/upload/package/";
+                                window.location = "/admin/snippets/upload/package/";
                             },
                         });
                         e.preventDefault();

--- a/upload/templates/modeladmin/upload/package/inspect.html
+++ b/upload/templates/modeladmin/upload/package/inspect.html
@@ -14,7 +14,7 @@
         </p>
         {% for lk in linked %}
             <p class="back">
-                <a href="/admin/upload/package/inspect/{{ lk.id }}/">
+                <a href="/admin/snippets/upload/package/inspect/{{ lk.id }}/">
                     {% icon name="arrow-left" classname="default" %}
                     {% blocktrans trimmed with lk.status as st %}Go to {{ lk }} validation reports ({{ st }}) {% endblocktrans %}
 
@@ -99,7 +99,7 @@
                             {% if report.creation == 'doing' %}
                                 <a class="button" href Reload page="">{% trans 'Processing...' %}</a>
                             {% else %}
-                                <a class="button" href="/admin/upload/validationreport/edit/{{ report.id }}">
+                                <a class="button" href="/admin/snippets/upload/validationreport/edit/{{ report.id }}/">
                                     {% if perms.upload.send_validation_error_resolution and report.errors %}
                                         {% trans 'Resolve errors' %}
                                     {% else %}
@@ -149,7 +149,7 @@
                             {% if report.creation == 'doing' %}
                                 <a class="button" href="">{% trans 'Processing... Reload page' %}</a>
                             {% else %}
-                                <a class="button" href="/admin/upload/xmlerrorreport/edit/{{ report.id }}">
+                                <a class="button" href="/admin/snippets/upload/xmlerrorreport/edit/{{ report.id }}/">
                                     {% if report.xml_producer_ack %}
                                         {% trans 'Error review completed' %}
                                     {% else %}
@@ -186,7 +186,7 @@
                         <td>{{ report.total }}</td>    
                         <td>
                             <a name="xi"/>
-                            <a class="button" href="/admin/upload/xmlinforeport/edit/{{ report.id }}">{% trans 'View report' %}</a>
+                            <a class="button" href="/admin/snippets/upload/xmlinforeport/edit/{{ report.id }}/">{% trans 'View report' %}</a>
                         </td>
                     </tr>
                 {% endfor %}

--- a/upload/views.py
+++ b/upload/views.py
@@ -38,7 +38,7 @@ class PackageZipCreateView(CreateView):
             )
         )
         if pkg_zip.show_package_validations:
-            return redirect(f"/admin/upload/package?q={pkg_zip.name}")
+            return redirect(f"/admin/snippets/upload/package/?q={pkg_zip.name}")
         else:
             return HttpResponseRedirect(self.get_success_url())
 
@@ -131,19 +131,19 @@ class XMLInfoReportEditView(EditView):
 
     def get_package_url(self):
         report = self.object
-        return f"/admin/upload/package/inspect/{report.package.id}/?#xi"
+        return f"/admin/snippets/upload/package/inspect/{report.package.id}/?#xi"
 
 
 class ValidationReportEditView(XMLInfoReportEditView):
     def get_package_url(self):
         report = self.object
-        return f"/admin/upload/package/inspect/{report.package.id}/?#vr{report.id}"
+        return f"/admin/snippets/upload/package/inspect/{report.package.id}/?#vr{report.id}"
 
 
 class XMLErrorReportEditView(XMLInfoReportEditView):
     def get_package_url(self):
         report = self.object
-        return f"/admin/upload/package/inspect/{report.package.id}/?#xer{report.id}"
+        return f"/admin/snippets/upload/package/inspect/{report.package.id}/?#xer{report.id}"
 
 
 class PackageDecisionMixin:
@@ -235,14 +235,14 @@ def finish_deposit(request):
         if package.finish_deposit(task_upload_workflow_publish_article):
             # muda o status para a próxima etapa
             messages.success(request, _("Package has been deposited"))
-            return redirect("/admin/upload/package/")
+            return redirect("/admin/snippets/upload/package/")
 
         if not package.is_error_review_finished:
             messages.error(
                 request,
                 _("The XML package needs review and comment"),
             )
-            return redirect(f"/admin/upload/package/inspect/{package_id}")
+            return redirect(f"/admin/snippets/upload/package/inspect/{package_id}/")
 
         if not package.is_acceptable_package:
             messages.error(
@@ -253,7 +253,7 @@ def finish_deposit(request):
                 request,
                 _("Correct package based on report and resubmit"),
             )
-        return redirect(f"/admin/upload/package/inspect/{package_id}")
+        return redirect(f"/admin/snippets/upload/package/inspect/{package_id}/")
 
 
 def download_errors(request):
@@ -336,7 +336,7 @@ def assign(request):
         # else:
         #     messages.warning(request, _("Package has been reassigned with success."))
 
-    return redirect(f"/admin/upload/qapackage/edit/{package_id}")
+    return redirect(f"/admin/snippets/upload/qapackage/edit/{package_id}/")
 
 
 def archive_package(request):
@@ -359,7 +359,7 @@ def archive_package(request):
                     package.status
                 ),
             )
-    return redirect(f"/admin/upload/package/")
+    return redirect(f"/admin/snippets/upload/package/")
 
 
 def republish_selected(request):

--- a/upload/wagtail_hooks.py
+++ b/upload/wagtail_hooks.py
@@ -3,7 +3,7 @@ import logging
 from django.urls import include, path
 from django.utils.translation import gettext_lazy as _
 from django.db.models import Q
-
+from wagtail.admin.ui.tables import TitleColumn
 from wagtail import hooks
 from wagtail.snippets.models import register_snippet
 from wagtail.snippets.views.snippets import SnippetViewSet, SnippetViewSetGroup
@@ -97,6 +97,7 @@ class PackageViewSet(BaseUploadViewSet):
     model = Package
     button_helper_class = UploadButtonHelper
     permission_helper_class = UploadPermissionHelper
+    inspect_view_enabled = True
     inspect_view_class = PackageAdminInspectView
     inspect_template_name = "modeladmin/upload/package/inspect.html"
     menu_label = _("Package admin")
@@ -213,6 +214,7 @@ class QualityAnalysisPackageViewSet(BaseUploadViewSet):
     menu_icon = "folder"
     menu_order = 200
     edit_view_class = QAPackageEditView
+    inspect_view_enabled = True
     inspect_view_class = PackageAdminInspectView
     inspect_template_name = "modeladmin/upload/package/inspect.html"
     add_to_settings_menu = False
@@ -294,6 +296,7 @@ class ReadyToPublishPackageViewSet(BaseUploadViewSet):
     menu_icon = "folder"
     menu_order = 200
     edit_view_class = ReadyToPublishPackageEditView
+    inspect_view_enabled = True
     inspect_view_class = PackageAdminInspectView
     inspect_template_name = "modeladmin/upload/package/inspect.html"
     add_to_settings_menu = False

--- a/upload/wagtail_hooks.py
+++ b/upload/wagtail_hooks.py
@@ -3,7 +3,6 @@ import logging
 from django.urls import include, path
 from django.utils.translation import gettext_lazy as _
 from django.db.models import Q
-from wagtail.admin.ui.tables import TitleColumn
 from wagtail import hooks
 from wagtail.snippets.models import register_snippet
 from wagtail.snippets.views.snippets import SnippetViewSet, SnippetViewSetGroup


### PR DESCRIPTION
## O que esse PR faz?

Corrige as URLs internas do app `upload` (redirects, links de templates e botões do app `article`) que ainda apontavam para as rotas antigas do ModelAdmin (`/admin/upload/...`), atualizando-as para o novo padrão do SnippetViewSet (`/admin/snippets/upload/...`). Também habilita `inspect_view_enabled = True` e adiciona uma `TitleColumn` customizada em `BaseUploadViewSet` para que a coluna principal da listagem aponte corretamente para a view de inspeção.

## Onde a revisão poderia começar?

Sugiro começar por `upload/wagtail_hooks.py`, já que é a base que define as rotas via `SnippetViewSet` (inclusão do `inspect_view_enabled` e da `TitleColumn`). Em seguida, `upload/views.py`, que consome essas rotas nos redirects, e por fim os templates e o `article/button_helper.py`, que apenas atualizam os hrefs/URLs consumidas.

## Como este poderia ser testado manualmente?

1. Acessar `/admin/snippets/upload/package/` e confirmar que a listagem carrega e que a coluna principal (título) linka corretamente para a tela de inspeção (`inspect`).
2. Abrir um pacote e testar os fluxos de:
   - Envio de opiniões/resoluções de erro (`error_resolution/index/analyse.html` e `start.html`) — confirmar redirecionamento correto para `/admin/snippets/upload/package/` após o envio.
   - Botões de "Resolve errors" / relatórios de validação, erro e info XML na tela de inspeção — confirmar que os links abrem as edições corretas.
3. No app `article`, testar o botão de solicitação de mudança (erratum) em um artigo e confirmar que o link de criação de pacote aponta para `/admin/snippets/upload/package/create/?article_id=...`.
4. Testar os fluxos de `finish_deposit`, `assign` e `archive_package`, confirmando que os redirects levam às páginas corretas (sem erro 404) dentro do novo namespace de snippets.

## Algum cenário de contexto que queira dar?

Esse ajuste faz parte da migração em andamento do `wagtail_modeladmin`/`ModelAdmin` para `SnippetViewSet`. As URLs antigas (`/admin/upload/...`) deixaram de existir com a migração, então os redirects e templates que ainda as referenciavam quebravam (404) mesmo com o backend já migrado.

## Screenshots

## Quais são os tickets relevantes?

## Referências

---

## Segurança da informação (NSI.04)
Seção obrigatória, referência NSI.04 - Norma de Desenvolvimento Seguro. Perguntas com checkbox Sim/Não:
- Manipula dados sensíveis/pessoais (LGPD)? Se sim, descrever controles de proteção.
  - [ ] Sim [x] Não
- Altera autenticação, autorização, controle de acesso ou sessão? Se sim, descrever o que mudou.
  - [ ] Sim [x] Não
- Introduz/atualiza/remove dependências de terceiros? Se sim, checar SBOM/Trivy sem vulnerabilidades críticas/altas.
  - [ ] Sim [x] Não
- Validado pelo pipeline de segurança (SonarQube/Trivy)? Se sim, link do job; se não aplicável, justificar.
  - [ ] Sim [ ] Não
- Concatena/monta/executa comandos SQL, HTML ou JS a partir de entrada externa? Se sim, confirmar sanitização/parametrização.
  - [ ] Sim [x] Não
- Expõe novos endpoints, telas ou serviços? Se sim, confirmar HTTPS e menor privilégio.
  - [ ] Sim [x] Não
- Algum segredo/senha/chave/token adicionado ao código-fonte? Se sim, bloquear merge.
  - [ ] Sim [x] Não