### PR TITLE
Melhorias na área administrativa de journal e institution, na coleta e na publicação

### DIFF
--- a/institution/wagtail_hooks.py
+++ b/institution/wagtail_hooks.py
@@ -24,11 +24,9 @@ class InstitutionViewSet(SnippetViewSet):
     )
     search_fields = (
         "name",
+    )
+    list_filter = (
         "institution_type",
-        "creator",
-        "updated",
-        "created",
-        "updated_by",
     )
     list_export = (
         "name",

--- a/journal/models.py
+++ b/journal/models.py
@@ -272,7 +272,7 @@ class Journal(CommonControlField, ClusterableModel):
     panels_institution = [
         InlinePanel("owner", label=_("Owner")),
         InlinePanel("publisher", label=_("Publisher")),
-        InlinePanel("sponsor", label=_("Owner")),
+        InlinePanel("sponsor", label=_("Sponsor")),
     ]
 
     panels_mission = [

--- a/journal/models.py
+++ b/journal/models.py
@@ -269,23 +269,20 @@ class Journal(CommonControlField, ClusterableModel):
         FieldPanel("core_synchronized"),
     ]
 
-    panels_owner = [
-        InlinePanel("owner", label=_("Owner"), classname="collapsed"),
-    ]
-
-    panels_publisher = [
-        InlinePanel("publisher", label=_("Publisher"), classname="collapsed"),
+    panels_institution = [
+        InlinePanel("owner", label=_("Owner")),
+        InlinePanel("publisher", label=_("Publisher")),
+        InlinePanel("sponsor", label=_("Owner")),
     ]
 
     panels_mission = [
-        InlinePanel("mission", label=_("Mission"), classname="collapsed"),
+        InlinePanel("mission", label=_("Mission")),
     ]
 
     edit_handler = TabbedInterface(
         [
             ObjectList(panels_identification, heading=_("Identification")),
-            ObjectList(panels_owner, heading=_("Owners")),
-            ObjectList(panels_publisher, heading=_("Publisher")),
+            ObjectList(panels_institution, heading=_("Institutions")),
             ObjectList(panels_mission, heading=_("Mission")),
         ]
     )

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -1468,7 +1468,7 @@ msgstr "Propietario"
 
 #: journal/models.py:277 journal/models.py:288
 msgid "Publisher"
-msgstr "Editor"
+msgstr "Publicador"
 
 #: journal/models.py:281 journal/models.py:289
 msgid "Mission"

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -1468,7 +1468,7 @@ msgstr "Propietario"
 
 #: journal/models.py:277 journal/models.py:288
 msgid "Publisher"
-msgstr "Editor"
+msgstr "Publicador"
 
 #: journal/models.py:281 journal/models.py:289
 msgid "Mission"

--- a/proc/source_core_api.py
+++ b/proc/source_core_api.py
@@ -398,10 +398,21 @@ def process_journal_result(
     for item in result.get("subject") or []:
         journal.subject.add(Subject.create_or_update(user, item["value"]))
 
-    # Processa publishers
+    institution_names = set()
     for item in result.get("publisher") or []:
-        institution = Institution.get_or_create(
-            inst_name=item["name"],
+        institution_names.add(item["name"])
+
+    # Processa owners
+    for item in result.get("owner") or []:
+        institution_names.add(item["name"])
+
+    for item in result.get("sponsor") or []:
+        institution_names.add(item["name"])
+
+    institutions = {}
+    for name in institution_names:
+        institutions[name] = Institution.get_or_create(
+            inst_name=name,
             inst_acronym=None,
             level_1=None,
             level_2=None,
@@ -409,31 +420,25 @@ def process_journal_result(
             location=None,
             user=user,
         )
+
+    # Processa publishers
+    for item in result.get("publisher") or []:
+        institution = institutions.get(item["name"])
+        if not institution:
+            continue
         journal.publisher.add(Publisher.create_or_update(user, journal, institution))
 
     # Processa owners
     for item in result.get("owner") or []:
-        institution = Institution.get_or_create(
-            inst_name=item["name"],
-            inst_acronym=None,
-            level_1=None,
-            level_2=None,
-            level_3=None,
-            location=None,
-            user=user,
-        )
+        institution = institutions.get(item["name"])
+        if not institution:
+            continue
         journal.owner.add(Owner.create_or_update(user, journal, institution))
 
     for item in result.get("sponsor") or []:
-        institution = Institution.get_or_create(
-            inst_name=item["name"],
-            inst_acronym=None,
-            level_1=None,
-            level_2=None,
-            level_3=None,
-            location=None,
-            user=user,
-        )
+        institution = institutions.get(item["name"])
+        if not institution:
+            continue
         journal.sponsor.add(Sponsor.create_or_update(user, journal, institution))
 
     no_lang = []

--- a/publication/api/journal.py
+++ b/publication/api/journal.py
@@ -199,6 +199,8 @@ class JournalPayload:
 
     def add_sponsor(self, sponsor):
         # Sponsors
+        if not sponsor:
+            return
         self.data["sponsors"].append({"name": sponsor})
 
     @staticmethod
@@ -299,5 +301,7 @@ class JournalPayload:
         self.data["is_public"] = availability_status == "C"
 
     def add_publisher(self, name):
+        if not name:
+            return
         self.data.setdefault("institution_responsible_for", [])
         self.data["institution_responsible_for"].append({"name": name})

--- a/publication/utils/journal.py
+++ b/publication/utils/journal.py
@@ -76,17 +76,19 @@ def build_journal(
     for sponsor in journal.sponsor.all():
         builder.add_sponsor(sponsor.institution.name)
 
-    names = []
+    names = set()
     for item in journal.owner.all():
         name = item.institution.name
-        if name not in names:
-            names.append(name)
-            builder.add_publisher(name)
+        if not name:
+            continue
+        names.add(name)
+        builder.add_publisher(name)
     for item in journal.publisher.all():
         name = item.institution.name
-        if name not in names:
-            names.append(name)
-            builder.add_publisher(name)
+        if not name:
+            continue
+        names.add(name)
+        builder.add_publisher(name)
 
     builder.add_thematic_scopes(
         subject_categories=journal.wos_areas,

--- a/upload/publication.py
+++ b/upload/publication.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+import traceback
 
 from django.contrib.auth import get_user_model
 
@@ -62,13 +63,17 @@ def ensure_published_journal(journal_proc, website, user, api_data, force_update
     Raises:
         PublicationError: Se ocorrer erro na publicação
     """
-
-    try:
-        if not force_update:
+    if not force_update:
+        try:
             journal_url = (
                 f"{website.url}/scielo.php?pid={journal_proc.pid}&script=sci_serial"
             )
             return {"journal": str(journal_proc), "published": bool(fetch_data(journal_url))}
+        except Exception:
+            pass
+
+    try:
+        response = {}
         response = journal_proc.publish(
             user,
             publish_journal,
@@ -80,9 +85,14 @@ def ensure_published_journal(journal_proc, website, user, api_data, force_update
         if not response:
             raise Exception(f"Unable to publish journal {journal_proc}")
         response["published"] = response.get("completed")
+        if not response["published"]:
+            raise Exception(f"Unable to publish journal {journal_proc}")
         return response
     except Exception as e:
-        return {"error": f"journal {journal_proc} is not published. {e}"}
+        response = response or {}
+        if not response.get("error"):
+            response["error"] = traceback.format_exc()
+        return response
 
 
 def ensure_published_issue(issue_proc, website, user, api_data, force_update=None):
@@ -108,6 +118,10 @@ def ensure_published_issue(issue_proc, website, user, api_data, force_update=Non
                 f"{website.url}/scielo.php?pid={issue_proc.pid}&script=sci_issuetoc"
             )
             return {"issue": str(issue_proc), "published": bool(fetch_data(issue_url))}
+    except Exception as e:
+        pass
+    try:
+        response = None
         response = issue_proc.publish(
             user,
             publish_issue,
@@ -119,10 +133,14 @@ def ensure_published_issue(issue_proc, website, user, api_data, force_update=Non
         if not response:
             raise Exception(f"Unable to publish issue {issue_proc}")
         response["published"] = response.get("completed")
+        if not response["published"]:
+            raise Exception(f"Unable to publish issue {issue_proc}")
         return response
     except Exception as e:
-        return {"error": f"issue {issue_proc} is not published. {e}"}
-
+        response = response or {}
+        if not response.get("error"):
+            response["error"] = traceback.format_exc()
+        return response
 
 
 def publish_article_on_collection_websites(

--- a/upload/tasks.py
+++ b/upload/tasks.py
@@ -637,12 +637,11 @@ def task_upload_workflow_publish_article(
     except Exception as e:
         exc_type, exc_value, exc_traceback = sys.exc_info()
         UnexpectedEvent.create(
+            item=str(manager),
+            action="task_upload_workflow_publish_article",
             e=e,
             exc_traceback=exc_traceback,
             detail=dict(
-                task="task_upload_workflow_publish_article",
-                item=str(manager),
-                upload_package_id=upload_package_id,
                 websites=websites,
             ),
         )


### PR DESCRIPTION
## O que esse PR faz?
Unifica os painéis de Owner/Publisher/Sponsor do Journal em uma única aba no Wagtail admin; corrige a tradução de "Publisher" (pt_BR/es); evita criação duplicada de instituições ao processar dados do Core (`proc/source_core_api.py`); impede que sponsors/publishers com nome vazio ou nulo entrem no payload de publicação (`publication/api/journal.py`, `publication/utils/journal.py`); melhora o tratamento de erro na publicação de journal/issue, preservando o traceback completo (`upload/publication.py`); e corrige os parâmetros de `UnexpectedEvent.create` e uma chamada `.delay()` quebrada em `upload/tasks.py`.

## Onde a revisão poderia começar?

`proc/source_core_api.py` (`process_journal_result`), seguido de `publication/utils/journal.py` (`build_journal`) e `upload/publication.py`.

## Como este poderia ser testado manualmente?

1. Publicar um artigo, clicando para forçar a publicação de journal e issue, isso vai disparar tarefas como `task_upload_workflow_publish_article` via `task_publish_issue_articles`
2. Confirmar no admin que Owner/Publisher/Sponsor aparecem juntos na aba "Institutions", expandidos por padrão, e que "Publisher" traduz como "Publicador".
3. Sincronizar um journal do Core cujo publisher/owner/sponsor compartilhem a mesma instituição e confirmar que não há duplicação em `Institution`.
4. Confirmar que instituições com nome vazio não entram no payload.


## Algum cenário de contexto que queira dar?
Indique um contexto onde as modificações se fazem necessárias ou passe informações que contextualizam o revisor a fim de facilitar o entendimento da funcionalidade.

Problema original: ao publicar um artigo, o journal é detectado como não publicado e a tentativa de publicá-lo falha porque o payload chega com `name: null` em alguma instituição — os dados de origem no Core estão corretos. Quando o journal ainda não existe no Upload, a criação ocorre sem problema; a falha parece restrita ao fluxo de **atualização** de um journal já existente, o que é intrigante porque `core_synchronized` é gravado como `True` ao final, sugerindo sucesso mesmo com o dado incompleto. **A causa raiz ainda não foi identificada.**

As mudanças aqui (guard clauses no payload, deduplicação de instituições, traceback completo) são mitigações que evitam o payload defeituoso e facilitam a investigação — não são o diagnóstico final. Vale comparar o caminho de criação vs. atualização em `process_journal_result` para entender onde a instituição perde o `name`.

## Screenshots
Quando aplicável e se fizer possível, adicione screenshots que remetem à situação gráfica do problema que o pull request resolve.

<img width="839" height="621" alt="Captura de Tela 2026-08-05 às 11 05 27" src="https://github.com/user-attachments/assets/00f75d56-4f71-45bb-9aa0-4cd0b399c80a" />

## Quais são os tickets relevantes?
n/a

## Referências
n/a

---
## Segurança da informação (NSI.04)
> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim — descreva os controles de proteção aplicados (criptografia, mascaramento, anonimização, etc.):
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim — descreva o que mudou e por quê:
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
  - [ ] Verificado e aprovado
  - [ ] Pendente / vulnerabilidade aceita com justificativa:
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim — link do job:
- [ ] Não aplicável a este PR (justifique):

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim — confirme que há sanitização/parametrização (prepared statements, escaping, etc.):
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim — HTTPS obrigatório está garantido e o acesso segue o princípio de menor privilégio?
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim (bloquear merge e corrigir antes de prosseguir)