### PR TITLE
Corrige a obtenção dos pdfs do pacote do Upload v3.x

### DIFF
--- a/article/models.py
+++ b/article/models.py
@@ -322,10 +322,12 @@ class Article(ClusterableModel, CommonControlField):
         return cls.objects.get(**params)
     
     @classmethod
-    def get_first(cls, pid_v2=None, sps_pkg_name=None, pid_v3=None, delete=False):
+    def get_first(cls, pid_v2=None, sps_pkg_name=None, pid_v3=None, delete=False, name_list=None):
         q = Q()
         if pid_v2:
             q |= Q(pid_v2=pid_v2)
+        if name_list:
+            q |= Q(sps_pkg__sps_pkg_name__in=name_list)
         if sps_pkg_name:
             q |= Q(sps_pkg__sps_pkg_name=sps_pkg_name)
         qs = cls.objects.filter(q).order_by("-updated")
@@ -364,7 +366,12 @@ class Article(ClusterableModel, CommonControlField):
             raise ValueError(f"SPSPkg {sps_pkg} xml_with_pre is missing pid_v2")
 
         try:
-            obj = cls.get_first(sps_pkg.sps_pkg_name, pid_v2, pid_v3, delete=True)
+            try:
+                name_list = self.xml_with_pre.pkg_name_variations
+            except AttributeError:
+                name_list = [self.xml_with_pre.sps_pkg_name]
+                name_list.extend(self.xml_with_pre.deprecated_sps_pkg_name_list)
+            obj = cls.get_first(sps_pkg.sps_pkg_name, pid_v2, pid_v3, delete=True, name_list=name_list)
         except cls.DoesNotExist:
             obj = cls()
             obj.creator = user

--- a/package/models.py
+++ b/package/models.py
@@ -863,6 +863,8 @@ class SPSPkg(CommonControlField, ClusterableModel):
                 content = item["content"].encode("utf-8")
             except KeyError:
                 content = None
+            if not content:
+                continue
             response = self.upload_to_the_cloud(
                 user,
                 minio,

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -90,7 +90,7 @@ iso639-lang==2.6.3  # Mantendo versão maior
 # SciELO Specific Packages
 # ========================================
 # Using specific versions for stability
--e git+https://github.com/scieloorg/packtools.git@4.16.8#egg=packtools
+-e git+https://github.com/scieloorg/packtools.git@4.16.11#egg=packtools
 -e git+https://github.com/scieloorg/scielo_scholarly_data#egg=scielo_scholarly_data
 -e git+https://github.com/scieloorg/opac_schema.git@v2.66#egg=opac_schema
 -e git+https://github.com/scieloorg/scielo_migration.git@1.10.8#egg=scielo_classic_website

--- a/upload/models.py
+++ b/upload/models.py
@@ -86,14 +86,14 @@ def report_datetime():
 def upload_package_directory_path(instance, filename):
     name, ext = os.path.splitext(filename)
     try:
-        sps_pkg_name = instance.name
+        xml_name = instance.name
     except AttributeError:
-        sps_pkg_name = instance.package.name
+        xml_name = instance.package.name
 
-    subdirs = (sps_pkg_name or name).split("-")
-    subdir_sps_pkg_name = "/".join(subdirs)
+    subdirs = (xml_name or name).split("-")
+    subdir_xml_name = "/".join(subdirs)
 
-    return f"upload/{subdir_sps_pkg_name}/{ext[1:]}/{filename}"
+    return f"upload/{subdir_xml_name}/{ext[1:]}/{filename}"
 
 
 class PackageZip(CommonControlField):
@@ -148,7 +148,6 @@ class PackageZip(CommonControlField):
     @property
     def xmls(self):
         for item in XMLWithPre.create(path=self.file.path):
-            logging.info(item.filename)
             yield item.filename
 
     def split(self, user):
@@ -440,20 +439,21 @@ class Package(CommonControlField, ClusterableModel):
     @property
     def renditions(self):
         """
-        Retorna um gerador de itens com este formato
+        Retorna um lista de itens com este formato
         {
             "name": name,
             "lang": item.language,
             "component_type": "rendition",
             "main": item.is_main_language,
-            "content": b'',
+            "sps_pkg_name": "dado ou construido ou ...",
+            "path_in_zip": "",
         }
         """
         renditions = self.xml_with_pre.renditions
 
         with ZipFile(self.file.path) as zf:
             for rendition in renditions:
-                rendition["content"] = zf.read(rendition["name"])
+                rendition["content"] = zf.read(rendition["path_in_zip"])
                 yield rendition
 
     def files_list(self):
@@ -564,7 +564,8 @@ class Package(CommonControlField, ClusterableModel):
                 detail = {"is_ready_to_publish": is_ready_to_publish}
 
                 response = self.prepare_to_publish(
-                    user, qa=is_ready_to_preview, public=is_ready_to_publish
+                    user, qa=is_ready_to_preview, public=is_ready_to_publish,
+                    force_update=None
                 )
                 detail.update(response or {})
 
@@ -853,7 +854,7 @@ class Package(CommonControlField, ClusterableModel):
 
                 # é desejável que qa e public sejam publicados simultaneamente
                 # exceto se há impedimento de em tornar público
-                response = self.prepare_to_publish(user, qa, public)
+                response = self.prepare_to_publish(user, qa, public, True)
                 self.update_status_and_add_comments(
                     user, response.get("result"), response.get("new_status")
                 )
@@ -966,7 +967,11 @@ class Package(CommonControlField, ClusterableModel):
         Atualiza data de publicação do artigo e/ou pid v2, se necessário
         """
         try:
-            xml_pub_date = datetime.fromisoformat(xml_with_pre.article_publication_date)
+            xml_pub_date = xml_with_pre.article_publication_date
+        except Exception as e:
+            xml_pub_date = xml_with_pre.get_complete_publication_date()
+        try:
+            xml_pub_date = datetime.fromisoformat(xml_pub_date)
         except Exception as e:
             xml_pub_date = None
 
@@ -1018,7 +1023,7 @@ class Package(CommonControlField, ClusterableModel):
             )
             raise
 
-    def prepare_sps_package(self, user, xml_with_pre, xml_file_changed):
+    def prepare_sps_package(self, user, xml_with_pre, xml_file_changed, force_update=None):
         # Aplica-se também para um pacote de atualização de um conteúdo anteriormente migrado
         # TODO components, texts
         if xml_file_changed:
@@ -1030,6 +1035,7 @@ class Package(CommonControlField, ClusterableModel):
             or not self.sps_pkg
             or not self.sps_pkg.registered_in_core
             or not self.sps_pkg.valid_components
+            or force_update
         ):
 
             texts = {
@@ -1037,7 +1043,6 @@ class Package(CommonControlField, ClusterableModel):
                 "pdf_langs": [
                     rendition["lang"]
                     for rendition in xml_with_pre.renditions
-                    if rendition["name"] in xml_with_pre.filenames
                 ],
             }
             self.sps_pkg = SPSPkg.create_or_update(
@@ -1212,7 +1217,7 @@ class Package(CommonControlField, ClusterableModel):
         report.creation = choices.REPORT_CREATION_DONE
         report.save()
 
-    def prepare_to_publish(self, user, qa=None, public=None):
+    def prepare_to_publish(self, user, qa=None, public=None, force_update=None):
         # verifica se há impedimentos de tornar o artigo público
         detail = {"qa": qa, "public": public}
         if not qa and not public:
@@ -1225,7 +1230,7 @@ class Package(CommonControlField, ClusterableModel):
             xml_with_pre = self.xml_with_pre
 
             xml_changed = self.check_xml_changed(user, xml_with_pre, public)
-            self.prepare_sps_package(user, xml_with_pre, xml_changed)
+            self.prepare_sps_package(user, xml_with_pre, xml_changed, force_update)
             result = self.analyze_sps_package(qa, public, xml_changed)
 
             detail.update(result)
@@ -2211,12 +2216,14 @@ class PidReservation(models.Model):
         ]
 
     @classmethod
-    def get(cls, pid_v2=None, pkg_name=None):
+    def get(cls, pid_v2=None, pkg_name=None, name_list=None):
         params = {}
         if pid_v2:
             params["pid_v2"] = pid_v2
         if pkg_name:
             params["pkg_name"] = pkg_name
+        if name_list:
+            params["pkg_name__in"] = name_list
         if not params:
             raise ValueError("PidReservation.is_reserved requires params")
         return cls.objects.get(**params)
@@ -2248,30 +2255,30 @@ class PidV2Generator:
 
     def generate(self, user, journal, issue):
         self.log = []
-        logging.info("PidV2Generator.generate PidProviderXML")
         registered = PidProviderXML.is_registered(self.xml_with_pre)
         if registered and registered.get("v2"):
             self.log.append(_("Setting package.pid_v2 from PidProviderXML"))
             return registered.get("v2")
 
-        logging.info("PidV2Generator.generate PidReservation")
         try:
-            return PidReservation.get(pkg_name=self.xml_with_pre.sps_pkg_name).pid_v2
+            try:
+                name_list = self.xml_with_pre.pkg_name_variations
+            except AttributeError:
+                name_list = [self.xml_with_pre.sps_pkg_name]
+                name_list.extend(self.xml_with_pre.deprecated_sps_pkg_name_list)
+            return PidReservation.get(name_list=name_list).pid_v2
         except PidReservation.DoesNotExist:
             pass
-
-        logging.info("PidV2Generator.generate IssueProc")
-
+        
         self.issue_pid = self.get_issue_pid(user, journal, issue)
         if not self.issue_pid:
             self.log.append(
                 _(
                     "Unable to set package.pid_v2 because issue ({}) is not registered"
-                ).format(self.issue)
+                ).format(issue)
             )
             raise ValueError("Package.generate_pid_v2: Missing issue_pid")
 
-        logging.info("PidV2Generator.generate generate_pid_v2_from_metadata")
         pid_v2 = self.generate_pid_v2_from_metadata()
         # if not pid_v2:
         #     logging.info("PidV2Generator.generate get_random_pid_v2")
@@ -2282,10 +2289,8 @@ class PidV2Generator:
                 f"Unable to get pid v2 for {self.xml_with_pre.sps_pkg_name}"
             )
 
-        logging.info("PidV2Generator.generate reserve_pid_v2")
         self.reserve_pid_v2(pid_v2)
         if registered:
-            logging.info("PidV2Generator.generate update_pid_provider_v2")
             self.update_pid_provider_v2(registered.get("v3"), pid_v2)
 
         return pid_v2
@@ -2347,9 +2352,6 @@ class PidV2Generator:
         for name, source in sources:
             if not source:
                 continue
-            logging.info(
-                f"PidV2Generator.generate generate_pid_v2_from_metadata {name}"
-            )
             pid_v2 = self.generate_pid_v2_from_source(source)
             if pid_v2:
                 self.log.append(_("Setting v2 ({}) from {}").format(pid_v2, name))


### PR DESCRIPTION
## O que esse PR faz?
Corrige a leitura do conteúdo dos renditions (PDFs) durante a publicação de pacotes, que anteriormente falhava ao localizar o arquivo dentro do .zip. Também: (a) permite localizar um `Article` já existente e reservas de PID (`PidReservation`) considerando variações/nomes depreciados de `sps_pkg_name`, evitando duplicidade de registros quando o nome do pacote muda entre versões; (b) adiciona fallback para obtenção da data de publicação do artigo quando `article_publication_date` não está disponível; (c) adiciona parâmetro `force_update` para permitir reprocessar o SPSPkg mesmo quando já registrado e válido no Core; (d) evita chamadas de upload ao storage com conteúdo vazio/inexistente; (e) atualiza a dependência packtools para 4.16.11; (f) remove logs de depuração (`logging.info`) sem valor em produção.

## Onde a revisão poderia começar?
`upload/models.py`, no método `Package.renditions` (leitura de `rendition["path_in_zip"]` em vez de `rendition["name"]`), que é a origem principal do problema relatado (PDFs não encontrados).

## Como este poderia ser testado manualmente?
1. Fazer upload de um pacote SPS com renditions (PDFs) cujo `name` de exibição seja diferente do caminho do arquivo dentro do .zip.
2. Avançar o pacote até a etapa de publicação (QA e/ou público) e confirmar que o PDF é lido/exibido corretamente, sem erros.

No entanto, foi identificado um bug no minio que será tratado no PR ... 

## Algum cenário de contexto que queira dar?
A questão principal é que os PDFs não eram encontrados. Isso ocorria porque a leitura do conteúdo do rendition usava a chave `name` (nome de exibição) ao invés do caminho real do arquivo dentro do .zip (`path_in_zip`), causando falha na recuperação do conteúdo do PDF durante a publicação. As demais alterações neste PR (variações de nome de pacote, fallback de data de publicação, `force_update`) foram necessárias para dar suporte e consistência ao fluxo de atualização de pacotes com o packtools 4.16.11.

## Screenshots
_Quando aplicável, anexar prints do erro anterior (PDF não encontrado) e da publicação funcionando corretamente após a correção._

## Quais são os tickets relevantes?
Issue relacionada: PDFs de renditions não encontrados durante a publicação de pacotes (ver issue acima).
FIx #1035 

## Referências
- packtools 4.16.11 (changelog/release notes referentes a `pkg_name_variations`, `deprecated_sps_pkg_name_list`, `get_complete_publication_date` e estrutura de `renditions` com `path_in_zip`)

---
## Segurança da informação (NSI.04)
> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim — descreva os controles de proteção aplicados (criptografia, mascaramento, anonimização, etc.):
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim — descreva o que mudou e por quê:
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [x] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
  - [ ] Verificado e aprovado
  - [ ] Pendente / vulnerabilidade aceita com justificativa: atualização do packtools de 4.16.8 para 4.16.11 (dependência interna do projeto SciELO) — verificação pendente de execução do pipeline
- [ ] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim — link do job:
- [ ] Não aplicável a este PR (justifique): _preencher após execução do pipeline no PR_

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim — confirme que há sanitização/parametrização (prepared statements, escaping, etc.):
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim — HTTPS obrigatório está garantido e o acesso segue o princípio de menor privilégio?
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim (bloquear merge e corrigir antes de prosseguir)