### PR TITLE
Corrige um bug de seleção de artigos para a pipeline de migração e publicação de artigos

### DIFF
--- a/proc/models.py
+++ b/proc/models.py
@@ -2393,69 +2393,9 @@ class ArticleProc(BaseProc, ClusterableModel):
             )
 
     @classmethod
-    def select_items_old(
-        cls,
-        qs=None,
-        collection_acron=None,
-        journal_acron=None,
-        issue_folder=None,
-        publication_year=None,
-        issue_proc_id=None,
-        journal_proc_id_list=None,
-        issue_proc_id_list=None,
-        exclude_issue_proc_id_list=None,
-        article_proc_id_list=None,
-        status_list=None,
-        force_update=False,
-        sps_pkg_id_list=None,
-    ):
-        status_list = tracker_choices.get_valid_status(status_list, force_update)
-        journal_proc_id_list = journal_proc_id_list or []
-        issue_proc_id_list = issue_proc_id_list or []
-        exclude_issue_proc_id_list = exclude_issue_proc_id_list or []
-
-        params = {}
-        if sps_pkg_id_list:
-            params["sps_pkg_id__in"] = sps_pkg_id_list
-        if collection_acron:
-            params["collection__acron"] = collection_acron
-        if journal_acron:
-            params["issue_proc__journal_proc__acron"] = journal_acron
-        if journal_proc_id_list:
-            params["issue_proc__journal_proc__id__in"] = journal_proc_id_list
-        if publication_year:
-            params["issue_proc__issue__publication_year"] = publication_year
-        if issue_folder:
-            params["issue_proc__issue_folder"] = issue_folder
-        if issue_proc_id:
-            params["issue_proc__id"] = issue_proc_id
-        if issue_proc_id_list:
-            params["issue_proc__id__in"] = issue_proc_id_list
-        if article_proc_id_list:
-            params["id__in"] = article_proc_id_list
-
-        qs_status = Q()
-        if status_list:
-            qs_status = (
-                Q(migration_status__in=status_list)
-                | Q(xml_status__in=status_list)
-                | Q(sps_pkg_status__in=status_list)
-                | Q(qa_ws_status__in=status_list)
-                | Q(public_ws_status__in=status_list)
-            )
-
-        qs = qs or cls.objects
-        qs = qs.filter(
-            qs_status,
-            **params,
-        )
-        if exclude_issue_proc_id_list:
-            return qs.exclude(issue_proc__id__in=exclude_issue_proc_id_list)
-        return qs
-
-    @classmethod
     def select_items(
         cls,
+        issue_proc_id=None,
         collection_acron_list=None,
         journal_acron_list=None,
         issue_folder=None,
@@ -2471,6 +2411,8 @@ class ArticleProc(BaseProc, ClusterableModel):
             params["collection__acron__in"] = collection_acron_list
         if journal_acron_list:
             params["issue_proc__journal_proc__acron__in"] = journal_acron_list
+        if issue_proc_id:
+            params["issue_proc_id"] = issue_proc_id
 
         qs_status = Q()
         if status_list:

--- a/proc/models.py
+++ b/proc/models.py
@@ -2393,7 +2393,7 @@ class ArticleProc(BaseProc, ClusterableModel):
             )
 
     @classmethod
-    def select_items(
+    def select_items_old(
         cls,
         qs=None,
         collection_acron=None,
@@ -2452,6 +2452,74 @@ class ArticleProc(BaseProc, ClusterableModel):
         if exclude_issue_proc_id_list:
             return qs.exclude(issue_proc__id__in=exclude_issue_proc_id_list)
         return qs
+
+    @classmethod
+    def select_items(
+        cls,
+        collection_acron_list=None,
+        journal_acron_list=None,
+        issue_folder=None,
+        publication_year=None,
+        status_list=None,
+    ):
+        params = {}
+        if publication_year:
+            params["issue_proc__issue__publication_year"] = publication_year
+        if issue_folder:
+            params["issue_proc__issue_folder"] = issue_folder
+        if collection_acron_list:
+            params["collection__acron__in"] = collection_acron_list
+        if journal_acron_list:
+            params["issue_proc__journal_proc__acron__in"] = journal_acron_list
+
+        qs_status = Q()
+        if status_list:
+            qs_status = (
+                Q(migration_status__in=status_list)
+                | Q(xml_status__in=status_list)
+                | Q(sps_pkg_status__in=status_list)
+                | Q(qa_ws_status__in=status_list)
+                | Q(public_ws_status__in=status_list)
+            )
+
+        return cls.objects.filter(
+            qs_status,
+            **params,
+        )
+
+    @classmethod
+    def get_issue_proc_ids(
+        cls,
+        collection_acron_list=None,
+        journal_acron_list=None,
+        issue_folder=None,
+        publication_year=None,
+        status_list=None,
+        force_migrate_document_records=None,
+        force_migrate_document_files=None,
+    ):
+        article_issue_proc_id_list = set(
+            cls.select_items(
+                collection_acron_list=collection_acron_list,
+                journal_acron_list=journal_acron_list,
+                issue_folder=issue_folder,
+                publication_year=publication_year,
+                status_list=status_list,
+            ).values_list("issue_proc_id", flat=True)
+        )
+        issue_proc_id_list = set(
+            IssueProc.select_items(
+                collection_acron_list=collection_acron_list,
+                journal_acron_list=journal_acron_list,
+                issue_folder=issue_folder,
+                publication_year=publication_year,
+                article_status_list=status_list,
+                force_migrate_document_records=force_migrate_document_records,
+                force_migrate_document_files=force_migrate_document_files,
+            ).values_list("id", flat=True)
+        )
+        # uniao dos dois resultados
+        return issue_proc_id_list | article_issue_proc_id_list
 
     @classmethod
     def filter_by_status(cls, STATUS):

--- a/proc/models.py
+++ b/proc/models.py
@@ -2488,7 +2488,7 @@ class ArticleProc(BaseProc, ClusterableModel):
         )
 
     @classmethod
-    def get_issue_proc_ids(
+    def get_journal_and_issue_proc_ids(
         cls,
         collection_acron_list=None,
         journal_acron_list=None,
@@ -2498,16 +2498,33 @@ class ArticleProc(BaseProc, ClusterableModel):
         force_migrate_document_records=None,
         force_migrate_document_files=None,
     ):
-        article_issue_proc_id_list = set(
+        """
+        Retorna os IDs de JournalProc e IssueProc agrupados por periódico.
+
+        Realiza a busca combinada em ArticleProc e IssueProc aplicando os
+        filtros informados e agrupa os IDs de fascículos (issue_proc_id) em
+        um conjunto mapeado pela tupla identificadora do periódico
+        (journal_proc_id, journal_acron).
+
+        Returns:
+            dict: Dicionário no formato:
+                {
+                    (journal_proc_id, journal_acron): {issue_proc_id1, issue_proc_id2, ...},
+                    ...
+                }
+        """
+        list_from_article = set(
             cls.select_items(
                 collection_acron_list=collection_acron_list,
                 journal_acron_list=journal_acron_list,
                 issue_folder=issue_folder,
                 publication_year=publication_year,
                 status_list=status_list,
-            ).values_list("issue_proc_id", flat=True)
+            ).values_list(
+                "issue_proc__journal_proc_id", "issue_proc__journal_proc__acron", "issue_proc_id"
+            )
         )
-        issue_proc_id_list = set(
+        list_from_issue = set(
             IssueProc.select_items(
                 collection_acron_list=collection_acron_list,
                 journal_acron_list=journal_acron_list,
@@ -2516,10 +2533,17 @@ class ArticleProc(BaseProc, ClusterableModel):
                 article_status_list=status_list,
                 force_migrate_document_records=force_migrate_document_records,
                 force_migrate_document_files=force_migrate_document_files,
-            ).values_list("id", flat=True)
+            ).values_list(
+                "journal_proc_id", "journal_proc__acron", "id"
+            )
         )
-        # uniao dos dois resultados
-        return issue_proc_id_list | article_issue_proc_id_list
+        items_to_process = {}
+        items = list_from_issue | list_from_article
+        for journal_proc_id, journal_acron, issue_proc_id in items:
+            items_to_process.setdefault((journal_proc_id, journal_acron), set()).add(
+                issue_proc_id
+            )
+        return items_to_process
 
     @classmethod
     def filter_by_status(cls, STATUS):

--- a/proc/tasks.py
+++ b/proc/tasks.py
@@ -1022,30 +1022,31 @@ def task_migrate_and_publish_articles(
             "total_journals_to_process", total_journals_to_process
         )
 
-        kwargs_ = {}
-        kwargs_.update(task_params)
-        kwargs_.pop("collection_acron_list", None)
-        kwargs_.pop("journal_acron_list", None)
-
         task_exec.total_to_process = total_journals_to_process
         total_processed = 0
-        for key in items_to_process.keys():
-            journal_proc_id, journal_acron = key
+        for (journal_proc_id, journal_acron), issue_proc_id_list in items_to_process.items():
 
-            kwargs = {}
-            kwargs.update(kwargs_)            
-            kwargs["journal_proc_id"] = journal_proc_id
-            kwargs["journal_acron"] = journal_acron
-            kwargs["issue_proc_id_list"] = items_to_process[key]
-            kwargs["status"] = status
-            
+            task_migrate_and_publish_articles_by_journal.delay(
+                user_id=user_id,
+                username=username,
+                collection_acron=collection_acron,
+                journal_acron=journal_acron,
+                journal_proc_id=journal_proc_id,
+                issue_folder=issue_folder,
+                publication_year=publication_year,
+                issue_proc_id_list=list(issue_proc_id_list),
+                status=status,
+                force_update=force_update,
+                force_import_acron_id_file=force_import_acron_id_file,
+                force_migrate_document_records=force_migrate_document_records,
+                force_migrate_document_files=force_migrate_document_files,
+            )
             total_processed += 1
             task_exec.add_event({
                 "action": "scheduled task_migrate_and_publish_articles_by_journal",
                 "item": journal_acron,
-                "total_issues": len(items_to_process[key])
+                "total_issues": len(issue_proc_id_list)
             })
-            task_migrate_and_publish_articles_by_journal.delay(**kwargs)
 
         task_exec.total_processed = total_processed
         task_exec.finish()

--- a/proc/tasks.py
+++ b/proc/tasks.py
@@ -1077,7 +1077,6 @@ def task_migrate_and_publish_articles_by_journal(
     publication_year=None,
     issue_folder=None,
     status=None,
-    valid_status=None,
     force_update=False,
     force_import_acron_id_file=False,
     force_migrate_document_records=False,
@@ -1111,10 +1110,10 @@ def task_migrate_and_publish_articles_by_journal(
     try:
         if not journal_proc_id:
             raise ValueError("journal_proc_id is required")
-
-        status = tracker_choices.get_valid_status(status, force_update)
         journal_proc = JournalProc.objects.get(id=journal_proc_id)
+
         user = _get_user(user_id, username)
+        status = tracker_choices.get_valid_status(status, force_update)
 
         task_exec.journal_proc_id = journal_proc_id
         task_exec.update_total_status(("Start"))
@@ -1142,53 +1141,10 @@ def task_migrate_and_publish_articles_by_journal(
             journal_proc.collection, "issue", "PUBLIC"
         )
         total_processed = 0
-        total_to_process = 0
+        total_to_process = len(issue_proc_id_list)
 
-        issue_proc_and_related_article_proc_id_list = {}
-        if issue_proc_id_list:
-            task_exec.add_number("total issue_proc_id_list", len(issue_proc_id_list))
-            selected_article_proc_items = []
-        else:
-            selected_issue_procs = IssueProc.select_items(
-                journal_proc_id_list=[journal_proc_id],
-                force_migrate_document_records=force_migrate_document_records,
-                force_migrate_document_files=force_migrate_document_files,
-                article_status_list=tracker_choices.PROGRESS_STATUS_REGULAR_TODO,
-            )
-            issue_proc_id_list = list(
-                selected_issue_procs.values_list("id", flat=True)
-            )
-            task_exec.add_number("total issue_proc todo or reproc", len(issue_proc_id_list))
-            selected_article_proc_items = (
-                ArticleProc.select_items_old(
-                    journal_proc_id_list=[journal_proc_id],
-                    exclude_issue_proc_id_list=issue_proc_id_list,
-                    status_list=status,
-                    force_update=force_update,
-                )
-                .values_list("issue_proc_id", "id")
-                .distinct()
-            )
-            task_exec.add_number("total articles todo or reproc", selected_article_proc_items.count())
-
-        issue_proc_and_related_article_proc_id_list = {
-            issue_proc_id: []
-            for issue_proc_id in (issue_proc_id_list or [])
-        }
-        if selected_article_proc_items:
-            for issue_proc_id, article_proc_id in selected_article_proc_items:
-                issue_proc_and_related_article_proc_id_list.setdefault(
-                    issue_proc_id, []
-                ).append(article_proc_id)
-
-        total_to_process = len(issue_proc_and_related_article_proc_id_list)
-        task_exec.add_number("total issue_proc todo or reproc", total_to_process)
-
-        for (
-            issue_proc_id,
-            article_proc_id_list,
-        ) in issue_proc_and_related_article_proc_id_list.items():
-            total_processed += 1
+        for issue_proc_id in issue_proc_id_list:
+            
             # executa sincronamente a eliminação de registros ArticleProc e Article cujo conteúdo é defeituoso
             response = task_exclude_invalid_issue_articles(
                 issue_proc_id=issue_proc_id,
@@ -1201,7 +1157,6 @@ def task_migrate_and_publish_articles_by_journal(
                 user_id=user_id,
                 username=username,
                 issue_proc_id=issue_proc_id,
-                article_proc_id_list=article_proc_id_list,
                 status=status,
                 force_update=force_update,
                 force_migrate_document_records=force_migrate_document_records,
@@ -1210,6 +1165,7 @@ def task_migrate_and_publish_articles_by_journal(
                 public_api_data=public_api_data,
                 exclude_invalid_articles_response=response,
             )
+            total_processed += 1
         task_exec.total_processed = total_processed
         task_exec.total_to_process = total_to_process
         task_exec.finish()

--- a/proc/tasks.py
+++ b/proc/tasks.py
@@ -998,7 +998,6 @@ def task_migrate_and_publish_articles(
         params=task_params,
     )
     try:
-        params = {}
         journal_acron_list = journal_acron_list or []
         if journal_acron:
             journal_acron_list += [journal_acron]
@@ -1006,36 +1005,17 @@ def task_migrate_and_publish_articles(
         if collection_acron:
             collection_acron_list += [collection_acron]
 
-        items_to_process = {}
         status = tracker_choices.get_valid_status(status, force_update)
 
-        if publication_year or issue_folder:
-            selected_issue_procs = IssueProc.select_items(
-                collection_acron_list=collection_acron_list,
-                journal_acron_list=journal_acron_list,
-                publication_year=publication_year,
-                issue_folder=issue_folder,
-                force_migrate_document_records=force_migrate_document_records,
-                force_migrate_document_files=force_migrate_document_files,
-                article_status_list=tracker_choices.PROGRESS_STATUS_REGULAR_TODO,
-            )
-            issue_proc_ids = selected_issue_procs.values_list(
-                "journal_proc_id", "journal_proc__acron", "id"
-            ).distinct()
-            for journal_proc_id, journal_acron, issue_proc_id in issue_proc_ids:
-                items_to_process.setdefault((journal_proc_id, journal_acron), []).append(
-                    issue_proc_id
-                )
-        else:
-            journal_proc_ids = JournalProc.select_items(
-                collection_acron_list=collection_acron_list,
-                journal_acron_list=journal_acron_list,
-                has_issue_proc=True,
-            ).values_list("id", "acron")
-            items_to_process = {
-                (journal_proc_id, journal_acron): None
-                for journal_proc_id, journal_acron in journal_proc_ids
-            }
+        items_to_process = ArticleProc.get_journal_and_issue_proc_ids(
+            collection_acron_list=collection_acron_list,
+            journal_acron_list=journal_acron_list,
+            publication_year=publication_year,
+            issue_folder=issue_folder,
+            force_migrate_document_records=force_migrate_document_records,
+            force_migrate_document_files=force_migrate_document_files,
+            status_list=status,
+        )
 
         total_journals_to_process = len(items_to_process)
         task_exec.add_number(
@@ -1060,6 +1040,11 @@ def task_migrate_and_publish_articles(
             kwargs["status"] = status
             
             total_processed += 1
+            task_exec.add_event({
+                "action": "scheduled task_migrate_and_publish_articles_by_journal",
+                "item": journal_acron,
+                "total_issues": len(items_to_process[key])
+            })
             task_migrate_and_publish_articles_by_journal.delay(**kwargs)
 
         task_exec.total_processed = total_processed

--- a/proc/tasks.py
+++ b/proc/tasks.py
@@ -1025,7 +1025,7 @@ def task_migrate_and_publish_articles(
         task_exec.total_to_process = total_journals_to_process
         total_processed = 0
         for (journal_proc_id, journal_acron), issue_proc_id_list in items_to_process.items():
-
+            issue_proc_id_list = list(issue_proc_id_list)
             task_migrate_and_publish_articles_by_journal.delay(
                 user_id=user_id,
                 username=username,
@@ -1034,7 +1034,7 @@ def task_migrate_and_publish_articles(
                 journal_proc_id=journal_proc_id,
                 issue_folder=issue_folder,
                 publication_year=publication_year,
-                issue_proc_id_list=list(issue_proc_id_list),
+                issue_proc_id_list=issue_proc_id_list,
                 status=status,
                 force_update=force_update,
                 force_import_acron_id_file=force_import_acron_id_file,
@@ -1181,7 +1181,6 @@ def task_migrate_and_publish_articles_by_issue(
     user_id=None,
     username=None,
     issue_proc_id=None,
-    article_proc_id_list=None,
     status=None,
     force_update=False,
     force_migrate_document_records=False,
@@ -1202,7 +1201,6 @@ def task_migrate_and_publish_articles_by_issue(
         "user_id": user_id,
         "username": username,
         "issue_proc_id": issue_proc_id,
-        "article_proc_id_list": article_proc_id_list,
         "status": status,
         "force_update": force_update,
         "force_migrate_document_records": force_migrate_document_records,
@@ -1227,42 +1225,33 @@ def task_migrate_and_publish_articles_by_issue(
 
         task_exec.add_event(exclude_invalid_articles_response)
 
-        total_articles_to_process = 0
-        article_procs = None
-        if article_proc_id_list:
-            article_procs = ArticleProc.objects.select_related(
-                "issue_proc",
-            ).filter(id__in=article_proc_id_list)
-        else:
-            # cria ou atualiza ArticleProc
-            response = issue_proc.migrate_document_records(
-                user, force_migrate_document_records
-            )
-            task_exec.add_event({"operation": "migrate_document_records", "response": response})
-            task_exec.update_total_status(("Created or updated Article Processing records"), issue_proc_id)
+        # a partir do IdFileRecord, cria ou atualiza ArticleProc
+        response = issue_proc.migrate_document_records(
+            user, force_migrate_document_records
+        )
+        task_exec.add_event({"operation": "migrate_document_records", "response": response})
+        task_exec.update_total_status(("Created or updated Article Processing records"), issue_proc_id)
 
-            # cria ou atualiza MigratedFile
-            response = issue_proc.migrate_document_files(
-                user,
-                force_migrate_document_files,
-                controller.migrate_issue_files,
-            )
-            task_exec.add_event({"operation": "migrate_document_files", "response": response})
-            task_exec.update_total_status(("Created or updated Migrated file records"), issue_proc_id)
+        # cria ou atualiza MigratedFile
+        response = issue_proc.migrate_document_files(
+            user,
+            force_migrate_document_files,
+            controller.migrate_issue_files,
+        )
+        task_exec.add_event({"operation": "migrate_document_files", "response": response})
+        task_exec.update_total_status(("Created or updated Migrated file records"), issue_proc_id)
 
-            article_procs = ArticleProc.select_items_old(
-                issue_proc_id_list=[issue_proc_id],
-                status_list=tracker_choices.get_valid_status(status, force_update),
-                force_update=force_update,
-            )
-        total_articles_to_process = article_procs.count()
-        task_exec.total_to_process = total_articles_to_process
+        article_procs = ArticleProc.select_items(
+            issue_proc_id=issue_proc_id,
+            status_list=None if force_update else status,
+        )
+        task_exec.total_to_process = article_procs.count()
 
         total_processed = 0
         exceptions = {}
         for article_proc in article_procs:
             try:
-                # faz o fluxo completo do artigo: get_xml e cria sps_pkg
+                # executa get_xml, generate_sps_pkg, cria / atualiza Article
                 article = article_proc.migrate_article(user, force_update)
                 total_processed += 1
             except Exception as e:

--- a/proc/tasks.py
+++ b/proc/tasks.py
@@ -1136,6 +1136,8 @@ def task_migrate_and_publish_articles_by_journal(
         fix_publication_status(journal_proc.collection)
         task_exec.update_total_status(("Updated publication status"))
 
+        # a partir de acron.id, cria ou atualiza JournalAcronIdFile e IdFileRecord,
+        # fonte para criar/atualizar ArticleProc
         response = controller.import_journal_acron_id_records(
             user,
             ArticleProc,
@@ -1172,7 +1174,7 @@ def task_migrate_and_publish_articles_by_journal(
             )
             task_exec.add_number("total issue_proc todo or reproc", len(issue_proc_id_list))
             selected_article_proc_items = (
-                ArticleProc.select_items(
+                ArticleProc.select_items_old(
                     journal_proc_id_list=[journal_proc_id],
                     exclude_issue_proc_id_list=issue_proc_id_list,
                     status_list=status,
@@ -1306,9 +1308,9 @@ def task_migrate_and_publish_articles_by_issue(
             task_exec.add_event({"operation": "migrate_document_files", "response": response})
             task_exec.update_total_status(("Created or updated Migrated file records"), issue_proc_id)
 
-            article_procs = ArticleProc.select_items(
+            article_procs = ArticleProc.select_items_old(
                 issue_proc_id_list=[issue_proc_id],
-                status_list=status,
+                status_list=tracker_choices.get_valid_status(status, force_update),
                 force_update=force_update,
             )
         total_articles_to_process = article_procs.count()


### PR DESCRIPTION
## O que esse PR faz?
Corrige um bug na pipeline de migração e publicação de artigos (`proc/models.py` e `proc/tasks.py`) em que alguns `ArticleProc` e `IssueProc` elegíveis para processamento não eram selecionados, dependendo da combinação de filtros informada:

- **Quando nenhum filtro era informado** (nem `journal_acron`, nem `issue_folder`, nem `publication_year`), `task_migrate_and_publish_articles` selecionava periódicos via `JournalProc.select_items(has_issue_proc=True)`, sem aplicar nenhum critério de status de artigo/fascículo nesse nível — a seleção fina de fascículos/artigos ficava inteiramente a cargo de `task_migrate_and_publish_articles_by_journal`, que recalculava `IssueProc.select_items` (com `article_status_list` fixo em `PROGRESS_STATUS_REGULAR_TODO`) e depois `ArticleProc.select_items` com `exclude_issue_proc_id_list`. Esse recálculo interno, isolado do restante do fluxo, é onde artigos elegíveis se perdiam.
- **Quando `status=["BLOCKED"]`** era passado para selecionar `IssueProc` cujo `docs_status` estivesse nesse valor, a consulta de `IssueProc.select_items` não considerava corretamente `docs_status`/`files_status` como critério de status — o filtro de status era resolvido/aplicado apenas em função de `ArticleProc` (via `article_status_list` fixo), não repassando o `status` recebido para o filtro de `docs_status`/`files_status` do próprio `IssueProc`. Como consequência, fascículos com `docs_status="BLOCKED"` não eram retornados.
- A composição "fascículos selecionados" + "artigos avulsos fora desses fascículos" (via `ArticleProc.select_items(exclude_issue_proc_id_list=...)`) usava dois conjuntos de critérios de status distintos e calculados separadamente — um fixo (`PROGRESS_STATUS_REGULAR_TODO`) para fascículos, outro (`status`/`force_update`) para artigos — o que permitia que itens elegíveis por um critério, mas não pelo outro, ficassem de fora de ambas as consultas.
- Adicionalmente, `task_migrate_and_publish_articles_by_issue` podia pular `migrate_document_records`/`migrate_document_files` quando recebia um `article_proc_id_list` pré-calculado; se esse pré-cálculo já tivesse deixado artigos novos de fora, eles nunca eram criados/atualizados naquela execução.

Para corrigir isso, o PR:

- Simplifica `ArticleProc.select_items`, removendo parâmetros redundantes (`qs`, `collection_acron`, `journal_acron`, `journal_proc_id_list`, `issue_proc_id_list`, `exclude_issue_proc_id_list`, `article_proc_id_list`, `force_update`, `sps_pkg_id_list`) e padronizando filtros de coleção/periódico como listas (`collection_acron_list`, `journal_acron_list`).
- Adiciona `ArticleProc.get_journal_and_issue_proc_ids`, que combina (união, não exclusão) os resultados de `ArticleProc.select_items` e `IssueProc.select_items` — usando o **mesmo** `status_list` recebido como parâmetro para ambas as consultas — em um único dicionário `{(journal_proc_id, journal_acron): {issue_proc_id, ...}}`. Isso garante que:
  - o mesmo `status` (incluindo valores como `"BLOCKED"`) seja aplicado tanto ao filtro de `ArticleProc` quanto ao filtro de `docs_status`/`files_status` de `IssueProc`;
  - um item elegível por qualquer um dos dois critérios (artigo pendente OU fascículo marcado para reproc) seja incluído no resultado, eliminando a dependência de `exclude_issue_proc_id_list`.
- Reescreve `task_migrate_and_publish_articles` para delegar a montagem de `items_to_process` a `ArticleProc.get_journal_and_issue_proc_ids` em todos os casos — inclusive quando nenhum filtro é informado — eliminando o caminho que antes passava por `JournalProc.select_items` sem aplicar critério de status algum nesse nível.
- Remove o parâmetro `article_proc_id_list` de toda a cadeia de tasks (`task_migrate_and_publish_articles_by_journal` e `task_migrate_and_publish_articles_by_issue`) e a lógica de `exclude_issue_proc_id_list`.
- Faz `task_migrate_and_publish_articles_by_issue` sempre executar `migrate_document_records` e `migrate_document_files` antes de selecionar os `ArticleProc` a processar, garantindo que artigos ainda não criados/atualizados no banco não fiquem de fora silenciosamente.
- Move a resolução de `status` via `tracker_choices.get_valid_status` para dentro das tasks, após obter `journal_proc`/`user`, padronizando o critério de status aplicado nas duas consultas combinadas.

> **Nota:** o ajuste específico do filtro de `docs_status`/`files_status` dentro de `IssueProc.select_items` (para passar a considerar corretamente o `status_list`/`article_status_list` recebido, incluindo valores como `"BLOCKED"`) não está incluído no diff analisado até o momento — se esse método também foi alterado nesta PR, incluir aqui o trecho correspondente para descrição completa.

## Onde a revisão poderia começar?
`proc/models.py`, método `ArticleProc.select_items` e o novo `ArticleProc.get_journal_and_issue_proc_ids`. Em seguida, `proc/tasks.py`, começando por `task_migrate_and_publish_articles` e seguindo a cadeia até `task_migrate_and_publish_articles_by_issue`. Revisar também `IssueProc.select_items`, em particular como `docs_status`/`files_status` são filtrados a partir de `status_list`/`article_status_list`.

## Como este poderia ser testado manualmente?
1. **Cenário que já funcionava:** disparar `task_migrate_and_publish_articles` informando `journal_acron` e `issue_folder`, e confirmar que os artigos continuam sendo processados normalmente (sem regressão).
2. **Cenário sem filtros:** disparar `task_migrate_and_publish_articles` sem informar `journal_acron`, `issue_folder` nem `publication_year`, e confirmar que artigos/fascículos antes ausentes agora aparecem em `ArticleProc.get_journal_and_issue_proc_ids` e são enfileirados para `task_migrate_and_publish_articles_by_journal`.
3. **Cenário `status=["BLOCKED"]`:** identificar um `IssueProc` com `docs_status="BLOCKED"` (ou `files_status`), disparar a task informando `status=["BLOCKED"]` e confirmar que esse fascículo agora é retornado pela seleção e enfileirado.
4. Conferir nos eventos de `task_exec` (`total_journals_to_process`, `total_issues` por periódico) se as contagens batem com o esperado, incluindo os itens antes ausentes nos três cenários acima.
5. Confirmar que `task_migrate_and_publish_articles_by_issue` executa `migrate_document_records`/`migrate_document_files` em todos os casos, mesmo quando antes seria pulado por haver `article_proc_id_list`.
6. Rodar a suíte de testes existente para `proc/models.py` e `proc/tasks.py`, ajustando os testes que ainda chamem `select_items` com os parâmetros removidos, e adicionar casos de teste cobrindo especificamente os cenários 2 e 3.

Os resultados podem ser vistos consultando Article Processing e também em Event Monitoring > Event Tracker

<img width="1247" height="670" alt="Captura de Tela 2026-08-20 às 18 36 43" src="https://github.com/user-attachments/assets/97e30ba7-92df-4e5b-ab52-0d37f30d67b6" />


## Algum cenário de contexto que queira dar?
O bug só se manifestava em combinações específicas de filtros: informando `journal_acron`/`issue_folder` o fluxo funcionava, o que mascarava o problema em testes mais diretos. Sem nenhum filtro, ou usando `status` para capturar `docs_status`/`files_status` de `IssueProc` (ex.: `"BLOCKED"`), artigos e fascículos elegíveis ficavam de fora silenciosamente. Vale lembrar que, embora `docs_status`/`files_status` sejam atributos de `IssueProc`, eles representam o estado dos artigos daquele fascículo — refletindo a organização do site clássico, onde artigos são agrupados em pastas por issue. Por isso, o critério de status usado para selecionar `ArticleProc` precisa ser o mesmo aplicado ao filtro de `docs_status`/`files_status` de `IssueProc`, e é exatamente essa falta de alinhamento que a unificação em `get_journal_and_issue_proc_ids` resolve.

## Screenshots
Não aplicável (mudança apenas em lógica de backend/tasks, sem alteração de interface).

## Quais são os tickets relevantes?
#1062

## Referências
_Nenhuma referência externa utilizada além do código-base existente do projeto `scms-upload`._

---
## Segurança da informação (NSI.04)
> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim — descreva os controles de proteção aplicados (criptografia, mascaramento, anonimização, etc.):
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim — descreva o que mudou e por quê:
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
  - [ ] Verificado e aprovado
  - [ ] Pendente / vulnerabilidade aceita com justificativa:
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim — link do job:
- [ ] Não aplicável a este PR (justifique): _pendente de execução do pipeline antes do merge_

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim — confirme que há sanitização/parametrização (prepared statements, escaping, etc.):
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim — HTTPS obrigatório está garantido e o acesso segue o princípio de menor privilégio?
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim (bloquear merge e corrigir antes de prosseguir)