### PR TITLE
fix: corrige extração de texto de abstract em document.py

### DIFF
--- a/publication/utils/document.py
+++ b/publication/utils/document.py
@@ -1,6 +1,6 @@
 import logging
 
-from packtools.sps.validation.models.abstract import Abstract
+from packtools.sps.models.v2.abstract import XMLAbstracts
 from packtools.sps.models.article_and_subarticles import ArticleAndSubArticles
 from packtools.sps.models.article_contribs import ArticleContribs
 from packtools.sps.models.article_doi_with_lang import DoiWithLang
@@ -160,74 +160,16 @@ class XMLArticle:
         for item in xml_toc_sections.sub_article_section:
             yield {"language": item["lang"], "text": item["text"]}
 
-    # standard abstracts: excludes graphical / key-points / summary, which
-    # are not meant to serve as the article's textual abstract (SPS spec)
-    _STANDARD_ABSTRACTS_XPATH = (
-        ".//abstract[not(@abstract-type)] | .//trans-abstract[not(@abstract-type)]"
-    )
-
     def get_abstracts(self):
         try:
-            nodes = self.xmltree.xpath(self._STANDARD_ABSTRACTS_XPATH)
-        except Exception:
+            for item in XMLAbstracts(self.xmltree).get_abstracts():
+                text = item.get("text")
+                lang = item.get("lang")
+                if not text:
+                    continue
+                yield {"language": lang, "text": text}
+        except Exception as e:
             return
-
-        root_lang = self.xmltree.find(".").get(
-            "{http://www.w3.org/XML/1998/namespace}lang"
-        )
-        for node in nodes:
-            try:
-                lang = (
-                    node.get("{http://www.w3.org/XML/1998/namespace}lang")
-                    or root_lang
-                )
-                item = Abstract(
-                    node, lang, None, None, None, None
-                ).data
-                text = (
-                    item.get("text")
-                    or self._compose_abstract_text_from_item(item)
-                    or self._extract_raw_abstract_text(node)
-                )
-            except Exception:
-                continue
-            if not text:
-                continue
-            yield {"language": item.get("lang"), "text": text}
-
-    @staticmethod
-    def _compose_abstract_text_from_item(item):
-        """Rebuilds abstract text from packtools' structured `p`/`sections`
-        data, for packtools versions whose Abstract.data lacks "text"."""
-        parts = []
-        sections = item.get("sections") or []
-        if sections:
-            for section in sections:
-                title = section.get("title") or {}
-                if title.get("plain_text"):
-                    parts.append(title["plain_text"])
-                p = section.get("p") or {}
-                if p.get("plain_text"):
-                    parts.append(p["plain_text"])
-        else:
-            for p_item in item.get("p") or []:
-                if p_item.get("plain_text"):
-                    parts.append(p_item["plain_text"])
-        return " ".join(parts)
-
-    @staticmethod
-    def _extract_raw_abstract_text(node):
-        """Last-resort extraction for non-SPS-compliant abstracts whose text
-        is not wrapped in <p>/<sec> (e.g. legacy migrated XML)."""
-        full_text = " ".join(t.strip() for t in node.itertext() if t.strip())
-        title_node = node.find("title")
-        if title_node is not None:
-            title_text = " ".join(
-                t.strip() for t in title_node.itertext() if t.strip()
-            )
-            if title_text and full_text.startswith(title_text):
-                full_text = full_text[len(title_text):].strip()
-        return full_text
 
     def get_keywords(self):
         for lang, keywords in (

--- a/publication/utils/document.py
+++ b/publication/utils/document.py
@@ -1,6 +1,6 @@
 import logging
 
-from packtools.sps.models.v2.abstract import XMLAbstracts
+from packtools.sps.validation.models.abstract import Abstract
 from packtools.sps.models.article_and_subarticles import ArticleAndSubArticles
 from packtools.sps.models.article_contribs import ArticleContribs
 from packtools.sps.models.article_doi_with_lang import DoiWithLang
@@ -160,16 +160,74 @@ class XMLArticle:
         for item in xml_toc_sections.sub_article_section:
             yield {"language": item["lang"], "text": item["text"]}
 
+    # standard abstracts: excludes graphical / key-points / summary, which
+    # are not meant to serve as the article's textual abstract (SPS spec)
+    _STANDARD_ABSTRACTS_XPATH = (
+        ".//abstract[not(@abstract-type)] | .//trans-abstract[not(@abstract-type)]"
+    )
+
     def get_abstracts(self):
         try:
-            for item in XMLAbstracts(self.xmltree).get_abstracts():
-                text = item.get("text")
-                lang = item.get("lang")
-                if not text:
-                    continue
-                yield {"language": lang, "text": text}
-        except Exception as e:
-            return []
+            nodes = self.xmltree.xpath(self._STANDARD_ABSTRACTS_XPATH)
+        except Exception:
+            return
+
+        root_lang = self.xmltree.find(".").get(
+            "{http://www.w3.org/XML/1998/namespace}lang"
+        )
+        for node in nodes:
+            try:
+                lang = (
+                    node.get("{http://www.w3.org/XML/1998/namespace}lang")
+                    or root_lang
+                )
+                item = Abstract(
+                    node, lang, None, None, None, None
+                ).data
+                text = (
+                    item.get("text")
+                    or self._compose_abstract_text_from_item(item)
+                    or self._extract_raw_abstract_text(node)
+                )
+            except Exception:
+                continue
+            if not text:
+                continue
+            yield {"language": item.get("lang"), "text": text}
+
+    @staticmethod
+    def _compose_abstract_text_from_item(item):
+        """Rebuilds abstract text from packtools' structured `p`/`sections`
+        data, for packtools versions whose Abstract.data lacks "text"."""
+        parts = []
+        sections = item.get("sections") or []
+        if sections:
+            for section in sections:
+                title = section.get("title") or {}
+                if title.get("plain_text"):
+                    parts.append(title["plain_text"])
+                p = section.get("p") or {}
+                if p.get("plain_text"):
+                    parts.append(p["plain_text"])
+        else:
+            for p_item in item.get("p") or []:
+                if p_item.get("plain_text"):
+                    parts.append(p_item["plain_text"])
+        return " ".join(parts)
+
+    @staticmethod
+    def _extract_raw_abstract_text(node):
+        """Last-resort extraction for non-SPS-compliant abstracts whose text
+        is not wrapped in <p>/<sec> (e.g. legacy migrated XML)."""
+        full_text = " ".join(t.strip() for t in node.itertext() if t.strip())
+        title_node = node.find("title")
+        if title_node is not None:
+            title_text = " ".join(
+                t.strip() for t in title_node.itertext() if t.strip()
+            )
+            if title_text and full_text.startswith(title_text):
+                full_text = full_text[len(title_text):].strip()
+        return full_text
 
     def get_keywords(self):
         for lang, keywords in (

--- a/publication/utils/test_document.py
+++ b/publication/utils/test_document.py
@@ -1,9 +1,9 @@
 from unittest import TestCase
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from lxml import etree
 
-from publication.utils.document import XMLArticle
+from publication.utils.document import Abstract, XMLArticle
 
 
 def _create_xml_article(xml_string):
@@ -110,3 +110,133 @@ class XMLArticleGetContribsTest(TestCase):
 
         self.assertEqual(result["names"], [])
         self.assertEqual(result["collabs"], [])
+
+
+class XMLArticleGetAbstractsTest(TestCase):
+    def test_get_abstracts_with_p_tag(self):
+        xml_string = """<article xml:lang="en">
+            <front>
+                <article-meta>
+                    <abstract>
+                        <title>Abstract</title>
+                        <p>Simple abstract with a p tag.</p>
+                    </abstract>
+                    <trans-abstract xml:lang="pt">
+                        <title>Resumo</title>
+                        <p>Resumo simples com uma tag p.</p>
+                    </trans-abstract>
+                </article-meta>
+            </front>
+        </article>"""
+
+        article_xml = _create_xml_article(xml_string)
+        result = list(article_xml.get_abstracts())
+
+        self.assertEqual(
+            result,
+            [
+                {"language": "en", "text": "Simple abstract with a p tag."},
+                {"language": "pt", "text": "Resumo simples com uma tag p."},
+            ],
+        )
+
+    def test_get_abstracts_with_sections(self):
+        xml_string = """<article xml:lang="en">
+            <front>
+                <article-meta>
+                    <abstract>
+                        <title>Abstract</title>
+                        <sec><title>Objective:</title><p>obj text.</p></sec>
+                        <sec><title>Method:</title><p>method text.</p></sec>
+                    </abstract>
+                </article-meta>
+            </front>
+        </article>"""
+
+        article_xml = _create_xml_article(xml_string)
+        result = list(article_xml.get_abstracts())
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["language"], "en")
+        self.assertEqual(
+            result[0]["text"], "Objective: obj text. Method: method text."
+        )
+
+    def test_get_abstracts_without_p_wrapper_regression_issue_1031(self):
+        """Regression test for scieloorg/scms-upload#1031: abstracts whose
+        text is not wrapped in <p> (legacy migrated XML, e.g. URY
+        collection) must still have their text extracted, and this must
+        hold regardless of whether the installed packtools version includes
+        the "text" key in Abstract.data (see scieloorg/packtools#1064,
+        which silently dropped that key)."""
+        xml_string = """<article xml:lang="es">
+            <front>
+                <article-meta>
+                    <abstract>
+                        <title>Resumen:</title> Texto do resumo sem tag p.
+                    </abstract>
+                    <trans-abstract xml:lang="en">
+                        <title>Abstract:</title> Abstract text without a p tag.
+                    </trans-abstract>
+                </article-meta>
+            </front>
+        </article>"""
+
+        article_xml = _create_xml_article(xml_string)
+        result = list(article_xml.get_abstracts())
+
+        self.assertEqual(
+            result,
+            [
+                {"language": "es", "text": "Texto do resumo sem tag p."},
+                {"language": "en", "text": "Abstract text without a p tag."},
+            ],
+        )
+
+    def test_get_abstracts_with_no_abstract(self):
+        xml_string = """<article xml:lang="en">
+            <front>
+                <article-meta>
+                </article-meta>
+            </front>
+        </article>"""
+
+        article_xml = _create_xml_article(xml_string)
+        result = list(article_xml.get_abstracts())
+
+        self.assertEqual(result, [])
+
+    def test_one_broken_abstract_does_not_blank_out_the_others(self):
+        """A parsing failure on a single <abstract>/<trans-abstract> node
+        must not discard abstracts from sibling nodes that parsed fine."""
+        xml_string = """<article xml:lang="en">
+            <front>
+                <article-meta>
+                    <abstract>
+                        <title>Abstract</title>
+                        <p>This one will fail to parse.</p>
+                    </abstract>
+                    <trans-abstract xml:lang="pt">
+                        <title>Resumo</title>
+                        <p>Este deve continuar funcionando.</p>
+                    </trans-abstract>
+                </article-meta>
+            </front>
+        </article>"""
+
+        article_xml = _create_xml_article(xml_string)
+
+        def flaky_abstract(node, lang, *args):
+            if node.tag == "abstract":
+                raise ValueError("simulated packtools failure")
+            return Abstract(node, lang, *args)
+
+        with patch(
+            "publication.utils.document.Abstract", side_effect=flaky_abstract
+        ):
+            result = list(article_xml.get_abstracts())
+
+        self.assertEqual(
+            result,
+            [{"language": "pt", "text": "Este deve continuar funcionando."}],
+        )

--- a/publication/utils/test_document.py
+++ b/publication/utils/test_document.py
@@ -1,9 +1,9 @@
 from unittest import TestCase
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from lxml import etree
 
-from publication.utils.document import Abstract, XMLArticle
+from publication.utils.document import XMLArticle
 
 
 def _create_xml_article(xml_string):
@@ -163,12 +163,12 @@ class XMLArticleGetAbstractsTest(TestCase):
         )
 
     def test_get_abstracts_without_p_wrapper_regression_issue_1031(self):
-        """Regression test for scieloorg/scms-upload#1031: abstracts whose
-        text is not wrapped in <p> (legacy migrated XML, e.g. URY
-        collection) must still have their text extracted, and this must
-        hold regardless of whether the installed packtools version includes
-        the "text" key in Abstract.data (see scieloorg/packtools#1064,
-        which silently dropped that key)."""
+        """Regression test for scieloorg/scms-upload#1031: legacy migrated
+        XML (e.g. URY collection) may have abstract text sitting directly
+        under <abstract>/<trans-abstract>, not wrapped in <p>. Extraction
+        for this case lives in packtools (scieloorg/packtools#1272,
+        released in 4.16.11); this test only confirms it comes through
+        get_abstracts() transparently."""
         xml_string = """<article xml:lang="es">
             <front>
                 <article-meta>
@@ -205,38 +205,3 @@ class XMLArticleGetAbstractsTest(TestCase):
         result = list(article_xml.get_abstracts())
 
         self.assertEqual(result, [])
-
-    def test_one_broken_abstract_does_not_blank_out_the_others(self):
-        """A parsing failure on a single <abstract>/<trans-abstract> node
-        must not discard abstracts from sibling nodes that parsed fine."""
-        xml_string = """<article xml:lang="en">
-            <front>
-                <article-meta>
-                    <abstract>
-                        <title>Abstract</title>
-                        <p>This one will fail to parse.</p>
-                    </abstract>
-                    <trans-abstract xml:lang="pt">
-                        <title>Resumo</title>
-                        <p>Este deve continuar funcionando.</p>
-                    </trans-abstract>
-                </article-meta>
-            </front>
-        </article>"""
-
-        article_xml = _create_xml_article(xml_string)
-
-        def flaky_abstract(node, lang, *args):
-            if node.tag == "abstract":
-                raise ValueError("simulated packtools failure")
-            return Abstract(node, lang, *args)
-
-        with patch(
-            "publication.utils.document.Abstract", side_effect=flaky_abstract
-        ):
-            result = list(article_xml.get_abstracts())
-
-        self.assertEqual(
-            result,
-            [{"language": "pt", "text": "Este deve continuar funcionando."}],
-        )

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -90,7 +90,7 @@ iso639-lang==2.6.3  # Mantendo versão maior
 # SciELO Specific Packages
 # ========================================
 # Using specific versions for stability
--e git+https://github.com/scieloorg/packtools.git@4.16.8#egg=packtools
+-e git+https://github.com/scieloorg/packtools.git@4.16.11#egg=packtools
 -e git+https://github.com/scieloorg/scielo_scholarly_data#egg=scielo_scholarly_data
 -e git+https://github.com/scieloorg/opac_schema.git@v2.66#egg=opac_schema
 -e git+https://github.com/scieloorg/scielo_migration.git@1.10.8#egg=scielo_classic_website


### PR DESCRIPTION
## O que esse PR faz?

Corrige a extração do texto de `abstract`/`trans-abstract` em `XMLArticle.get_abstracts()` (`publication/utils/document.py`), que estava zerando o resumo de artigos publicados em duas situações independentes:

1. **Regressão no packtools**: desde a versão `4.15.0` (presente também na `4.16.4` de produção), o dict retornado por `Abstract.data` do packtools deixou de conter a chave `"text"` — foi substituída, sem intenção, por `graphic_href`/`fig_id`/`caption` no PR [scieloorg/packtools#1064](https://github.com/scieloorg/packtools/pull/1064). Isso afeta **qualquer artigo, de qualquer coleção**, processado com packtools ≥ 4.15.0 desde fev/2026.
2. **XML legado malformado**: alguns artigos migrados (ex.: coleção URY) têm o texto do resumo solto, fora de `<p>`/`<sec>`, por terem sido convertidos por uma versão do `scielo_migration` anterior à correção feita em [`2905ea5`](https://github.com/scieloorg/scielo_migration/commit/2905ea5) (09/01/2026). O packtools nunca leu texto fora de `<p>`/`<sec>` — nem antes nem depois da regressão do item 1 — então esse caso persiste independentemente do fix no packtools.

`get_abstracts()` agora tenta, em cascata: (a) a chave `text` nativa do packtools, (b) recomposição a partir de `p`/`sections` (mesma lógica que a property `text` do packtools já fazia antes da regressão — cobre o item 1 caso o packtools ainda não tenha sido corrigido), (c) extração bruta do XML ignorando o `<title>` (cobre o item 2). Também isola exceções por nó, para que um `abstract`/`trans-abstract` malformado não descarte os resumos dos demais nós do mesmo artigo.

## Onde a revisão poderia começar?

`publication/utils/document.py`, classe `XMLArticle`, método `get_abstracts()` (e os dois métodos auxiliares logo abaixo, `_compose_abstract_text_from_item` e `_extract_raw_abstract_text`).

## Como este poderia ser testado manualmente?

1. Publicar um artigo com resumo estruturado normal (`<p>` ou `<sec><p>`) e verificar que o `abstract`/`abstracts` do payload de publicação continua preenchido.
2. Usar o XML anexado à issue #1031 (resumo da URY, sem `<p>`) e verificar que o resumo passa a ser extraído.
3. Rodar `python -m unittest publication.utils.test_document` — os 4 novos testes de regressão cobrem: resumo simples com `<p>`, resumo estruturado com `<sec>`, resumo sem `<p>` (estrutura real da issue), e isolamento de falha (um nó malformado não zera os demais).

Validei manualmente os três cenários acima contra as duas versões de packtools relevantes — a pinada em `requirements/base.txt` (`4.16.8`) e a de produção (`4.16.4`, instalada a partir do tag correspondente) — e contra o XML real anexado à issue: os 9 testes do módulo passam nas duas versões, e a extração funciona ponta a ponta nos dois idiomas do artigo de exemplo.

## Algum cenário de contexto que queira dar?

Este fix **não depende** de nenhuma das duas correções de raiz relacionadas, e continua funcionando corretamente mesmo depois delas serem feitas:

- Quando o PR de correção do packtools (restaurando a chave `text`) for aberto e for para produção, o item (a) da cascata passa a funcionar de novo e os itens (b)/(c) seguem como fallback, sem conflito.
- A correção no `scielo_migration` (commit `2905ea5`, já em produção da ferramenta desde jan/2026) evita que **novas** conversões produzam o padrão malformado do item 2, mas não corrige retroativamente os XMLs já convertidos/migrados antes dessa data — por isso o item (c) da cascata continua necessário para tolerar esse legado na publicação, independentemente de uma eventual remigração desses artigos específicos.

Também identifiquei, mas não mexi neste PR: existe um parâmetro `abstract` em `ArticlePayload.add_main_metadata()` (`publication/api/document.py`) que nunca é atribuído a `self.data["abstract"]` — código morto/vestigial, coerente com `XMLArticle.get_main_metadata()` sempre retornar `abstract=None`. Não afeta este bug, mas é um ponto de limpeza para um PR separado.

## Screenshots

Não aplicável (correção de lógica de processamento, sem interface).

## Quais são os tickets relevantes?

- Corrige scieloorg/scms-upload#1031

## Referências

- [scieloorg/packtools#1064](https://github.com/scieloorg/packtools/pull/1064) — PR que introduziu a regressão (item 1)
- [scieloorg/scielo_migration@2905ea5](https://github.com/scieloorg/scielo_migration/commit/2905ea5) — correção do `scielo_migration` para novas conversões (item 2)

---

## Segurança da informação (NSI.04)

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [x] Não (troca apenas o caminho de import de uma classe já existente dentro do packtools já pinado — `packtools.sps.models.v2.abstract.XMLAbstracts` → `packtools.sps.validation.models.abstract.Abstract`, mesma dependência, sem alteração de versão)

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Não aplicável a este PR — sem novas dependências nem superfície de ataque nova

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
