### PR TITLE
Corrige ausência de retorno de JournalCollection.create_or_update

### DIFF
--- a/journal/models.py
+++ b/journal/models.py
@@ -955,9 +955,7 @@ class JournalCollection(CommonControlField, ClusterableModel):
     @classmethod
     def create_or_update(cls, user, collection, journal):
         try:
-            obj = cls.get(collection, journal)
-            obj.updated_by = obj.updated_by or user
-            obj.save()
+            return cls.get(collection, journal)
         except cls.DoesNotExist:
             return cls.create(user, collection, journal)
 


### PR DESCRIPTION
## O que esse PR faz?

Corrige um bug onde o método `JournalCollection.create_or_update` retornava `None` quando o registro já existia, pois o bloco `try` executava apenas `obj.save()` sem um comando `return`.

Essa ausência de retorno fazia com que o objeto `journal_collection` ficasse `None` nos fluxos de sincronização do Core, quebrando a execução subsequente de `JournalHistory.create_or_update` (falha ao atualizar o histórico de status `status_history`).

Com esta alteração, o método passa a retornar diretamente a instância recuperada por `cls.get(collection, journal)`, pois não há necessidade de nenhuma mudança.

## Onde a revisão poderia começar?

A revisão deve focar em:

* `journal/models.py`: linha ~958, no método `@classmethod create_or_update` da classe `JournalCollection`.

## Como este poderia ser testado manualmente?

1. Execute a sincronização de dados com a API do Core através do método `fetch_and_create_journal`.
2. Certifique-se de que o processo execute para um periódico/coleção que já possua registro existente e histórico associado (`journal_history`).
3. Verifique que `JournalCollection.create_or_update` agora retorna a instância corretamente (ao invés de `None`) e que os registros em `JournalHistory` são criados/atualizados sem exceções.

## Algum cenário de contexto que queira dar?

No trecho de código abaixo:

```python
journal_collection = JournalCollection.create_or_update(user, collection, journal)
for jh in item.get("journal_history") or []:
    JournalHistory.create_or_update(...)

```

A variável `journal_collection` recebia `None` porque o ramo de atualização do `JournalCollection.create_or_update` executava a alteração/save mas omitia a instrução `return`. Ao ajustar para `return cls.get(collection, journal)`, garantimos que uma instância válida seja sempre entregue.

## Screenshots

N/A (Alteração puramente de lógica no backend).

## Quais são os tickets relevantes?

*(Adicione o link ou número da issue aqui, ex: #1234)*

## Referências

* N/A

---

## Segurança da informação (NSI.04)

> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**

* [ ] Sim — descreva os controles de proteção aplicados (criptografia, mascaramento, anonimização, etc.):
* [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**

* [ ] Sim — descreva o que mudou e por quê:
* [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**

* [ ] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
* [ ] Verificado e aprovado
* [ ] Pendente / vulnerabilidade aceita com justificativa:


* [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**

* [x] Sim — link do job: *(Adicione o link da pipeline aqui)*
* [ ] Não aplicável a este PR (justifique):

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**

* [ ] Sim — confirme que há sanitização/parametrização (prepared statements, escaping, etc.):
* [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**

* [ ] Sim — HTTPS obrigatório está garantido e o acesso segue o princípio de menor privilégio?
* [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**

* [x] Não, nenhum segredo foi commitado
* [ ] Sim (bloquear merge e corrigir antes de prosseguir)