### PR TITLE
Corrige o uso de `XMLWithPre.body_fragment_fingerprint` e `XMLWithPre.body_fingerprint`

### DIFF
--- a/pid_provider/query_params.py
+++ b/pid_provider/query_params.py
@@ -89,13 +89,16 @@ class QueryBuilderPidProviderXML:
         """
         self.xml_adapter = xml_adapter
         # Centraliza o acesso aos dados brutos e normalizados (hashes de 64 chars)
-        # z_body_fragment: fingerprint sha256 do corpo INTEIRO do artigo
+        # z_body: fingerprint sha256 do corpo INTEIRO do artigo
+        # (XMLWithPre.body_fingerprint), acessado direto do xml_with_pre.
+        # z_body_fragment: fingerprint sha256 de um fragmento do artigo
         # (XMLWithPre.body_fragment_fingerprint), acessado direto do
         # xml_with_pre — não requer nenhuma mudança no packtools nem no
         # PidProviderXMLAdapter. É mais robusto que z_partial_body (que
         # é só o primeiro parágrafo não vazio e pode colidir entre
         # artigos diferentes, ex.: rótulos de seção genéricos como
         # "ARTIGO DE REVISÃO").
+        self.z_body = xml_adapter.xml_with_pre.body_fingerprint
         self.z_body_fragment = xml_adapter.xml_with_pre.body_fragment_fingerprint
         self.adapter_data = xml_adapter.data
         self.compare_data = xml_adapter.get_data_to_compare()
@@ -146,7 +149,6 @@ class QueryBuilderPidProviderXML:
         Constrói queries para busca por identificadores (v3, v2, aop_pid, pkg_name, DOI).
         """
         q = Q()
-        other_pids = set()
         
         # PIDs diretos do xml_adapter (não envelopados no data dict)
         v3 = self.xml_adapter.v3
@@ -237,7 +239,7 @@ class QueryBuilderPidProviderXML:
 
         - legado: hash de z_partial_body (primeiro parágrafo não vazio
           do corpo, via xml_adapter.z_partial_body);
-        - atual: fingerprint do corpo INTEIRO do artigo
+        - atual: fingerprint do parcial do artigo
           (xml_with_pre.body_fragment_fingerprint), gravado no mesmo
           campo z_partial_body a partir desta correção (sem necessidade
           de migração/backfill).
@@ -255,7 +257,7 @@ class QueryBuilderPidProviderXML:
         `Q(z_partial_body=None)` (que o Django traduz para IS NULL).
         """
         z_partial_body = self.adapter_data.get("z_partial_body")
-        candidates = set(v for v in (z_partial_body, self.z_body_fragment) if v)
+        candidates = set(v for v in (z_partial_body, self.z_body_fragment, self.z_body) if v)
         if candidates:
             return Q(z_partial_body__in=candidates)
         return Q(z_partial_body__isnull=True)

--- a/pid_provider/tests/test_query_params.py
+++ b/pid_provider/tests/test_query_params.py
@@ -4,9 +4,9 @@ Testes para QueryBuilderPidProviderXML e as funções de comparação
 
 Atualizado para cobrir a correção do falso-match na branch journal-article:
 - QueryBuilderPidProviderXML agora também lê
-  `xml_adapter.xml_with_pre.body_fragment_fingerprint` (fingerprint do
-  corpo INTEIRO do artigo) diretamente do xml_with_pre — sem depender de
-  mudança no PidProviderXMLAdapter/packtools.
+  `xml_adapter.xml_with_pre.body_fragment_fingerprint` (fingerprint parcial do body do artigo)
+   e também `xml_adapter.xml_with_pre.body_fingerprint` (fingerprint corpo INTEIRO do artigo) 
+   diretamente do xml_with_pre.
 - `article_data_query` não usa mais z_partial_body isolado: delega ao
   novo `partial_body_query`, que monta `z_partial_body__in=[...]` com os
   hashes disponíveis (legado + novo fingerprint) ou, quando nenhum dos
@@ -48,6 +48,7 @@ def make_xml_adapter(
     collab=None,
     links=None,
     partial_body=None,
+    body_fingerprint=None,
     body_fragment_fingerprint=None,
 ):
     """
@@ -68,6 +69,7 @@ def make_xml_adapter(
     adapter.sps_pkg_name = sps_pkg_name
     adapter.order = order
     adapter.xml_with_pre.deprecated_sps_pkg_name_list = deprecated_sps_pkg_name_list or []
+    adapter.xml_with_pre.body_fingerprint = body_fingerprint
     adapter.xml_with_pre.body_fragment_fingerprint = body_fragment_fingerprint
     adapter.xml_with_pre.get_article_data.return_value = {
         "article_titles": article_titles or [],
@@ -286,23 +288,23 @@ class PartialBodyQueryTests(SimpleTestCase):
     def test_uses_in_with_only_body_fragment_fingerprint(self):
         adapter = make_xml_adapter(
             data={},
-            body_fragment_fingerprint="hash-corpo-inteiro",
+            body_fragment_fingerprint="hash-fragmento-do-corpo",
         )
         qbuilder = QueryBuilderPidProviderXML(adapter)
         self.assertEqual(
             qbuilder.partial_body_query,
-            Q(z_partial_body__in=["hash-corpo-inteiro"]),
+            Q(z_partial_body__in=["hash-fragmento-do-corpo"]),
         )
 
     def test_uses_in_with_both_hashes_when_both_present_and_different(self):
         adapter = make_xml_adapter(
             data={"z_partial_body": "hash-legado"},
-            body_fragment_fingerprint="hash-corpo-inteiro",
+            body_fragment_fingerprint="hash-fragmento-do-corpo",
         )
         qbuilder = QueryBuilderPidProviderXML(adapter)
         self.assertEqual(
             qbuilder.partial_body_query,
-            Q(z_partial_body__in=["hash-legado", "hash-corpo-inteiro"]),
+            Q(z_partial_body__in={"hash-legado", "hash-fragmento-do-corpo"}),
         )
 
     def test_deduplicates_when_both_hashes_are_equal(self):
@@ -330,6 +332,55 @@ class PartialBodyQueryTests(SimpleTestCase):
             qbuilder.partial_body_query, Q(z_partial_body__in=(None, None))
         )
 
+    def test_combines_textual_fields_with_all_three_body_hashes(self):
+        """
+        article_data_query propaga corretamente o candidato adicional
+        body_fingerprint (corpo inteiro) através de partial_body_query,
+        junto com z_partial_body legado e body_fragment_fingerprint.
+        """
+        adapter = make_xml_adapter(
+            data={
+                "z_surnames": "Silva",
+                "z_collab": None,
+                "z_links": None,
+                "z_partial_body": "hash-legado",
+            },
+            body_fragment_fingerprint="hash-fragmento-do-corpo",
+            body_fingerprint="hash-corpo-inteiro",
+        )
+        qbuilder = QueryBuilderPidProviderXML(adapter)
+        expected = Q(z_surnames="Silva", z_collab=None, z_links=None) & Q(
+            z_partial_body__in={
+                "hash-legado",
+                "hash-fragmento-do-corpo",
+                "hash-corpo-inteiro",
+            }
+        )
+        self.assertEqual(qbuilder.article_data_query, expected)
+
+    def test_two_articles_with_same_legacy_hash_but_different_body_fingerprint_differ(self):
+        """
+        Regressão direta do incidente original: dois artigos com o mesmo
+        rótulo genérico em z_partial_body legado (ex. "ARTIGO DE REVISÃO")
+        mas com body_fingerprint (corpo inteiro) diferentes devem produzir
+        queries distintas — o falso-positivo de match não deve mais ocorrer.
+        """
+        adapter_a = make_xml_adapter(
+            data={"z_partial_body": "rotulo-generico-artigo-revisao"},
+            body_fragment_fingerprint=None,
+            body_fingerprint="hash-corpo-artigo-a",
+        )
+        adapter_b = make_xml_adapter(
+            data={"z_partial_body": "rotulo-generico-artigo-revisao"},
+            body_fragment_fingerprint=None,
+            body_fingerprint="hash-corpo-artigo-b",
+        )
+        qbuilder_a = QueryBuilderPidProviderXML(adapter_a)
+        qbuilder_b = QueryBuilderPidProviderXML(adapter_b)
+        self.assertNotEqual(
+            qbuilder_a.article_data_query, qbuilder_b.article_data_query
+        )
+
 
 class ArticleDataQueryTests(SimpleTestCase):
     """
@@ -346,11 +397,11 @@ class ArticleDataQueryTests(SimpleTestCase):
                 "z_links": None,
                 "z_partial_body": "hash-legado",
             },
-            body_fragment_fingerprint="hash-corpo-inteiro",
+            body_fragment_fingerprint="hash-fragmento-do-corpo",
         )
         qbuilder = QueryBuilderPidProviderXML(adapter)
         expected = Q(z_surnames="Silva", z_collab=None, z_links=None) & Q(
-            z_partial_body__in=["hash-legado", "hash-corpo-inteiro"]
+            z_partial_body__in={"hash-legado", "hash-fragmento-do-corpo"}
         )
         self.assertEqual(qbuilder.article_data_query, expected)
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -90,7 +90,7 @@ iso639-lang==2.6.3  # Mantendo versão maior
 # SciELO Specific Packages
 # ========================================
 # Using specific versions for stability
--e git+https://github.com/scieloorg/packtools.git@4.16.8#egg=packtools
+-e git+https://github.com/scieloorg/packtools.git@4.16.11#egg=packtools
 -e git+https://github.com/scieloorg/scielo_scholarly_data#egg=scielo_scholarly_data
 -e git+https://github.com/scieloorg/opac_schema.git@v2.66#egg=opac_schema
 -e git+https://github.com/scieloorg/scielo_migration.git@1.10.8#egg=scielo_classic_website


### PR DESCRIPTION
## O que esse PR faz?
Corrige o falso-positivo de match em `QueryBuilderPidProviderXML.partial_body_query` causado por um bug em `XMLWithPre.body_fragment_fingerprint`, que retornava o fingerprint do corpo **INTEIRO** do artigo em vez do fingerprint de um **fragmento**. Isso permitia colisão entre artigos diferentes que compartilham rótulos de seção genéricos no início do corpo (ex.: "ARTIGO DE REVISÃO"), já que o hash legado `z_partial_body` é calculado apenas a partir do primeiro parágrafo não vazio.

A correção foi feita em duas frentes:
1. **packtools** (dependência externa, atualizada para `4.16.11`): `XMLWithPre` passa a expor dois atributos distintos — `body_fingerprint` (corpo INTEIRO) e `body_fragment_fingerprint` (fragmento, agora corrigido).
2. **`pid_provider/query_params.py`**: `QueryBuilderPidProviderXML` passa a ler ambos os atributos (`self.z_body` e `self.z_body_fragment`) e considerá-los como candidatos independentes em `partial_body_query`, junto com o hash legado `z_partial_body`, sem exigir migração/backfill dos registros já existentes.

## Onde a revisão poderia começar?
`pid_provider/query_params.py`, método `partial_body_query` (e o construtor `__init__` da classe `QueryBuilderPidProviderXML`, onde `self.z_body` e `self.z_body_fragment` são definidos).

## Como este poderia ser testado manualmente?
1. Atualizar a dependência packtools conforme `requirements/base.txt` (`4.16.11`).
2. Rodar a suíte de testes: `python manage.py test pid_provider.tests.test_query_params`.
3. Opcionalmente, simular em shell dois XMLs de artigos diferentes com o mesmo primeiro parágrafo genérico e corpos distintos, gerando via `XMLWithPre` os fingerprints, e verificar que `QueryBuilderPidProviderXML(...).partial_body_query` produz condições `z_partial_body__in` distintas para cada um (não deve haver match cruzado ao consultar `PidProviderXML.objects.filter(...)`).

## Algum cenário de contexto que queira dar?
Esta correção resolve um incidente de produção em que artigos distintos, com seção inicial de rótulo genérico (comum em editoriais/artigos de revisão), estavam sendo indevidamente associados a um mesmo registro `PidProviderXML` durante o processo de re-ingestão/atualização de XML, devido à imprecisão do hash de corpo parcial. A solução mantém retrocompatibilidade: registros antigos que gravaram no campo `z_partial_body` tanto o formato legado quanto o formato (bugado) anterior de `body_fragment_fingerprint` continuam sendo encontrados, pois todos os hashes conhecidos entram como candidatos no `IN`.

## Screenshots
Não aplicável (mudança de lógica de backend, sem interface gráfica).

## Quais são os tickets relevantes?
Relacionado à issue de correção do falso-positivo de match em `PidProviderXML` (falso-positivo de `QueryDocumentMultipleObjectsReturnedError`). 

Fixes #1039

## Referências
- packtools `4.16.11`: https://github.com/scieloorg/packtools (correção de `XMLWithPre.body_fragment_fingerprint`)
- Documentação interna sobre `NULL = NULL` ser `UNKNOWN` em SQL (motivação do fallback `z_partial_body__isnull=True`)

---
## Segurança da informação (NSI.04)
> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim — descreva os controles de proteção aplicados (criptografia, mascaramento, anonimização, etc.):
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim — descreva o que mudou e por quê:
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [x] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
  - [ ] Verificado e aprovado
  - [ ] Pendente / vulnerabilidade aceita com justificativa: atualização de versão do packtools (`4.16.8` → `4.16.11`), dependência já utilizada no projeto; pendente validação formal via SBOM/Trivy no pipeline de CI.
- [ ] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim — link do job:
- [ ] Não aplicável a este PR (justifique):

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim — confirme que há sanitização/parametrização (prepared statements, escaping, etc.):
- [x] Não — as queries são construídas via Django ORM (`Q` objects), sem concatenação de strings SQL.

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim — HTTPS obrigatório está garantido e o acesso segue o princípio de menor privilégio?
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim (bloquear merge e corrigir antes de prosseguir)